### PR TITLE
perf: replace CSV round-trip with Arrow IPC in mutation ops; stream parquet write

### DIFF
--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,260 +1,260 @@
 {
-  "timestamp": "2026-04-05 12:16:00",
+  "timestamp": "2026-04-05 19:24:08",
   "host": {
     "os": "Darwin 24.6.0",
     "python": "3.14.3",
     "cpu": "Apple M1 Pro",
     "cores": "10 (8 performance and 2 efficiency)",
     "memory": "32 GB",
-    "git_commit": "0558e9b",
+    "git_commit": "f8c306a",
     "rustc": "1.92.0"
   },
   "results": [
     {
       "name": "filter_10000",
       "rows": 10000,
-      "time_ms": 2.12,
-      "rows_per_sec": 4705913.0
+      "time_ms": 2.19,
+      "rows_per_sec": 4562247.0
     },
     {
       "name": "filter_100000",
       "rows": 100000,
-      "time_ms": 7.9,
-      "rows_per_sec": 12656269.0
+      "time_ms": 8.48,
+      "rows_per_sec": 11794693.0
     },
     {
       "name": "filter_1000000",
       "rows": 1000000,
-      "time_ms": 13.59,
-      "rows_per_sec": 73586071.0
+      "time_ms": 14.33,
+      "rows_per_sec": 69789488.0
     },
     {
       "name": "filter_complex_100000",
       "rows": 100000,
-      "time_ms": 8.33,
-      "rows_per_sec": 12006083.0
+      "time_ms": 8.39,
+      "rows_per_sec": 11915105.0
     },
     {
       "name": "derive_10000",
       "rows": 10000,
-      "time_ms": 1.81,
-      "rows_per_sec": 5530464.0
+      "time_ms": 1.97,
+      "rows_per_sec": 5068390.0
     },
     {
       "name": "derive_100000",
       "rows": 100000,
-      "time_ms": 5.64,
-      "rows_per_sec": 17715228.0
+      "time_ms": 5.68,
+      "rows_per_sec": 17600772.0
     },
     {
       "name": "derive_1000000",
       "rows": 1000000,
-      "time_ms": 10.12,
-      "rows_per_sec": 98828062.0
+      "time_ms": 10.88,
+      "rows_per_sec": 91908720.0
     },
     {
       "name": "derive_multi_100000",
       "rows": 100000,
-      "time_ms": 5.8,
-      "rows_per_sec": 17244186.0
+      "time_ms": 5.85,
+      "rows_per_sec": 17093815.0
     },
     {
       "name": "join_10000x10000",
       "rows": 20000,
-      "time_ms": 5.21,
-      "rows_per_sec": 3840789.0
+      "time_ms": 4.84,
+      "rows_per_sec": 4131248.0
     },
     {
       "name": "join_100000x10000",
       "rows": 110000,
-      "time_ms": 17.05,
-      "rows_per_sec": 6450788.0
+      "time_ms": 15.98,
+      "rows_per_sec": 6883988.0
     },
     {
       "name": "join_100000x100000",
       "rows": 200000,
-      "time_ms": 28.35,
-      "rows_per_sec": 7055548.0
+      "time_ms": 27.94,
+      "rows_per_sec": 7158584.0
     },
     {
       "name": "window_lag_10000",
       "rows": 10000,
-      "time_ms": 2.15,
-      "rows_per_sec": 4648041.0
+      "time_ms": 2.34,
+      "rows_per_sec": 4281382.0
     },
     {
       "name": "window_lag_100000",
       "rows": 100000,
-      "time_ms": 5.7,
-      "rows_per_sec": 17550874.0
+      "time_ms": 5.99,
+      "rows_per_sec": 16694221.0
     },
     {
       "name": "window_cumsum_10000",
       "rows": 10000,
-      "time_ms": 2.28,
-      "rows_per_sec": 4385778.0
+      "time_ms": 2.31,
+      "rows_per_sec": 4325337.0
     },
     {
       "name": "window_cumsum_100000",
       "rows": 100000,
-      "time_ms": 6.1,
-      "rows_per_sec": 16392659.0
+      "time_ms": 5.75,
+      "rows_per_sec": 17393699.0
     },
     {
       "name": "group_agg_10000",
       "rows": 10000,
-      "time_ms": 3.07,
-      "rows_per_sec": 3261785.0
+      "time_ms": 3.04,
+      "rows_per_sec": 3287776.0
     },
     {
       "name": "group_agg_100000",
       "rows": 100000,
-      "time_ms": 12.45,
-      "rows_per_sec": 8030874.0
+      "time_ms": 12.91,
+      "rows_per_sec": 7746717.0
     },
     {
       "name": "chain_10000",
       "rows": 10000,
-      "time_ms": 2.95,
-      "rows_per_sec": 3385766.0
+      "time_ms": 2.67,
+      "rows_per_sec": 3751681.0
     },
     {
       "name": "chain_100000",
       "rows": 100000,
-      "time_ms": 9.21,
-      "rows_per_sec": 10854767.0
+      "time_ms": 8.51,
+      "rows_per_sec": 11749999.0
     },
     {
       "name": "chain_1000000",
       "rows": 1000000,
-      "time_ms": 16.79,
-      "rows_per_sec": 59551380.0
+      "time_ms": 17.45,
+      "rows_per_sec": 57292134.0
     },
     {
       "name": "read_csv_10000",
       "rows": 10000,
-      "time_ms": 1.66,
-      "rows_per_sec": 6038952.0
+      "time_ms": 1.62,
+      "rows_per_sec": 6162220.0
     },
     {
       "name": "read_csv_100000",
       "rows": 100000,
-      "time_ms": 5.63,
-      "rows_per_sec": 17761289.0
+      "time_ms": 5.48,
+      "rows_per_sec": 18239577.0
     },
     {
       "name": "read_csv_1000000",
       "rows": 1000000,
-      "time_ms": 10.25,
-      "rows_per_sec": 97531240.0
+      "time_ms": 11.1,
+      "rows_per_sec": 90077692.0
     },
     {
       "name": "sort_10000",
       "rows": 10000,
-      "time_ms": 1.92,
-      "rows_per_sec": 5218677.0
+      "time_ms": 2.14,
+      "rows_per_sec": 4683658.0
     },
     {
       "name": "sort_100000",
       "rows": 100000,
-      "time_ms": 6.0,
-      "rows_per_sec": 16660303.0
+      "time_ms": 5.42,
+      "rows_per_sec": 18446167.0
     },
     {
       "name": "sort_1000000",
       "rows": 1000000,
-      "time_ms": 11.38,
-      "rows_per_sec": 87868318.0
+      "time_ms": 11.44,
+      "rows_per_sec": 87437216.0
     },
     {
       "name": "sort_multi_100000",
       "rows": 100000,
-      "time_ms": 5.61,
-      "rows_per_sec": 17815389.0
+      "time_ms": 5.7,
+      "rows_per_sec": 17550616.0
     },
     {
       "name": "group_ordered_10000",
       "rows": 10000,
-      "time_ms": 7.68,
-      "rows_per_sec": 1302588.0
+      "time_ms": 7.18,
+      "rows_per_sec": 1392235.0
     },
     {
       "name": "group_ordered_100000",
       "rows": 100000,
-      "time_ms": 49.29,
-      "rows_per_sec": 2028650.0
+      "time_ms": 48.47,
+      "rows_per_sec": 2063034.0
     },
     {
       "name": "search_first_10000",
       "rows": 10000,
-      "time_ms": 1.01,
-      "rows_per_sec": 9929803.0
+      "time_ms": 0.81,
+      "rows_per_sec": 12282286.0
     },
     {
       "name": "search_first_100000",
       "rows": 100000,
-      "time_ms": 0.87,
-      "rows_per_sec": 115166831.0
+      "time_ms": 0.93,
+      "rows_per_sec": 107144447.0
     },
     {
       "name": "mutation_insert_10000",
       "rows": 10000,
-      "time_ms": 43.63,
-      "rows_per_sec": 229201.0
+      "time_ms": 3.15,
+      "rows_per_sec": 3173456.0
     },
     {
       "name": "mutation_insert_100000",
       "rows": 100000,
-      "time_ms": 401.71,
-      "rows_per_sec": 248935.0
+      "time_ms": 16.39,
+      "rows_per_sec": 6099705.0
     },
     {
       "name": "mutation_delete_10000",
       "rows": 10000,
-      "time_ms": 2.34,
-      "rows_per_sec": 4277312.0
+      "time_ms": 2.48,
+      "rows_per_sec": 4034834.0
     },
     {
       "name": "mutation_delete_100000",
       "rows": 100000,
-      "time_ms": 7.95,
-      "rows_per_sec": 12585894.0
+      "time_ms": 7.8,
+      "rows_per_sec": 12826680.0
     },
     {
       "name": "mutation_update_10000",
       "rows": 10000,
-      "time_ms": 43.38,
-      "rows_per_sec": 230519.0
+      "time_ms": 3.89,
+      "rows_per_sec": 2570052.0
     },
     {
       "name": "mutation_update_100000",
       "rows": 100000,
-      "time_ms": 390.75,
-      "rows_per_sec": 255919.0
+      "time_ms": 18.09,
+      "rows_per_sec": 5528943.0
     },
     {
       "name": "write_parquet_10000",
       "rows": 10000,
-      "time_ms": 3.03,
-      "rows_per_sec": 3302389.0
+      "time_ms": 2.86,
+      "rows_per_sec": 3500413.0
     },
     {
       "name": "write_parquet_100000",
       "rows": 100000,
-      "time_ms": 27.5,
-      "rows_per_sec": 3635888.0
+      "time_ms": 28.12,
+      "rows_per_sec": 3556309.0
     },
     {
       "name": "read_parquet_10000",
       "rows": 10000,
-      "time_ms": 0.55,
-      "rows_per_sec": 18279667.0
+      "time_ms": 0.48,
+      "rows_per_sec": 20991863.0
     },
     {
       "name": "read_parquet_100000",
       "rows": 100000,
-      "time_ms": 0.62,
-      "rows_per_sec": 161283038.0
+      "time_ms": 0.66,
+      "rows_per_sec": 151512038.0
     }
   ]
 }

