### PR TITLE
fix: correct R3 funnel sort key to (userid, eventtime, watchid)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 benchmarks/data/*.parquet
 .opencode/
 .claude/
+build/

--- a/benchmarks/bench_vs.py
+++ b/benchmarks/bench_vs.py
@@ -164,10 +164,12 @@ def duckdb_session(data_file):
 
 def ltseq_session(t_sorted):
     """LTSeq: group_ordered on user/time boundary, count groups via first()."""
+
     def cond(r):
-        return (
-            (r.userid != r.userid.shift(1)) | (r.eventtime - r.eventtime.shift(1) > 1800)
+        return (r.userid != r.userid.shift(1)) | (
+            r.eventtime - r.eventtime.shift(1) > 1800
         )
+
     grouped = t_sorted.group_ordered(cond)
     # Each group = one session. first() collapses to 1 row per group, count() gives total.
     return grouped.first().count()
@@ -201,16 +203,19 @@ def ltseq_session_v2(t_sorted):
 def duckdb_funnel(data_file, p1, p2, p3):
     """DuckDB: LEAD window function for consecutive URL matching.
 
-    Uses ORDER BY eventtime (no watchid) to match the physical parquet order,
-    which is sorted by (userid, eventtime) only.
+    Uses ORDER BY eventtime, watchid to match the physical parquet order.
+    hits_sorted.parquet is sorted by (userid, eventtime, watchid): for the
+    ~5M rows that share the same (userid, eventtime), watchid is the
+    tiebreaker.  Without watchid the ORDER BY is non-deterministic for those
+    rows, producing a different count than LTSeq's physical-order scan.
     """
     return duckdb.sql(f"""
         SELECT count(*)
         FROM (
             SELECT
                 url,
-                LEAD(url) OVER (PARTITION BY userid ORDER BY eventtime) as next1,
-                LEAD(url, 2) OVER (PARTITION BY userid ORDER BY eventtime) as next2
+                LEAD(url) OVER (PARTITION BY userid ORDER BY eventtime, watchid) as next1,
+                LEAD(url, 2) OVER (PARTITION BY userid ORDER BY eventtime, watchid) as next2
             FROM '{data_file}'
         )
         WHERE starts_with(url, '{p1}')
@@ -371,8 +376,9 @@ def main():
 
     print("Sorting for LTSeq (declaring sort order)...")
     t0 = time.perf_counter()
-    # hits_sorted.parquet is sorted by (userid, eventtime) only — no watchid tiebreak.
-    t_ltseq_sorted = t_ltseq.assume_sorted("userid", "eventtime")
+    # hits_sorted.parquet is sorted by (userid, eventtime, watchid).
+    # watchid is the tiebreaker for the ~5M rows with the same (userid, eventtime).
+    t_ltseq_sorted = t_ltseq.assume_sorted("userid", "eventtime", "watchid")
     sort_time = time.perf_counter() - t0
     print(f"  LTSeq assume_sorted time: {sort_time:.3f}s")
 

--- a/benchmarks/clickbench_results.json
+++ b/benchmarks/clickbench_results.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-04-05T13:25:31.801012",
+  "timestamp": "2026-04-05T13:28:46.140632",
   "system": {
     "platform": "Linux-6.18.20-1-cachyos-lts-x86_64-with-glibc2.43",
     "processor": "",
@@ -12,27 +12,77 @@
   "iterations": 3,
   "rounds": [
     {
+      "round_name": "R1: Top URLs",
+      "duckdb": {
+        "name": "DuckDB",
+        "median_s": 1.0612,
+        "times": [
+          1.0969,
+          1.0612,
+          1.0228
+        ],
+        "mem_delta_mb": 1044.9,
+        "result": "[('http://liver.ru/belgorod/page/1006.j\u043a\u0438/\u0434\u043e\u043f_\u043f\u0440\u0438\u0431\u043e\u0440\u044b', 3288173), ('http://kinopoisk.ru', 1625250), ('http://bdsm_po_yers=0&with_video', 791465), ('http://video.yandex', 582400), ('http://smeshariki.r"
+      },
+      "ltseq": {
+        "name": "LTSeq",
+        "median_s": 1.5946,
+        "times": [
+          1.5933,
+          1.5946,
+          1.6029
+        ],
+        "mem_delta_mb": 1166.1,
+        "result": "[{'url': 'http://liver.ru/belgorod/page/1006.j\u043a\u0438/\u0434\u043e\u043f_\u043f\u0440\u0438\u0431\u043e\u0440\u044b', 'cnt': 3288173}, {'url': 'http://kinopoisk.ru', 'cnt': 1625250}, {'url': 'http://bdsm_po_yers=0&with_video', 'cnt': 791465}, {'url': 'htt"
+      }
+    },
+    {
+      "round_name": "R2: Sessionization",
+      "duckdb": {
+        "name": "DuckDB",
+        "median_s": 1.1962,
+        "times": [
+          1.1962,
+          1.2675,
+          1.1347
+        ],
+        "mem_delta_mb": 87.2,
+        "result": "26181387"
+      },
+      "ltseq": {
+        "name": "LTSeq",
+        "median_s": 0.1215,
+        "times": [
+          0.1215,
+          0.1189,
+          0.1234
+        ],
+        "mem_delta_mb": 1.3,
+        "result": "26181387"
+      }
+    },
+    {
       "round_name": "R3: Funnel",
       "duckdb": {
         "name": "DuckDB",
-        "median_s": 3.473,
+        "median_s": 3.4962,
         "times": [
-          3.4452,
-          3.473,
-          3.5685
+          3.42,
+          3.5039,
+          3.4962
         ],
-        "mem_delta_mb": 128.8,
+        "mem_delta_mb": 362.5,
         "result": "155373"
       },
       "ltseq": {
         "name": "LTSeq",
-        "median_s": 2.3444,
+        "median_s": 2.3109,
         "times": [
-          2.346,
-          2.3444,
-          2.3433
+          2.3075,
+          2.3109,
+          2.3158
         ],
-        "mem_delta_mb": 19.0,
+        "mem_delta_mb": 20.7,
         "result": "155373"
       }
     }

--- a/benchmarks/clickbench_results.json
+++ b/benchmarks/clickbench_results.json
@@ -1,89 +1,39 @@
 {
-  "timestamp": "2026-03-03T10:23:38.098210",
+  "timestamp": "2026-04-05T13:25:31.801012",
   "system": {
-    "platform": "macOS-15.7.4-arm64-arm-64bit-Mach-O",
-    "processor": "arm",
-    "cpu_count": 10,
-    "ram_gb": 32.0,
+    "platform": "Linux-6.18.20-1-cachyos-lts-x86_64-with-glibc2.43",
+    "processor": "",
+    "cpu_count": 32,
+    "ram_gb": 125.1,
     "python_version": "3.14.3"
   },
-  "data_file": "/Users/ruoshi/code/github/ltseq/benchmarks/data/hits_sorted.parquet",
+  "data_file": "/home/ruoshi/code/github/ltseq/benchmarks/data/hits_sorted.parquet",
   "warmup": 1,
   "iterations": 3,
   "rounds": [
     {
-      "round_name": "R1: Top URLs",
-      "duckdb": {
-        "name": "DuckDB",
-        "median_s": 2.5523,
-        "times": [
-          2.5867,
-          2.5523,
-          2.5493
-        ],
-        "mem_delta_mb": 382.1,
-        "result": "[('http://liver.ru/belgorod/page/1006.j\u043a\u0438/\u0434\u043e\u043f_\u043f\u0440\u0438\u0431\u043e\u0440\u044b', 3288173), ('http://kinopoisk.ru', 1625250), ('http://bdsm_po_yers=0&with_video', 791465), ('http://video.yandex', 582400), ('http://smeshariki.r"
-      },
-      "ltseq": {
-        "name": "LTSeq",
-        "median_s": 4.3235,
-        "times": [
-          4.3313,
-          4.3235,
-          4.2456
-        ],
-        "mem_delta_mb": 1104.3,
-        "result": "[{'url': 'http://liver.ru/belgorod/page/1006.j\u043a\u0438/\u0434\u043e\u043f_\u043f\u0440\u0438\u0431\u043e\u0440\u044b', 'cnt': 3288173}, {'url': 'http://kinopoisk.ru', 'cnt': 1625250}, {'url': 'http://bdsm_po_yers=0&with_video', 'cnt': 791465}, {'url': 'htt"
-      }
-    },
-    {
-      "round_name": "R2: Sessionization",
-      "duckdb": {
-        "name": "DuckDB",
-        "median_s": 1.6755,
-        "times": [
-          1.6604,
-          1.6755,
-          1.7219
-        ],
-        "mem_delta_mb": 167.2,
-        "result": "26181387"
-      },
-      "ltseq": {
-        "name": "LTSeq",
-        "median_s": 0.211,
-        "times": [
-          0.2071,
-          0.2259,
-          0.211
-        ],
-        "mem_delta_mb": 0.1,
-        "result": "26181387"
-      }
-    },
-    {
       "round_name": "R3: Funnel",
       "duckdb": {
         "name": "DuckDB",
-        "median_s": 17.0013,
+        "median_s": 3.473,
         "times": [
-          19.3173,
-          17.0013,
-          16.0207
+          3.4452,
+          3.473,
+          3.5685
         ],
-        "mem_delta_mb": 825.5,
-        "result": "155336"
+        "mem_delta_mb": 128.8,
+        "result": "155373"
       },
       "ltseq": {
         "name": "LTSeq",
-        "median_s": 7.0412,
+        "median_s": 2.3444,
         "times": [
-          7.1717,
-          7.0412,
-          7.0364
+          2.346,
+          2.3444,
+          2.3433
         ],
-        "mem_delta_mb": 0,
-        "result": "155336"
+        "mem_delta_mb": 19.0,
+        "result": "155373"
       }
     }
   ]

--- a/benchmarks/prepare_data.py
+++ b/benchmarks/prepare_data.py
@@ -66,13 +66,15 @@ def download_data():
 
 
 def sort_data():
-    """Pre-sort the dataset by (userid, eventtime) using DuckDB.
+    """Pre-sort the dataset by (userid, eventtime, watchid) using DuckDB.
 
-    Sort key is (userid, eventtime) only.  watchid is NOT used as a tiebreaker
-    because the benchmark's DuckDB queries and LTSeq both rely on the physical
-    parquet row order for rows that share the same (userid, eventtime), and
-    adding watchid here would produce a different ordering than what
-    assume_sorted("userid", "eventtime") declares.
+    Sort key is (userid, eventtime, watchid).  watchid is used as a tiebreaker
+    for the ~5M rows that share the same (userid, eventtime).  This makes the
+    sort order fully deterministic and matches the physical row order that
+    LTSeq's parallel pattern matcher relies on (via assume_sorted).
+
+    The DuckDB funnel query uses ORDER BY eventtime, watchid to match this
+    ordering, ensuring both engines produce identical results.
     """
     if os.path.exists(HITS_SORTED):
         size_gb = os.path.getsize(HITS_SORTED) / (1024**3)
@@ -81,7 +83,9 @@ def sort_data():
 
     import duckdb
 
-    print("  Sorting hits.parquet by (userid, eventtime) with lowercase columns...")
+    print(
+        "  Sorting hits.parquet by (userid, eventtime, watchid) with lowercase columns..."
+    )
     t0 = time.perf_counter()
     con = duckdb.connect()
     # Get all column names and build rename expressions
@@ -92,7 +96,7 @@ def sort_data():
         COPY (
             SELECT {select_str}
             FROM '{HITS_RAW}'
-            ORDER BY userid, eventtime
+            ORDER BY userid, eventtime, watchid
         ) TO '{HITS_SORTED}' (FORMAT 'parquet')
     """)
     elapsed = time.perf_counter() - t0

--- a/benchmarks/verify_parquet_order.py
+++ b/benchmarks/verify_parquet_order.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""
+verify_parquet_order.py — Verify that a Parquet file is sorted by specified columns.
+
+Supports compound sort keys (multiple columns), ASC/DESC per column, and
+produces a clear PASS/FAIL report with violation samples.
+
+Algorithm
+---------
+Two-phase vectorized scan using PyArrow:
+
+  Phase 1 — Intra-RG:  For each row group, compare col[1:] vs col[:-1]
+             using Arrow compute kernels (no Python loop over rows).
+             Row groups are processed in parallel (ThreadPoolExecutor).
+
+  Phase 2 — Cross-RG seam:  Compare the last row of RG[i] against the
+             first row of RG[i+1] for all adjacent pairs, sequentially
+             (only N-1 comparisons for N row groups).
+
+Compound lexicographic violation condition for keys (k0, k1, ..., kn):
+
+    violation = (k0[i] ⊳ k0[i-1])
+              | (k0[i] == k0[i-1]  &  k1[i] ⊳ k1[i-1])
+              | (k0[i] == k0[i-1]  &  k1[i] == k1[i-1]  &  k2[i] ⊳ k2[i-1])
+              | ...
+
+where ⊳ means < for ASC columns and > for DESC columns.
+
+NULL handling: NULLs propagate through Arrow comparisons as NULL (not True),
+so they are treated as non-violations.  This matches the common convention
+that NULL is considered "not out of order" — flag them separately with
+--report-nulls if needed.
+
+Usage
+-----
+    # One or more columns, all ASC (default)
+    python benchmarks/verify_parquet_order.py data/hits_sorted.parquet userid eventtime
+
+    # Mixed ASC/DESC
+    python benchmarks/verify_parquet_order.py data/hits.parquet userid:asc score:desc
+
+    # Multiple files (glob-friendly)
+    python benchmarks/verify_parquet_order.py data/*.parquet userid eventtime watchid
+
+    # Limit parallel workers
+    python benchmarks/verify_parquet_order.py --workers 4 data/file.parquet col1 col2
+
+    # Quick metadata-only pre-check (single primary key, no data read)
+    python benchmarks/verify_parquet_order.py --metadata-only data/file.parquet userid
+
+    # Show up to 20 violation samples
+    python benchmarks/verify_parquet_order.py --samples 20 data/file.parquet userid
+
+Requirements
+------------
+    pip install pyarrow
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import NamedTuple
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SortKey:
+    name: str
+    asc: bool = True  # True = ASC, False = DESC
+
+    @classmethod
+    def parse(cls, spec: str) -> "SortKey":
+        """Parse 'col', 'col:asc', or 'col:desc'."""
+        if ":" in spec:
+            name, direction = spec.rsplit(":", 1)
+            direction = direction.strip().lower()
+            if direction not in ("asc", "desc"):
+                raise ValueError(
+                    f"Unknown sort direction '{direction}' in '{spec}' — use :asc or :desc"
+                )
+            return cls(name=name.strip(), asc=(direction == "asc"))
+        return cls(name=spec.strip())
+
+    def __str__(self) -> str:
+        return f"{self.name} {'ASC' if self.asc else 'DESC'}"
+
+
+class Violation(NamedTuple):
+    row_group: int  # Which RG (or -1 for cross-RG seam)
+    row_offset: int  # Row index within the combined batch where violation occurs
+    prev_values: dict  # Column values of the previous row
+    curr_values: dict  # Column values of the violating row
+
+
+@dataclass
+class RgResult:
+    rg_idx: int
+    violation_count: int
+    samples: list[Violation] = field(default_factory=list)
+    last_row: pa.RecordBatch | None = None  # 1-row batch — last row of this RG
+    first_row: pa.RecordBatch | None = None  # 1-row batch — first row of this RG
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Core: violation detection on an Arrow RecordBatch
+# ---------------------------------------------------------------------------
+
+
+def _build_violation_mask(
+    batch: pa.RecordBatch,
+    keys: list[SortKey],
+) -> pa.ChunkedArray | pa.Array:
+    """
+    Return a BooleanArray of length (n-1) where True means row[i+1] violates
+    the sort order relative to row[i].
+
+    'batch' must have at least 2 rows and must contain all key columns.
+    """
+    n = batch.num_rows
+    assert n >= 2
+
+    # For each key, build cur = col[1:] and prev = col[:-1]
+    cols: dict[str, tuple[pa.Array, pa.Array]] = {}
+    for key in keys:
+        arr = batch.column(key.name)
+        cols[key.name] = (arr.slice(1), arr.slice(0, n - 1))  # (cur, prev)
+
+    # Build violation mask lexicographically
+    # violation  = key0_bad
+    # eq_prefix  = key0_eq
+    # Then for each subsequent key k:
+    #   violation |= (eq_prefix & key_k_bad)
+    #   eq_prefix &= key_k_eq
+
+    def _less(cur: pa.Array, prev: pa.Array) -> pa.Array:
+        return pc.less(cur, prev)
+
+    def _greater(cur: pa.Array, prev: pa.Array) -> pa.Array:
+        return pc.greater(cur, prev)
+
+    key0 = keys[0]
+    cur0, prev0 = cols[key0.name]
+    bad_fn = _less if key0.asc else _greater
+    violation: pa.Array = bad_fn(cur0, prev0)
+    eq_prefix: pa.Array = pc.equal(cur0, prev0)
+
+    for key in keys[1:]:
+        cur_k, prev_k = cols[key.name]
+        bad_k = (_less if key.asc else _greater)(cur_k, prev_k)
+        eq_k = pc.equal(cur_k, prev_k)
+        violation = pc.or_(violation, pc.and_(eq_prefix, bad_k))
+        eq_prefix = pc.and_(eq_prefix, eq_k)
+
+    return violation
+
+
+def _collect_samples(
+    violation_mask: pa.Array,
+    batch: pa.RecordBatch,
+    keys: list[SortKey],
+    rg_idx: int,
+    max_samples: int,
+) -> list[Violation]:
+    """Extract up to max_samples violation rows as Violation objects."""
+    samples: list[Violation] = []
+    n = len(violation_mask)
+    col_names = [k.name for k in keys]
+
+    for i in range(n):
+        if len(samples) >= max_samples:
+            break
+        val = violation_mask[i]
+        if val.is_valid and val.as_py():
+            # row i+1 in the batch is the violating row; row i is the predecessor
+            prev_row = {c: batch.column(c)[i].as_py() for c in col_names}
+            curr_row = {c: batch.column(c)[i + 1].as_py() for c in col_names}
+            samples.append(
+                Violation(
+                    row_group=rg_idx,
+                    row_offset=i + 1,
+                    prev_values=prev_row,
+                    curr_values=curr_row,
+                )
+            )
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Intra-RG check (parallel)
+# ---------------------------------------------------------------------------
+
+
+def _check_row_group(
+    parquet_file: pq.ParquetFile,
+    rg_idx: int,
+    keys: list[SortKey],
+    max_samples: int,
+) -> RgResult:
+    col_names = [k.name for k in keys]
+    try:
+        batch = parquet_file.read_row_group(rg_idx, columns=col_names)
+    except Exception as e:
+        return RgResult(rg_idx=rg_idx, violation_count=0, error=str(e))
+
+    n = batch.num_rows
+    first_row = batch.slice(0, 1) if n > 0 else None
+    last_row = batch.slice(n - 1, 1) if n > 0 else None
+
+    if n < 2:
+        return RgResult(
+            rg_idx=rg_idx,
+            violation_count=0,
+            last_row=last_row,
+            first_row=first_row,
+        )
+
+    violation_mask = _build_violation_mask(batch, keys)
+    count = pc.sum(violation_mask).as_py() or 0
+    samples = (
+        _collect_samples(violation_mask, batch, keys, rg_idx, max_samples)
+        if count > 0
+        else []
+    )
+
+    return RgResult(
+        rg_idx=rg_idx,
+        violation_count=count,
+        samples=samples,
+        last_row=last_row,
+        first_row=first_row,
+    )
+
+
+def check_intra_rg(
+    parquet_file: pq.ParquetFile,
+    keys: list[SortKey],
+    workers: int,
+    max_samples: int,
+) -> list[RgResult]:
+    """Check all row groups in parallel. Returns results sorted by rg_idx."""
+    n_rg = parquet_file.metadata.num_row_groups
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(_check_row_group, parquet_file, i, keys, max_samples): i
+            for i in range(n_rg)
+        }
+        results: list[RgResult] = []
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    results.sort(key=lambda r: r.rg_idx)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Cross-RG seam check (sequential, O(N) tiny comparisons)
+# ---------------------------------------------------------------------------
+
+
+def check_cross_rg_seams(
+    rg_results: list[RgResult],
+    keys: list[SortKey],
+    max_samples: int,
+) -> list[Violation]:
+    """
+    For each adjacent pair (RG[i], RG[i+1]), check whether the last row of
+    RG[i] is ordered before the first row of RG[i+1].
+    """
+    violations: list[Violation] = []
+    col_names = [k.name for k in keys]
+
+    for i in range(len(rg_results) - 1):
+        last_row = rg_results[i].last_row
+        first_row = rg_results[i + 1].first_row
+        if last_row is None or first_row is None:
+            continue
+
+        # Combine into a 2-row batch and check
+        try:
+            combined = pa.concat_tables(
+                [
+                    pa.table({c: last_row.column(c) for c in col_names}),
+                    pa.table({c: first_row.column(c) for c in col_names}),
+                ]
+            ).to_batches()[0]
+        except pa.lib.ArrowInvalid:
+            # Schema mismatch between RGs — cast to common type
+            combined = _unify_and_concat(last_row, first_row, col_names)
+            if combined is None:
+                continue
+
+        if combined.num_rows < 2:
+            continue
+
+        violation_mask = _build_violation_mask(combined, keys)
+        is_violation = violation_mask[0]
+        if is_violation.is_valid and is_violation.as_py():
+            if len(violations) < max_samples:
+                prev_vals = {c: combined.column(c)[0].as_py() for c in col_names}
+                curr_vals = {c: combined.column(c)[1].as_py() for c in col_names}
+                violations.append(
+                    Violation(
+                        row_group=-1,  # cross-RG seam
+                        row_offset=i,  # boundary index between RG[i] and RG[i+1]
+                        prev_values=prev_vals,
+                        curr_values=curr_vals,
+                    )
+                )
+
+    return violations
+
+
+def _unify_and_concat(
+    a: pa.RecordBatch,
+    b: pa.RecordBatch,
+    col_names: list[str],
+) -> pa.RecordBatch | None:
+    """Cast b's columns to a's schema and concatenate."""
+    try:
+        cast_cols = {}
+        for c in col_names:
+            target_type = a.schema.field(c).type
+            col_b = b.column(c)
+            if col_b.type != target_type:
+                col_b = col_b.cast(target_type)
+            cast_cols[c] = pa.concat_arrays([a.column(c), col_b])
+        return pa.record_batch(cast_cols)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Metadata-only fast pre-check (single column, uses Parquet column statistics)
+# ---------------------------------------------------------------------------
+
+
+def check_metadata_only(
+    parquet_file: pq.ParquetFile,
+    key: SortKey,
+) -> tuple[int, list[dict]]:
+    """
+    Use per-RG column min/max statistics to detect global order violations
+    for a single sort key without reading any data.
+
+    Returns (violation_count, samples).
+
+    Limitation: statistics only give per-RG min/max, so this can only detect
+    cases where RG[i+1].min < RG[i].max (for ASC). It cannot detect
+    intra-RG violations or violations involving equal RG-boundary values.
+    Use this as a fast sanity check before the full data scan.
+    """
+    meta = parquet_file.metadata
+    n_rg = meta.num_row_groups
+    violations = 0
+    samples: list[dict] = []
+
+    # Find column index by name
+    col_idx: int | None = None
+    rg0 = meta.row_group(0)
+    for j in range(rg0.num_columns):
+        if rg0.column(j).path_in_schema == key.name:
+            col_idx = j
+            break
+
+    if col_idx is None:
+        raise ValueError(f"Column '{key.name}' not found in Parquet schema")
+
+    prev_max = None
+    prev_min = None
+    for i in range(n_rg):
+        rg = meta.row_group(i)
+        stats = rg.column(col_idx).statistics
+        if stats is None or not stats.has_min_max:
+            continue
+        rg_min, rg_max = stats.min, stats.max
+
+        if prev_max is not None:
+            if key.asc and rg_min < prev_max:
+                violations += 1
+                if len(samples) < 5:
+                    samples.append(
+                        {
+                            "rg_prev": i - 1,
+                            "rg_curr": i,
+                            "prev_max": prev_max,
+                            "curr_min": rg_min,
+                            "prev_min": prev_min,
+                            "curr_max": rg_max,
+                        }
+                    )
+            elif not key.asc and rg_max > prev_min:
+                violations += 1
+                if len(samples) < 5:
+                    samples.append(
+                        {
+                            "rg_prev": i - 1,
+                            "rg_curr": i,
+                            "prev_min": prev_min,
+                            "curr_max": rg_max,
+                        }
+                    )
+
+        prev_max = rg_max
+        prev_min = rg_min
+
+    return violations, samples
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+
+
+def _fmt_values(vals: dict) -> str:
+    parts = [f"{k}={repr(v)}" for k, v in vals.items()]
+    return "  ".join(parts)
+
+
+def _print_samples(samples: list[Violation], label: str) -> None:
+    print(f"  Sample violations ({label}):")
+    for v in samples:
+        loc = (
+            f"RG {v.row_group} row {v.row_offset}"
+            if v.row_group >= 0
+            else f"seam after RG {v.row_offset}"
+        )
+        print(f"    [{loc}]")
+        print(f"      prev: {_fmt_values(v.prev_values)}")
+        print(f"      curr: {_fmt_values(v.curr_values)}")
+
+
+# ---------------------------------------------------------------------------
+# Main verification entry point
+# ---------------------------------------------------------------------------
+
+
+def verify_file(
+    path: str,
+    keys: list[SortKey],
+    workers: int,
+    max_samples: int,
+    metadata_only: bool,
+) -> bool:
+    """
+    Verify one Parquet file. Returns True if PASS, False if FAIL.
+    Prints a human-readable report to stdout.
+    """
+    if not os.path.exists(path):
+        print(f"ERROR: file not found: {path}")
+        return False
+
+    key_str = ", ".join(str(k) for k in keys)
+    filename = os.path.basename(path)
+    print(f"\nVerifying order [{key_str}] in {filename}")
+
+    pf = pq.ParquetFile(path)
+    meta = pf.metadata
+    n_rg = meta.num_row_groups
+    n_rows = meta.num_rows
+    print(f"  Row groups: {n_rg:,} | Rows: {n_rows:,}")
+
+    # ------------------------------------------------------------------
+    # Metadata-only path (single key, no data read)
+    # ------------------------------------------------------------------
+    if metadata_only:
+        if len(keys) > 1:
+            print(
+                "  WARNING: --metadata-only supports only one key; ignoring extra keys"
+            )
+        t0 = time.perf_counter()
+        count, samples = check_metadata_only(pf, keys[0])
+        elapsed = time.perf_counter() - t0
+        print(
+            f"  Metadata-only check (no data read)...  {count} RG-level violations  [{elapsed:.2f}s]"
+        )
+        if count > 0:
+            print(
+                f"  FAIL — {count} row group(s) have min/max overlap violating {keys[0]} order"
+            )
+            for s in samples:
+                print(
+                    f"    RG {s['rg_prev']} max={s.get('prev_max', s.get('prev_min'))}  "
+                    f"RG {s['rg_curr']} min={s.get('curr_min', s.get('curr_max'))}"
+                )
+            return False
+        else:
+            print(
+                f"  PASS (metadata only — no RG-level violations; run without --metadata-only for full check)"
+            )
+            return True
+
+    # ------------------------------------------------------------------
+    # Full data scan — Phase 1: intra-RG (parallel)
+    # ------------------------------------------------------------------
+    t0 = time.perf_counter()
+    rg_results = check_intra_rg(pf, keys, workers, max_samples)
+    t1 = time.perf_counter()
+
+    intra_errors = [r for r in rg_results if r.error]
+    intra_violations = sum(r.violation_count for r in rg_results)
+    intra_samples: list[Violation] = []
+    for r in rg_results:
+        intra_samples.extend(r.samples)
+        if len(intra_samples) >= max_samples:
+            intra_samples = intra_samples[:max_samples]
+            break
+
+    status_intra = "FAIL" if (intra_violations > 0 or intra_errors) else "OK"
+    print(
+        f"  Intra-RG check ({workers} workers)...    "
+        f"{intra_violations:,} violations  [{t1 - t0:.2f}s]  {status_intra}"
+    )
+    if intra_errors:
+        print(f"  WARNING: {len(intra_errors)} row group(s) failed to read:")
+        for r in intra_errors[:3]:
+            print(f"    RG {r.rg_idx}: {r.error}")
+    if intra_violations > 0 and intra_samples:
+        _print_samples(intra_samples[:max_samples], "intra-RG")
+
+    # ------------------------------------------------------------------
+    # Phase 2: cross-RG seams (sequential, fast)
+    # ------------------------------------------------------------------
+    t0 = time.perf_counter()
+    cross_violations = check_cross_rg_seams(rg_results, keys, max_samples)
+    t1 = time.perf_counter()
+
+    status_cross = "FAIL" if cross_violations else "OK"
+    print(
+        f"  Cross-RG seam check...           "
+        f"{len(cross_violations):,} violations  [{t1 - t0:.2f}s]  {status_cross}"
+    )
+    if cross_violations:
+        _print_samples(cross_violations[:max_samples], "cross-RG seam")
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    total = intra_violations + len(cross_violations)
+    passed = total == 0 and not intra_errors
+    if passed:
+        print(f"  PASS — file is sorted by [{key_str}]")
+    else:
+        print(f"  FAIL — {total:,} total violation(s) found")
+    return passed
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that a Parquet file is sorted by the specified columns.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        metavar="FILE_OR_COL",
+        help=(
+            "Parquet file(s) followed by column specs.  "
+            "Columns are specified as 'col' (ASC) or 'col:asc'/'col:desc'.  "
+            "All non-.parquet arguments after the last .parquet file are treated as column specs.  "
+            "Example:  data/hits.parquet userid eventtime:asc score:desc"
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=min(8, (os.cpu_count() or 4)),
+        metavar="N",
+        help="Number of parallel workers for row-group scanning (default: min(8, cpu_count))",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Maximum number of violation examples to display per file (default: 5)",
+    )
+    parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        help=(
+            "Fast pre-check using Parquet column statistics (no data read).  "
+            "Only supports a single sort key.  Detects RG-level min/max overlaps only."
+        ),
+    )
+    return parser.parse_args()
+
+
+def split_files_and_keys(args_list: list[str]) -> tuple[list[str], list[SortKey]]:
+    """
+    Split the positional args into Parquet file paths and column specs.
+
+    Rules:
+    - A token ending in '.parquet' (case-insensitive) or that is an existing
+      file is treated as a file path.
+    - Everything else is treated as a column spec (col or col:asc/col:desc).
+    - Files must come before column specs (standard CLI convention).
+    """
+    files: list[str] = []
+    col_specs: list[str] = []
+    switched = False  # Once we see the first non-file token, all remaining are cols
+
+    for token in args_list:
+        if not switched and (
+            token.lower().endswith(".parquet") or os.path.isfile(token)
+        ):
+            files.append(token)
+        else:
+            switched = True
+            col_specs.append(token)
+
+    if not files:
+        raise ValueError("No Parquet file paths provided.")
+    if not col_specs:
+        raise ValueError(
+            "No column specs provided.  Specify at least one column, e.g.: userid  or  userid:asc eventtime:desc"
+        )
+
+    keys = [SortKey.parse(s) for s in col_specs]
+    return files, keys
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        files, keys = split_files_and_keys(args.files)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    all_passed = True
+    for path in files:
+        passed = verify_file(
+            path=path,
+            keys=keys,
+            workers=args.workers,
+            max_samples=args.samples,
+            metadata_only=args.metadata_only,
+        )
+        if not passed:
+            all_passed = False
+
+    if len(files) > 1:
+        print(f"\nOverall: {'PASS' if all_passed else 'FAIL'} ({len(files)} files)")
+
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Root cause**: `hits_sorted.parquet` is sorted by `(userid, eventtime, watchid)`, but the DuckDB funnel query used `ORDER BY eventtime` only. For the ~5M rows sharing the same `(userid, eventtime)`, this made DuckDB's ordering non-deterministic, producing counts that disagreed with LTSeq's physical-order scan (e.g. 155,349 vs 155,373).
- **Fix**: Add `watchid` as tiebreaker in DuckDB's `LEAD()` window `ORDER BY`, update `assume_sorted()` to declare all 3 columns, and correct `prepare_data.py`'s `sort_data()` to `ORDER BY userid, eventtime, watchid`.
- **New tool**: `benchmarks/verify_parquet_order.py` — verifies physical sort order of any Parquet file in ~0.32s using parallel PyArrow reads; supports multi-column keys, asc/desc, cross-row-group seam checks, and a fast metadata-only mode.

## Results (Linux, 32-core, 125GB RAM)

| Round | DuckDB | LTSeq | Speedup |
|-------|--------|-------|---------|
| R1: Top URLs | 1.06s | 1.59s | DuckDB 1.5x |
| R2: Sessionization | 1.20s | 0.12s | **LTSeq 10x** |
| R3: Funnel | 3.50s | 2.31s | **LTSeq 1.5x** |

Both engines now produce identical R3 counts: **155,373**.