--- a/py-ltseq/ltseq/advanced_ops.py
+++ b/py-ltseq/ltseq/advanced_ops.py
@@ -519,15 +519,16 @@ class AdvancedOpsMixin:
                     f"State transition function failed at row {idx}: {e}"
                 ) from e
 
-        df[output_col] = results
-        rows = df.to_dict("records")
+        import pyarrow as pa
 
+        df[output_col] = results
         result_schema = self._schema.copy()
         result_schema[output_col] = self._infer_type_from_value(
             results[0] if results else init
         )
 
-        result = LTSeq._from_rows(rows, result_schema)
+        result = LTSeq.from_arrow(pa.Table.from_pandas(df, preserve_index=False))
+        result._schema = result_schema
         result._sort_keys = self._sort_keys
         return result
 

--- a/py-ltseq/ltseq/core.py
+++ b/py-ltseq/ltseq/core.py
@@ -195,12 +195,18 @@ class LTSeq(
             # No batches returned - empty result
             return pa.table({col: [] for col in self._schema.keys()})
 
-        batches = []
+        tables = []
         for buf in ipc_buffers:
             reader = pa.ipc.open_stream(buf)
-            batches.extend(reader.read_all().to_batches())
+            tables.append(reader.read_all())
 
-        return pa.Table.from_batches(batches)
+        if not tables:
+            return pa.table({col: [] for col in self._schema.keys()})
+
+        result = pa.concat_tables(tables)
+        if result.num_rows == 0 and result.num_columns == 0 and self._schema:
+            return pa.table({col: [] for col in self._schema.keys()})
+        return result
 
     def __len__(self) -> int:
         """

--- a/py-ltseq/ltseq/grouping/nested_table.py
+++ b/py-ltseq/ltseq/grouping/nested_table.py
@@ -258,10 +258,13 @@ Supported group methods:
         result_df = filtered_df[result_cols]
 
         # Convert back to LTSeq
-        rows = result_df.to_dict("records")
-        schema = self._ltseq._schema.copy()
+        import pyarrow as pa
 
-        result_ltseq = self._ltseq.__class__._from_rows(rows, schema)
+        schema = self._ltseq._schema.copy()
+        result_ltseq = self._ltseq.__class__.from_arrow(
+            pa.Table.from_pandas(result_df, preserve_index=False)
+        )
+        result_ltseq._schema = schema
 
         result_nested = NestedTable(
             result_ltseq, self._grouping_lambda, is_sorted=self._is_sorted
@@ -476,8 +479,12 @@ Supported group methods:
         for col_name in derive_exprs.keys():
             result_schema[col_name] = "Unknown"
 
-        rows = df.to_dict("records")
-        result = self._ltseq.__class__._from_rows(rows, result_schema)
+        import pyarrow as pa
+
+        result = self._ltseq.__class__.from_arrow(
+            pa.Table.from_pandas(df, preserve_index=False)
+        )
+        result._schema = result_schema
 
         return result
 

--- a/py-ltseq/ltseq/io_ops.py
+++ b/py-ltseq/ltseq/io_ops.py
@@ -210,7 +210,7 @@ class IOMixin:
     @classmethod
     def _from_rows(cls, rows: list[dict[str, Any]], schema: dict[str, str]) -> "LTSeq":
         """
-        Create an LTSeq instance from a list of row dictionaries.
+        Create an LTSeq instance from a list of row dictionaries via Arrow IPC.
 
         Internal method used by partition() and similar operations.
         Callers should prefer the public from_rows() which supports schema inference.
@@ -222,42 +222,35 @@ class IOMixin:
         Returns:
             New LTSeq instance
         """
-        import csv
-        import os
-        import tempfile
+        import pyarrow as pa
 
         from .core import LTSeq
 
+        # Map LTSeq schema type strings to PyArrow types (for empty-table creation)
+        _schema_to_arrow: dict[str, Any] = {
+            "int64": pa.int64(), "Int64": pa.int64(),
+            "float64": pa.float64(), "Float64": pa.float64(),
+            "bool": pa.bool_(), "Boolean": pa.bool_(),
+            "string": pa.string(), "Utf8": pa.string(), "utf8": pa.string(),
+            "large_string": pa.large_utf8(), "large_utf8": pa.large_utf8(),
+            "date32": pa.date32(), "date64": pa.date64(),
+        }
+
+        col_names = list(schema.keys())
+
         if not rows:
-            # Create empty table with schema
-            t = LTSeq()
-            t._schema = schema
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".csv", delete=False, newline=""
-            ) as f:
-                writer = csv.DictWriter(f, fieldnames=schema.keys())
-                writer.writeheader()
-                temp_path = f.name
-            try:
-                t._inner.read_csv(temp_path, True)
-            finally:
-                os.unlink(temp_path)
-            return t
+            arrays = {
+                col: pa.array([], type=_schema_to_arrow.get(schema[col], pa.string()))
+                for col in col_names
+            }
+            pa_table = pa.table(arrays)
+        else:
+            col_data = {col: [row.get(col) for row in rows] for col in col_names}
+            pa_table = pa.table(col_data)
 
-        # Convert rows to CSV and load
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".csv", delete=False, newline=""
-        ) as f:
-            writer = csv.DictWriter(f, fieldnames=schema.keys())
-            writer.writeheader()
-            for row in rows:
-                writer.writerow(row)
-            temp_path = f.name
-
-        t = LTSeq.read_csv(temp_path)
-        # Honor the explicitly provided schema instead of re-inferring from CSV content
-        t._schema = schema
-        return t
+        result = LTSeq.from_arrow(pa_table)
+        result._schema = schema
+        return result
 
     def write_csv(self, path: str) -> None:
         """

--- a/py-ltseq/ltseq/joins.py
+++ b/py-ltseq/ltseq/joins.py
@@ -133,11 +133,13 @@ class JoinMixin:
         left_key = left_key_expr.get("name", "")
         right_key = left_key  # Simplified - assume same key name
 
-        merged = _pandas_join_fallback(df1, df2, left_key, right_key, how, "_other")
-        rows = merged.to_dict("records")
+        import pyarrow as pa
 
+        merged = _pandas_join_fallback(df1, df2, left_key, right_key, how, "_other")
         result_schema = _build_join_result_schema(self._schema, other._schema, "_other")
-        return LTSeq._from_rows(rows, result_schema)
+        result = LTSeq.from_arrow(pa.Table.from_pandas(merged, preserve_index=False))
+        result._schema = result_schema
+        return result
 
     def join(
         self,

--- a/py-ltseq/ltseq/mutation_mixin.py
+++ b/py-ltseq/ltseq/mutation_mixin.py
@@ -27,10 +27,7 @@ class MutationMixin:
             >>> t2 = t.insert(0, {"id": 99, "name": "Alice"})   # prepend
             >>> t2 = t.insert(len(t), {"id": 99, "name": "Bob"}) # append
         """
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError("insert() requires pandas. Install with: pip install pandas")
+        import pyarrow as pa
 
         from .core import LTSeq
 
@@ -39,16 +36,23 @@ class MutationMixin:
                 "Schema not initialized. Call read_csv() first to populate the schema."
             )
 
-        df = self.to_pandas()
-        pos = max(0, min(pos, len(df)))
+        pa_table = self.to_arrow()
+        pos = max(0, min(pos, len(pa_table)))
 
-        new_row = pd.DataFrame([row_dict])
-        result_df = pd.concat(
-            [df.iloc[:pos], new_row, df.iloc[pos:]]
-        ).reset_index(drop=True)
+        # Build single-row Arrow table matching the existing schema.
+        # Infer type from the Python value first, then cast to the column type
+        # so that implicit coercions (e.g. "0.00" str → float64) work correctly.
+        new_row_arrays = {
+            field.name: pa.array([row_dict.get(field.name)]).cast(field.type)
+            for field in pa_table.schema
+        }
+        new_row = pa.table(new_row_arrays, schema=pa_table.schema)
 
-        rows = result_df.to_dict("records")
-        result = LTSeq._from_rows(rows, self._schema)
+        result_table = pa.concat_tables(
+            [pa_table.slice(0, pos), new_row, pa_table.slice(pos)]
+        )
+        result = LTSeq.from_arrow(result_table)
+        result._schema = self._schema
         result._sort_keys = None
         return result
 
@@ -68,6 +72,8 @@ class MutationMixin:
             >>> t2 = t.delete(lambda r: r.status == "deleted")
             >>> t2 = t.delete(0)   # remove first row
         """
+        import pyarrow as pa
+
         from .core import LTSeq
 
         if not self._schema:
@@ -80,19 +86,17 @@ class MutationMixin:
             return self.filter(lambda r, _p=pred: ~_p(r))
 
         # integer positional delete
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError("delete() with int pos requires pandas.")
-
         pos = int(predicate_or_pos)
-        df = self.to_pandas()
+        pa_table = self.to_arrow()
 
-        if 0 <= pos < len(df):
-            df = df.drop(index=df.index[pos]).reset_index(drop=True)
+        if 0 <= pos < len(pa_table):
+            # Keep rows before and after pos
+            pa_table = pa.concat_tables(
+                [pa_table.slice(0, pos), pa_table.slice(pos + 1)]
+            ) if pos < len(pa_table) - 1 else pa_table.slice(0, pos)
 
-        rows = df.to_dict("records")
-        result = LTSeq._from_rows(rows, self._schema)
+        result = LTSeq.from_arrow(pa_table)
+        result._schema = self._schema
         result._sort_keys = None
         return result
 
@@ -122,28 +126,28 @@ class MutationMixin:
         if not updates:
             return self
 
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise RuntimeError("update() requires pandas. Install with: pip install pandas")
+        import pyarrow as pa
+        import pyarrow.compute as pc
 
         from .core import LTSeq
 
-        # Derive a boolean mask column (new name, no overwrite), then apply
-        # updates in pandas.  This avoids the DataFusion schema-ambiguity error
-        # that occurs when derive() rewrites an existing column referencing itself.
+        # Derive a boolean mask column, then apply updates using Arrow compute
         _MASK = "__ltseq_update_mask__"
         with_mask = self.derive(**{_MASK: predicate})
-        df = with_mask.to_pandas()
-        mask = df[_MASK].astype(bool)
-        df = df.drop(columns=[_MASK])
+        pa_table = with_mask.to_arrow()
+
+        mask_idx = pa_table.schema.get_field_index(_MASK)
+        mask_col = pa_table.column(mask_idx).cast(pa.bool_())
+        pa_table = pa_table.remove_column(mask_idx)
 
         for col_name, new_val in updates.items():
-            if col_name in df.columns:
-                df.loc[mask, col_name] = new_val
+            idx = pa_table.schema.get_field_index(col_name)
+            if idx >= 0:
+                new_arr = pc.if_else(mask_col, new_val, pa_table.column(idx))
+                pa_table = pa_table.set_column(idx, col_name, new_arr)
 
-        rows = df.to_dict("records")
-        result = LTSeq._from_rows(rows, self._schema)
+        result = LTSeq.from_arrow(pa_table)
+        result._schema = self._schema
         result._sort_keys = None
         return result
 
@@ -163,10 +167,7 @@ class MutationMixin:
         Example:
             >>> t2 = t.modify(0, status="active", score=100)
         """
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError("modify() requires pandas. Install with: pip install pandas")
+        import pyarrow as pa
 
         from .core import LTSeq
 
@@ -175,14 +176,20 @@ class MutationMixin:
                 "Schema not initialized. Call read_csv() first to populate the schema."
             )
 
-        df = self.to_pandas()
+        pa_table = self.to_arrow()
 
-        if 0 <= pos < len(df):
+        if 0 <= pos < len(pa_table):
             for col_name, val in updates.items():
-                if col_name in df.columns:
-                    df.iloc[pos, df.columns.get_loc(col_name)] = val
+                idx = pa_table.schema.get_field_index(col_name)
+                if idx >= 0:
+                    col_list = pa_table.column(idx).to_pylist()
+                    col_list[pos] = val
+                    field_type = pa_table.schema.field(col_name).type
+                    pa_table = pa_table.set_column(
+                        idx, col_name, pa.array(col_list, type=field_type)
+                    )
 
-        rows = df.to_dict("records")
-        result = LTSeq._from_rows(rows, self._schema)
+        result = LTSeq.from_arrow(pa_table)
+        result._schema = self._schema
         result._sort_keys = None
         return result

--- a/src/ops/io.rs
+++ b/src/ops/io.rs
@@ -44,6 +44,9 @@ pub fn write_csv_impl(table: &LTSeqTable, path: String) -> PyResult<()> {
 
 /// Write table data to a Parquet file using Arrow's native Parquet writer.
 ///
+/// Batches are streamed from DataFusion and written incrementally, avoiding
+/// full in-memory materialization before the first write.
+///
 /// Args:
 ///     table: Reference to LTSeqTable
 ///     path: Path to the output Parquet file
@@ -56,23 +59,20 @@ pub fn write_parquet_impl(
     let df = table.require_df()?;
 
     RUNTIME.block_on(async {
+        use datafusion::arrow::datatypes::Schema as ArrowSchema;
+        use futures_util::StreamExt;
         use parquet::arrow::ArrowWriter;
         use parquet::basic::Compression;
         use parquet::file::properties::WriterProperties;
         use std::fs::File;
+        use std::sync::Arc;
 
         let df_clone = (**df).clone();
-        let batches = df_clone.collect().await.map_err(LtseqError::collect)?;
 
-        if batches.is_empty() {
-            return Err(LtseqError::Validation("No data to write".into()).into());
-        }
-
-        let schema = batches[0].schema();
-
-        let file = File::create(&path).map_err(|e| {
-            LtseqError::io(&format!("Failed to create file '{}'", path), e)
-        })?;
+        // Extract Arrow schema before consuming the DataFrame
+        let df_schema = df_clone.schema();
+        let arrow_fields: Vec<_> = df_schema.fields().iter().map(|f| (**f).clone()).collect();
+        let schema = Arc::new(ArrowSchema::new(arrow_fields));
 
         let comp = match compression.as_deref() {
             Some("snappy") => Compression::SNAPPY,
@@ -92,14 +92,37 @@ pub fn write_parquet_impl(
             .set_compression(comp)
             .build();
 
+        // Stream batches from DataFusion directly into the Parquet writer
+        let mut stream = df_clone
+            .execute_stream()
+            .await
+            .map_err(|e| LtseqError::Runtime(format!("Failed to create stream: {}", e)))?;
+
+        let file = File::create(&path).map_err(|e| {
+            LtseqError::io(&format!("Failed to create file '{}'", path), e)
+        })?;
+
         let mut writer = ArrowWriter::try_new(file, schema, Some(props)).map_err(|e| {
             LtseqError::Io(format!("Failed to create Parquet writer: {}", e))
         })?;
 
-        for batch in &batches {
-            writer.write(batch).map_err(|e| {
-                LtseqError::Io(format!("Failed to write Parquet batch: {}", e))
+        let mut wrote_any = false;
+        while let Some(batch_result) = stream.next().await {
+            let batch = batch_result.map_err(|e| {
+                LtseqError::Io(format!("Failed to read batch: {}", e))
             })?;
+            if batch.num_rows() > 0 {
+                writer.write(&batch).map_err(|e| {
+                    LtseqError::Io(format!("Failed to write Parquet batch: {}", e))
+                })?;
+                wrote_any = true;
+            }
+        }
+
+        if !wrote_any {
+            drop(writer);
+            let _ = std::fs::remove_file(&path);
+            return Err(LtseqError::Validation("No data to write".into()).into());
         }
 
         writer.close().map_err(|e| {


### PR DESCRIPTION
## Summary

### Commit 1: mutation ops + parquet streaming

- **mutation insert/update/delete/modify**: replaced `_from_rows()` (temp CSV → disk → Rust CSV parser) with the existing `from_arrow()` / `load_arrow_ipc` path. Data is manipulated directly as PyArrow tables — slicing for insert/delete, `pyarrow.compute.if_else` for update — then transferred to Rust via Arrow IPC bytes. No disk I/O, no format conversion.
- **write_parquet**: switched from `collect().await` (full materialization before writing) to `execute_stream()` so RecordBatches flow directly from DataFusion into `ArrowWriter`. Reduces peak memory at large table sizes.

### Commit 2: eliminate CSV round-trip from `_from_rows()` and all remaining callers

- Rewrote `_from_rows()` itself to use Arrow IPC: builds a `pa.Table` from the row dicts and loads via `from_arrow()`. All callers (partitioning, utils, advanced_ops, grouping) now benefit.
- Converted callers that already hold a pandas DataFrame to call `from_arrow(pa.Table.from_pandas(...))` directly, skipping the `to_dict("records")` step: `joins.py`, `advanced_ops.py` (stateful_scan), `grouping/nested_table.py` (filter + derive).
- Fixed `to_arrow()` to use `pa.concat_tables()` instead of `pa.Table.from_batches()` so empty tables (0 rows, valid schema) round-trip correctly.

## Benchmark results (Apple M1 Pro, release build)

| Operation | Before | After | Speedup |
|---|---|---|---|
| `mutation_insert_10000` | 43.6ms | 3.2ms | **14x** |
| `mutation_insert_100000` | 401.7ms | 16.4ms | **24x** |
| `mutation_update_10000` | 43.4ms | 3.9ms | **11x** |
| `mutation_update_100000` | 390.8ms | 18.1ms | **22x** |
| `write_parquet_100000` | 27.5ms | 28.1ms | flat (I/O bound at 100k) |

## Test plan

- [x] All 21 mutation tests pass
- [x] Full test suite: 1262 passed (29 pre-existing failures unrelated to this change)
- [x] Benchmarks re-run and `results.json` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)