### PR TITLE
feat: autoresearch — automated performance research tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 
 # Benchmark data files (large parquet datasets)
 benchmarks/data/*.parquet
+
+# autoresearch generated results (flamegraphs, run summaries)
+benchmarks/autoresearch/results/
 .opencode/
 .claude/
 build/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,11 @@ lto = "fat"
 codegen-units = 1
 opt-level = 3
 strip = "symbols"
+
+# Profile for flamegraph generation (retains debug symbols)
+# Build with: maturin develop --profile flamegraph
+# Provides readable Rust function names in py-spy/perf flamegraphs.
+[profile.flamegraph]
+inherits = "release"
+debug = true
+strip = "none"

--- a/benchmarks/autoresearch/__init__.py
+++ b/benchmarks/autoresearch/__init__.py
@@ -1,0 +1,1 @@
+# autoresearch: automated performance research for LTSeq

--- a/benchmarks/autoresearch/analyzer.py
+++ b/benchmarks/autoresearch/analyzer.py
@@ -1,0 +1,104 @@
+"""
+analyzer.py — Parse flamegraph SVG files to extract hotspot functions.
+
+Flamegraph SVGs contain <title> elements with function names and
+rect widths proportional to CPU time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def extract_hotspots(svg_path: Path, top_n: int = 20) -> list[dict]:
+    """Extract top-N hotspot functions from a flamegraph SVG.
+
+    Each flamegraph <g> element has:
+      - <title>funcname (N samples, M%)</title>  (inferno format)
+      - OR <title>funcname</title> with a width attribute
+
+    Returns list of dicts: {function, self_pct, samples}
+    """
+    if not svg_path.exists():
+        return []
+
+    content = svg_path.read_text(encoding="utf-8", errors="replace")
+
+    # Try inferno format: <title>name (N samples, M%)</title>
+    inferno_pattern = re.compile(
+        r"<title>(.+?)\s+\((\d+)\s+samples,\s+([\d.]+)%\)</title>"
+    )
+    hotspots = []
+    for m in inferno_pattern.finditer(content):
+        func_name = m.group(1).strip()
+        samples = int(m.group(2))
+        pct = float(m.group(3))
+        hotspots.append({"function": func_name, "self_pct": pct, "samples": samples})
+
+    if not hotspots:
+        # Try Brendan Gregg format: <title>name (N)</title> with rect width
+        gregg_pattern = re.compile(r"<title>(.+?)\s+\((\d+)\)</title>")
+        total_samples = 0
+        entries = []
+        for m in gregg_pattern.finditer(content):
+            func_name = m.group(1).strip()
+            samples = int(m.group(2))
+            entries.append((func_name, samples))
+            if not total_samples:
+                # First entry is usually the root with total count
+                total_samples = samples
+        if total_samples > 0:
+            for func_name, samples in entries[1:]:  # skip root
+                pct = round(samples / total_samples * 100, 2)
+                hotspots.append(
+                    {"function": func_name, "self_pct": pct, "samples": samples}
+                )
+
+    # Deduplicate and sort by self_pct descending
+    seen = {}
+    for h in hotspots:
+        fn = h["function"]
+        if fn not in seen or h["self_pct"] > seen[fn]["self_pct"]:
+            seen[fn] = h
+    sorted_hotspots = sorted(seen.values(), key=lambda x: x["self_pct"], reverse=True)
+
+    return sorted_hotspots[:top_n]
+
+
+def diff_hotspots(
+    current: list[dict], previous: list[dict]
+) -> list[dict]:
+    """Compare two hotspot lists, annotate with delta."""
+    prev_map = {h["function"]: h["self_pct"] for h in previous}
+    result = []
+    for h in current:
+        fn = h["function"]
+        prev_pct = prev_map.get(fn)
+        delta = None
+        if prev_pct is not None:
+            delta = round(h["self_pct"] - prev_pct, 2)
+        result.append({**h, "prev_pct": prev_pct, "delta": delta})
+    return result
+
+
+def summarize_hotspots(hotspots: list[dict], top_n: int = 10) -> str:
+    """Format hotspots as a Markdown table."""
+    if not hotspots:
+        return "_No profiling data available._\n"
+
+    lines = [
+        "| Rank | Function | Self% | Delta |",
+        "|------|----------|-------|-------|",
+    ]
+    for i, h in enumerate(hotspots[:top_n], 1):
+        fn = h["function"]
+        # Truncate long function names
+        if len(fn) > 60:
+            fn = fn[:57] + "..."
+        pct = h.get("self_pct", 0)
+        delta = h.get("delta")
+        delta_str = f"{delta:+.1f}%" if delta is not None else "new"
+        lines.append(f"| {i} | `{fn}` | {pct:.1f}% | {delta_str} |")
+
+    return "\n".join(lines) + "\n"

--- a/benchmarks/autoresearch/hypothesis.py
+++ b/benchmarks/autoresearch/hypothesis.py
@@ -1,0 +1,198 @@
+"""
+hypothesis.py — Generate optimization hypotheses from profiling hotspots.
+
+Maps known Rust/Python function patterns to actionable suggestions.
+"""
+
+from __future__ import annotations
+
+# Known optimization patterns: substring match → suggestion
+# Each entry has:
+#   hypothesis: what to try
+#   files: relevant source files
+#   effort: S/M/L (small/medium/large)
+#   round: which benchmark round is most affected
+KNOWN_PATTERNS: list[dict] = [
+    {
+        "match": "datafusion::physical_plan::aggregat",
+        "label": "DataFusion GroupByExec: too many partitions",
+        "hypothesis": (
+            "target_partitions=32 causes GroupByExec to create 32 concurrent hash tables; "
+            "the merge phase overhead outweighs the parallelism benefit for this workload. "
+            "Suggestion: dynamically set target_partitions=CPU/4 for aggregation, "
+            "or use a sequential session (target_partitions=1) specifically for agg() calls."
+        ),
+        "files": ["src/engine.rs:37", "src/ops/aggregation.rs"],
+        "effort": "S",
+        "round": "R1",
+        "expected_gain": "R1 -15~25%",
+    },
+    {
+        "match": "arrow::compute::concat",
+        "label": "Arrow concat_batches: O(N) memory copy",
+        "hypothesis": (
+            "pattern_match.rs materializes all RecordBatches into one before pattern evaluation, "
+            "causing an O(N) memcpy over the entire dataset. "
+            "Suggestion: use a ChunkedArray or cross-batch index addressing to avoid the copy, "
+            "or switch to batch-by-batch streaming evaluation."
+        ),
+        "files": ["src/ops/pattern_match.rs"],
+        "effort": "M",
+        "round": "R3",
+        "expected_gain": "R3 -10~20%",
+    },
+    {
+        "match": "ltseq_core::transpiler",
+        "label": "Expression deserialization on every call",
+        "hypothesis": (
+            "Every filter()/derive() call fully deserializes the PyExpr dict from Python. "
+            "For repeated calls with the same lambda this is redundant work. "
+            "Suggestion: cache the serialized dict on the lambda object in Python, "
+            "or intern identical dicts on the Rust side."
+        ),
+        "files": ["src/transpiler/mod.rs", "src/lib.rs"],
+        "effort": "S",
+        "round": "all",
+        "expected_gain": "filter/derive -5~10% globally",
+    },
+    {
+        "match": "ltseq::expr::proxy",
+        "label": "SchemaProxy rebuilt on every call",
+        "hypothesis": (
+            "The Python layer constructs a new SchemaProxy and performs schema column lookup "
+            "on every filter()/derive() call. "
+            "Suggestion: cache the SchemaProxy instance on the LTSeq object and invalidate "
+            "only when the schema changes."
+        ),
+        "files": ["py-ltseq/ltseq/expr/proxy.py", "py-ltseq/ltseq/transforms.py"],
+        "effort": "S",
+        "round": "all",
+        "expected_gain": "filter/derive -3~8%",
+    },
+    {
+        "match": "rayon",
+        "label": "Rayon thread-pool overhead on small datasets",
+        "hypothesis": (
+            "parallel_scan.rs uses rayon parallelism unconditionally. "
+            "For datasets smaller than ~1M rows, thread scheduling overhead exceeds "
+            "the parallelism benefit. "
+            "Suggestion: add an adaptive threshold — fall back to sequential scan below N rows."
+        ),
+        "files": ["src/ops/parallel_scan.rs"],
+        "effort": "S",
+        "round": "R3",
+        "expected_gain": "R3 -5~15% on small data",
+    },
+    {
+        "match": "parquet::arrow::async_reader",
+        "label": "Parquet IO bottleneck",
+        "hypothesis": (
+            "Parquet reading dominates total time, suggesting the dataset is not cached "
+            "in the OS page cache or read concurrency is insufficient. "
+            "Suggestion: verify prefetch_size settings and apply projection pushdown "
+            "to read only the columns needed by each round."
+        ),
+        "files": ["src/ops/io.rs", "src/engine.rs"],
+        "effort": "M",
+        "round": "all",
+        "expected_gain": "IO-bound scenarios -10~30%",
+    },
+    {
+        "match": "datafusion::physical_plan::sorts",
+        "label": "Unexpected SortExec on pre-sorted data",
+        "hypothesis": (
+            "DataFusion is triggering SortExec even though assume_sorted was called. "
+            "Suggestion: verify that sort_exprs exactly match the DataFusion "
+            "EquivalenceProperties injected by assume_sorted, and that the injection "
+            "path in lib.rs propagates correctly through all chained operations."
+        ),
+        "files": ["src/ops/sort.rs:107-114", "src/lib.rs"],
+        "effort": "S",
+        "round": "R2",
+        "expected_gain": "R2 -5~15% (skip redundant sort)",
+    },
+    {
+        "match": "starts_with",
+        "label": "starts_with not using Arrow vectorized kernel",
+        "hypothesis": (
+            "The starts_with evaluation in pattern_match.rs goes through the generic "
+            "eval_expr fallback path instead of arrow::compute::starts_with. "
+            "Suggestion: add a dedicated fast path in eval_expr for "
+            "StringMethod::StartsWith that calls arrow::compute::starts_with(array, scalar) directly."
+        ),
+        "files": ["src/ops/pattern_match.rs:459"],
+        "effort": "S",
+        "round": "R3",
+        "expected_gain": "R3 starts_with eval -10~30%",
+    },
+]
+
+
+def generate_hypotheses(hotspots: list[dict], max_results: int = 8) -> list[dict]:
+    """Match hotspot function names against known patterns, return suggestions."""
+    matched = []
+    matched_patterns = set()
+
+    for h in hotspots:
+        fn = h.get("function", "")
+        for pattern in KNOWN_PATTERNS:
+            pid = pattern["match"]
+            if pid in matched_patterns:
+                continue
+            if pattern["match"].lower() in fn.lower():
+                matched.append(
+                    {
+                        "trigger_function": fn,
+                        "trigger_self_pct": h.get("self_pct", 0),
+                        **pattern,
+                    }
+                )
+                matched_patterns.add(pid)
+
+    # Sort by trigger_self_pct (most expensive first)
+    matched.sort(key=lambda x: x["trigger_self_pct"], reverse=True)
+
+    # Include unmatched hotspots for manual review
+    matched_fns = {m["trigger_function"] for m in matched}
+    unmatched = [
+        {
+            "trigger_function": h["function"],
+            "trigger_self_pct": h.get("self_pct", 0),
+            "label": "Unknown hotspot (manual review needed)",
+            "hypothesis": "No known optimization pattern for this function. Inspect the flamegraph manually.",
+            "files": [],
+            "effort": "?",
+            "round": "?",
+            "expected_gain": "?",
+        }
+        for h in hotspots[:5]
+        if h["function"] not in matched_fns
+    ]
+
+    return (matched + unmatched)[:max_results]
+
+
+def render_hypotheses(hypotheses: list[dict]) -> str:
+    """Format hypotheses as Markdown sections."""
+    if not hypotheses:
+        return "_No known optimization patterns matched. Inspect flamegraphs manually._\n"
+
+    lines = []
+    effort_label = {"S": "Small", "M": "Medium", "L": "Large", "?": "Unknown"}
+
+    for i, h in enumerate(hypotheses, 1):
+        pct = h.get("trigger_self_pct", 0)
+        effort = effort_label.get(h.get("effort", "?"), "?")
+        round_tag = h.get("round", "?")
+        gain = h.get("expected_gain", "?")
+
+        lines.append(f"### [{i}] {h['label']}")
+        lines.append(f"- **Trigger**: `{h['trigger_function']}` ({pct:.1f}% self time)")
+        lines.append(f"- **Round**: {round_tag} | **Effort**: {effort} | **Expected gain**: {gain}")
+        lines.append(f"- **Hypothesis**: {h['hypothesis']}")
+        if h.get("files"):
+            file_list = ", ".join(f"`{f}`" for f in h["files"])
+            lines.append(f"- **Files**: {file_list}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/benchmarks/autoresearch/profiler.py
+++ b/benchmarks/autoresearch/profiler.py
@@ -1,0 +1,228 @@
+"""
+profiler.py — Generate Rust + Python flamegraphs for benchmark rounds.
+
+Two profiling approaches:
+  1. py-spy (recommended): profiles Python + native Rust extension in one pass.
+     Requires: pip install py-spy
+     Advantage: no special Rust build needed for Python-level profiling;
+                use --native flag to see Rust frames (debug symbols help).
+
+  2. perf + inferno (Linux): kernel-level profiling with full Rust resolution.
+     Requires: linux-perf, cargo install inferno
+     Build with: maturin develop --profile flamegraph (adds debug=true)
+     Advantage: more accurate Rust frame attribution.
+
+Notes:
+  - py-spy requires no elevated privileges on most systems.
+  - perf may need: echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BENCHMARKS_DIR = Path(__file__).parent.parent
+REPO_ROOT = BENCHMARKS_DIR.parent
+
+
+def _check_tool(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def check_dependencies() -> dict[str, bool]:
+    """Return availability of profiling tools."""
+    return {
+        "py-spy": _check_tool("py-spy"),
+        "perf": _check_tool("perf"),
+        "inferno-collapse-perf": _check_tool("inferno-collapse-perf"),
+        "inferno-flamegraph": _check_tool("inferno-flamegraph"),
+        "flamegraph": _check_tool("flamegraph"),  # cargo install flamegraph
+    }
+
+
+def print_install_hints(deps: dict[str, bool]) -> None:
+    if not deps["py-spy"] and not deps["perf"]:
+        print("  [profiler] Warning: no profiling tools found.")
+        print("  Install py-spy:   pip install py-spy")
+        print("  Or inferno:       cargo install inferno")
+
+
+def profile_with_pyspy(
+    round_num: int,
+    output_svg: Path,
+    data_flag: str = "--sample",
+    extra_args: list[str] | None = None,
+) -> bool:
+    """Profile a single benchmark round using py-spy.
+
+    Args:
+        round_num: 1, 2, or 3
+        output_svg: destination SVG path
+        data_flag: '--sample' for 1M rows, '' for full dataset
+        extra_args: additional bench_vs.py arguments
+
+    Returns True on success.
+    """
+    bench_script = BENCHMARKS_DIR / "bench_vs.py"
+    cmd = [
+        "py-spy", "record",
+        "--native",           # capture Rust frames (needs debug symbols for readable names)
+        "--format", "flamegraph",
+        "--output", str(output_svg),
+        "--",
+        sys.executable, str(bench_script),
+        "--round", str(round_num),
+        "--iterations", "1",
+        "--warmup", "0",
+    ]
+    if data_flag:
+        cmd.append(data_flag)
+    if extra_args:
+        cmd.extend(extra_args)
+
+    print(f"  [profiler] py-spy: round {round_num} -> {output_svg.name}")
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode != 0:
+            print(f"  [profiler] py-spy failed (rc={result.returncode}):")
+            print(f"    {result.stderr[:500]}")
+            return False
+        return output_svg.exists()
+    except subprocess.TimeoutExpired:
+        print("  [profiler] py-spy timed out (300s)")
+        return False
+    except FileNotFoundError:
+        print("  [profiler] py-spy not installed, skipping")
+        return False
+
+
+def profile_with_perf(
+    round_num: int,
+    output_svg: Path,
+    data_flag: str = "--sample",
+) -> bool:
+    """Profile using Linux perf + inferno (more accurate Rust frame resolution).
+
+    Requires:
+      - perf installed
+      - cargo install inferno
+      - maturin develop --profile flamegraph  (for readable Rust symbols)
+    """
+    bench_script = BENCHMARKS_DIR / "bench_vs.py"
+    perf_data = output_svg.parent / f"perf_r{round_num}.data"
+
+    # Step 1: perf record
+    record_cmd = [
+        "perf", "record",
+        "-F", "99",       # 99 Hz sampling frequency
+        "-g",             # call graphs
+        "--call-graph", "dwarf",
+        "-o", str(perf_data),
+        "--",
+        sys.executable, str(bench_script),
+        "--round", str(round_num),
+        "--iterations", "1",
+        "--warmup", "0",
+    ]
+    if data_flag:
+        record_cmd.append(data_flag)
+
+    print(f"  [profiler] perf record: round {round_num}...")
+    try:
+        result = subprocess.run(
+            record_cmd, cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=300
+        )
+        if result.returncode != 0:
+            print(f"  [profiler] perf record failed: {result.stderr[:300]}")
+            return False
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        print(f"  [profiler] perf unavailable: {e}")
+        return False
+
+    # Step 2: perf script | inferno-collapse-perf | inferno-flamegraph
+    print(f"  [profiler] generating flamegraph -> {output_svg.name}")
+    try:
+        perf_script = subprocess.run(
+            ["perf", "script", "-i", str(perf_data)],
+            cwd=str(REPO_ROOT), capture_output=True, timeout=120
+        )
+        collapse = subprocess.run(
+            ["inferno-collapse-perf"],
+            input=perf_script.stdout, capture_output=True, timeout=60
+        )
+        with open(output_svg, "wb") as f:
+            flamegraph = subprocess.run(
+                ["inferno-flamegraph"],
+                input=collapse.stdout, stdout=f, timeout=60
+            )
+        perf_data.unlink(missing_ok=True)
+        return output_svg.exists() and flamegraph.returncode == 0
+    except Exception as e:
+        print(f"  [profiler] flamegraph generation failed: {e}")
+        return False
+
+
+def profile_round(
+    round_num: int,
+    output_svg: Path,
+    data_flag: str = "--sample",
+    prefer: str = "pyspy",
+) -> bool:
+    """Profile a benchmark round using available tools.
+
+    Args:
+        prefer: 'pyspy' (default) or 'perf'
+    """
+    deps = check_dependencies()
+
+    if prefer == "perf" and deps["perf"] and deps["inferno-collapse-perf"]:
+        return profile_with_perf(round_num, output_svg, data_flag)
+
+    if deps["py-spy"]:
+        return profile_with_pyspy(round_num, output_svg, data_flag)
+
+    if deps["perf"] and deps["inferno-collapse-perf"]:
+        return profile_with_perf(round_num, output_svg, data_flag)
+
+    print_install_hints(deps)
+    return False
+
+
+def profile_python_layer(output_svg: Path, data_flag: str = "--sample") -> bool:
+    """Profile Python expression serialization overhead using bench_core.py."""
+    bench_script = BENCHMARKS_DIR / "bench_core.py"
+    deps = check_dependencies()
+
+    if not deps["py-spy"]:
+        print("  [profiler] py-spy not installed, skipping Python layer profiling")
+        return False
+
+    cmd = [
+        "py-spy", "record",
+        "--format", "flamegraph",
+        "--output", str(output_svg),
+        "--",
+        sys.executable, str(bench_script),
+    ]
+
+    print(f"  [profiler] Python layer profiling -> {output_svg.name}")
+    try:
+        result = subprocess.run(
+            cmd, cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=180
+        )
+        if result.returncode != 0:
+            print(f"  [profiler] bench_core profiling failed: {result.stderr[:300]}")
+            return False
+        return output_svg.exists()
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        print(f"  [profiler] failed: {e}")
+        return False

--- a/benchmarks/autoresearch/report.py
+++ b/benchmarks/autoresearch/report.py
@@ -1,0 +1,116 @@
+"""
+report.py — Generate Markdown research reports.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from .analyzer import summarize_hotspots, diff_hotspots
+from .hypothesis import render_hypotheses
+from .tracker import render_trend_table
+
+
+def generate_report(
+    run_dir: Path,
+    bench_vs_results: dict | None,
+    bench_core_results: dict | None,
+    hotspots: dict[str, list[dict]],
+    hypotheses: list[dict],
+    history: list[dict],
+    data_flag: str = "--sample",
+) -> str:
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    git_sha = (history[0].get("git_sha", "?") if history else "?")
+    dataset_label = "1M-row sample" if "sample" in data_flag else "full dataset"
+
+    lines = [
+        f"# LTSeq autoresearch report — {now}",
+        "",
+        f"**Git SHA**: `{git_sha}` | **Dataset**: {dataset_label}",
+        "",
+    ]
+
+    # --- Benchmark comparison ---
+    lines += ["## Benchmark comparison (bench_vs)", ""]
+    if bench_vs_results and bench_vs_results.get("rounds"):
+        lines += [
+            "| Round | LTSeq (s) | DuckDB (s) | Ratio | LTSeq mem (MB) |",
+            "|-------|-----------|------------|-------|----------------|",
+        ]
+        for r in bench_vs_results["rounds"]:
+            name = r.get("round_name", "?")
+            lt = r.get("ltseq", {})
+            dk = r.get("duckdb", {})
+            lt_s = lt.get("median_s", "-")
+            dk_s = dk.get("median_s", "-")
+            lt_mem = lt.get("mem_delta_mb", "-")
+            if isinstance(lt_s, float) and isinstance(dk_s, float) and dk_s > 0:
+                ratio = dk_s / lt_s
+                ratio_str = f"{ratio:.1f}x LT" if ratio > 1 else f"{1/ratio:.1f}x DK"
+            else:
+                ratio_str = "N/A"
+            lines.append(f"| {name} | {lt_s} | {dk_s} | {ratio_str} | {lt_mem} |")
+        lines.append("")
+    else:
+        lines += ["_bench_vs not run — no comparison data._", ""]
+
+    # --- Core operation benchmarks ---
+    if bench_core_results:
+        lines += ["## Core operation benchmarks (bench_core)", ""]
+        lines += [
+            "| Operation | Rows | Time (ms) | Throughput (rows/s) |",
+            "|-----------|------|-----------|---------------------|",
+        ]
+        for r in bench_core_results:
+            rps = r.get("rows_per_sec")
+            rps_str = f"{rps:.0f}" if isinstance(rps, (int, float)) else "-"
+            lines.append(
+                f"| {r.get('name','?')} | {r.get('rows','-')} | "
+                f"{r.get('time_ms','-')} | {rps_str} |"
+            )
+        lines.append("")
+
+    # --- Flamegraph hotspots ---
+    lines += ["## Flamegraph hotspot analysis", ""]
+    if hotspots:
+        prev_hotspots: dict[str, list[dict]] = {}
+        if len(history) > 1:
+            prev_hs = history[1].get("hotspots", {})
+            prev_hotspots = prev_hs if isinstance(prev_hs, dict) else {}
+
+        for round_key, hs in hotspots.items():
+            round_label = round_key.upper().replace("_", " ")
+            lines.append(f"### {round_label}")
+            prev = prev_hotspots.get(round_key, [])
+            annotated = diff_hotspots(hs, prev) if prev else hs
+            lines.append(summarize_hotspots(annotated))
+            lines.append("")
+    else:
+        lines += ["_No flamegraphs generated. Run with --profile to enable._", ""]
+
+    # --- Optimization hypotheses ---
+    lines += ["## Optimization hypotheses", ""]
+    lines.append(render_hypotheses(hypotheses))
+
+    # --- Historical trend ---
+    lines += ["## Historical trend", ""]
+    lines.append(render_trend_table(history))
+
+    # --- Next steps ---
+    lines += [
+        "## Next steps",
+        "",
+        "1. Open the flamegraph SVG files in a browser (see `results/` directory)",
+        "2. Pick the highest-priority hypothesis above and implement the change",
+        "3. Run `pytest py-ltseq/tests/ -q` to verify correctness",
+        "4. Re-run autoresearch to confirm the performance improvement",
+        "",
+        "```bash",
+        "# Quick re-run after a change",
+        "python benchmarks/autoresearch/runner.py --skip-profile",
+        "```",
+    ]
+
+    return "\n".join(lines) + "\n"

--- a/benchmarks/autoresearch/runner.py
+++ b/benchmarks/autoresearch/runner.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""
+autoresearch/runner.py — Automated performance research for LTSeq.
+
+Research loop:
+  1. Run bench_vs.py (LTSeq vs DuckDB) + bench_core.py
+  2. Profile hot rounds with py-spy or perf (optional)
+  3. Extract Top-N hotspot functions from flamegraph SVGs
+  4. Match hotspots against known optimization patterns → hypotheses
+  5. Save results + compare with history
+  6. Generate Markdown report
+
+Usage:
+    # Quick benchmark only (no profiling)
+    python benchmarks/autoresearch/runner.py --skip-profile
+
+    # Full research with flamegraphs (1M sample)
+    python benchmarks/autoresearch/runner.py --profile
+
+    # Research on full 100M dataset
+    python benchmarks/autoresearch/runner.py --profile --full
+
+    # Specific round only
+    python benchmarks/autoresearch/runner.py --round 1
+
+    # Trend report without running benchmarks
+    python benchmarks/autoresearch/runner.py --report-only
+
+    # Use perf instead of py-spy
+    python benchmarks/autoresearch/runner.py --profile --profiler perf
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Ensure the benchmarks/ directory is on sys.path for ltseq imports
+REPO_ROOT = Path(__file__).parent.parent.parent
+BENCHMARKS_DIR = Path(__file__).parent.parent
+AUTORESEARCH_DIR = Path(__file__).parent
+RESULTS_DIR = AUTORESEARCH_DIR / "results"
+sys.path.insert(0, str(REPO_ROOT / "py-ltseq"))
+
+from .analyzer import extract_hotspots
+from .hypothesis import generate_hypotheses
+from .profiler import profile_round, profile_python_layer, check_dependencies
+from .report import generate_report
+from .tracker import save_run, load_history
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runners
+# ---------------------------------------------------------------------------
+
+def run_bench_vs(data_flag: str, rounds: list[int], iterations: int, warmup: int) -> dict | None:
+    """Run bench_vs.py and return parsed JSON results."""
+    bench_script = BENCHMARKS_DIR / "bench_vs.py"
+    results_json = BENCHMARKS_DIR / "clickbench_results.json"
+
+    cmd = [sys.executable, str(bench_script), "--iterations", str(iterations), "--warmup", str(warmup)]
+    if data_flag == "--sample":
+        cmd.append("--sample")
+    elif data_flag.startswith("--data"):
+        cmd.extend(data_flag.split("=", 1))
+
+    # If all three rounds, run once together to get the combined JSON
+    if sorted(rounds) == [1, 2, 3]:
+        print("\n  [bench_vs] Running all rounds...")
+        subprocess.run(cmd, cwd=str(REPO_ROOT), text=True)
+    else:
+        for r in rounds:
+            print(f"\n  [bench_vs] Round {r}...")
+            result = subprocess.run(cmd + ["--round", str(r)], cwd=str(REPO_ROOT), text=True)
+            if result.returncode != 0:
+                print(f"  [bench_vs] Round {r} failed (rc={result.returncode})")
+
+    if results_json.exists():
+        try:
+            return json.loads(results_json.read_text())
+        except Exception as e:
+            print(f"  [bench_vs] Failed to parse JSON: {e}")
+    return None
+
+
+def run_bench_core() -> list[dict] | None:
+    """Run bench_core.py and return parsed results."""
+    bench_script = BENCHMARKS_DIR / "bench_core.py"
+    results_json = BENCHMARKS_DIR / "results.json"
+
+    print("\n  [bench_core] Running core operation benchmarks...")
+    result = subprocess.run(
+        [sys.executable, str(bench_script)],
+        cwd=str(REPO_ROOT),
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"  [bench_core] Failed (rc={result.returncode})")
+        return None
+
+    if results_json.exists():
+        try:
+            data = json.loads(results_json.read_text())
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict) and "results" in data:
+                return data["results"]
+            return data
+        except Exception:
+            pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main research loop
+# ---------------------------------------------------------------------------
+
+def run_research(
+    rounds: list[int],
+    data_flag: str,
+    skip_profile: bool,
+    profiler: str,
+    bench_core: bool,
+    iterations: int,
+    warmup: int,
+    report_only: bool,
+) -> Path:
+    """Execute the full research loop, return path to run directory."""
+    date_str = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    run_dir = RESULTS_DIR / date_str
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_label = "1M-row sample" if data_flag == "--sample" else "full dataset"
+
+    print(f"\n{'='*60}")
+    print(f"LTSeq autoresearch — {date_str}")
+    print(f"Dataset: {dataset_label} | Rounds: {rounds}")
+    print(f"{'='*60}")
+
+    bench_vs_results = None
+    bench_core_results = None
+    hotspots: dict[str, list[dict]] = {}
+    hypotheses: list[dict] = []
+
+    if not report_only:
+        # --- Step 1: Benchmarks ---
+        print("\n[1/4] Running benchmarks...")
+        bench_vs_results = run_bench_vs(data_flag, rounds, iterations, warmup)
+        if bench_vs_results:
+            (run_dir / "bench_vs.json").write_text(json.dumps(bench_vs_results, indent=2))
+
+        if bench_core:
+            bench_core_results = run_bench_core()
+            if bench_core_results:
+                (run_dir / "bench_core.json").write_text(
+                    json.dumps(bench_core_results, indent=2)
+                )
+
+        # --- Step 2: Profiling ---
+        if not skip_profile:
+            print("\n[2/4] Generating flamegraphs...")
+            deps = check_dependencies()
+            if not deps["py-spy"] and not (deps["perf"] and deps["inferno-collapse-perf"]):
+                print("  No profiling tools found. Install with: pip install py-spy")
+            else:
+                for r in rounds:
+                    svg = run_dir / f"r{r}_flamegraph.svg"
+                    ok = profile_round(r, svg, data_flag=data_flag, prefer=profiler)
+                    if ok:
+                        hs = extract_hotspots(svg)
+                        if hs:
+                            hotspots[f"r{r}"] = hs
+                            print(f"  -> r{r}: {len(hs)} hotspot functions found")
+
+                py_svg = run_dir / "python_flamegraph.svg"
+                ok = profile_python_layer(py_svg, data_flag=data_flag)
+                if ok:
+                    hs = extract_hotspots(py_svg)
+                    if hs:
+                        hotspots["python"] = hs
+                        print(f"  -> python layer: {len(hs)} hotspot functions found")
+        else:
+            print("\n[2/4] Skipping profiling (use --profile to enable)")
+
+        # --- Step 3: Hypotheses ---
+        print("\n[3/4] Generating optimization hypotheses...")
+        all_hotspots = [h for hs in hotspots.values() for h in hs]
+        hypotheses = generate_hypotheses(all_hotspots)
+        if hypotheses:
+            for h in hypotheses[:3]:
+                print(f"  -> [{h.get('effort','?')}] {h['label']} ({h.get('expected_gain','?')})")
+        else:
+            print("  No profiling data — using static known-pattern list")
+
+        # --- Step 4: Save ---
+        print("\n[4/4] Saving results...")
+        save_run(run_dir, bench_vs_results, bench_core_results, hotspots)
+    else:
+        print("  [report-only] Skipping benchmarks and profiling")
+
+    history = load_history(10)
+
+    report = generate_report(
+        run_dir=run_dir,
+        bench_vs_results=bench_vs_results,
+        bench_core_results=bench_core_results,
+        hotspots=hotspots,
+        hypotheses=hypotheses if not report_only else [],
+        history=history,
+        data_flag=data_flag,
+    )
+    report_path = run_dir / "report.md"
+    report_path.write_text(report)
+
+    print(f"\n{'='*60}")
+    print(f"Report saved: {report_path}")
+    print(f"{'='*60}\n")
+    print(report)
+
+    return run_dir
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="LTSeq autoresearch: automated performance research tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Data selection
+    data_group = parser.add_mutually_exclusive_group()
+    data_group.add_argument(
+        "--sample", action="store_true", default=True,
+        help="Use 1M-row sample (default)",
+    )
+    data_group.add_argument(
+        "--full", action="store_true",
+        help="Use full 100M-row dataset",
+    )
+    data_group.add_argument(
+        "--data", type=str, metavar="PATH",
+        help="Custom Parquet file path",
+    )
+
+    # Round selection
+    parser.add_argument(
+        "--round", type=int, choices=[1, 2, 3], action="append", dest="rounds",
+        help="Run specific round (repeatable; default: all)",
+    )
+
+    # Profiling
+    parser.add_argument(
+        "--profile", action="store_true",
+        help="Generate flamegraphs (requires py-spy or perf)",
+    )
+    parser.add_argument(
+        "--skip-profile", action="store_true",
+        help="Skip profiling, run benchmarks only",
+    )
+    parser.add_argument(
+        "--profiler", choices=["pyspy", "perf"], default="pyspy",
+        help="Preferred profiler (default: pyspy)",
+    )
+
+    # Bench options
+    parser.add_argument(
+        "--no-bench-core", action="store_true",
+        help="Skip bench_core.py",
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=3,
+        help="Number of timed iterations for bench_vs.py (default: 3)",
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=1,
+        help="Number of warmup iterations for bench_vs.py (default: 1)",
+    )
+
+    # Report only
+    parser.add_argument(
+        "--report-only", action="store_true",
+        help="Generate trend report from history only, do not run benchmarks",
+    )
+
+    args = parser.parse_args()
+
+    # Determine data flag
+    if args.data:
+        data_flag = f"--data={args.data}"
+    elif args.full:
+        data_flag = ""  # no flag = full dataset
+    else:
+        data_flag = "--sample"
+
+    rounds = sorted(set(args.rounds)) if args.rounds else [1, 2, 3]
+    skip_profile = not args.profile or args.skip_profile
+
+    run_research(
+        rounds=rounds,
+        data_flag=data_flag,
+        skip_profile=skip_profile,
+        profiler=args.profiler,
+        bench_core=not args.no_bench_core,
+        iterations=args.iterations,
+        warmup=args.warmup,
+        report_only=args.report_only,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/autoresearch/tracker.py
+++ b/benchmarks/autoresearch/tracker.py
@@ -1,0 +1,111 @@
+"""
+tracker.py — Results history storage and trend analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+RESULTS_DIR = Path(__file__).parent / "results"
+
+
+def get_git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def save_run(
+    run_dir: Path,
+    bench_vs_results: dict | None,
+    bench_core_results: dict | None,
+    hotspots: dict[str, list[dict]],
+) -> None:
+    summary = {
+        "timestamp": datetime.now().isoformat(),
+        "git_sha": get_git_sha(),
+        "bench_vs": bench_vs_results,
+        "bench_core": bench_core_results,
+        "hotspots": hotspots,
+    }
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+
+
+def load_history(n: int = 10) -> list[dict]:
+    """Load the most recent n research runs."""
+    summaries = sorted(RESULTS_DIR.glob("*/summary.json"), reverse=True)
+    history = []
+    for p in summaries[:n]:
+        try:
+            history.append(json.loads(p.read_text()))
+        except Exception:
+            pass
+    return history
+
+
+def render_trend_table(history: list[dict]) -> str:
+    """Generate a Markdown trend table from historical runs."""
+    if not history:
+        return "_No historical data yet. Run autoresearch at least once to start tracking._\n"
+
+    lines = [
+        "| Date | Git SHA | R1 LTSeq (s) | R2 LTSeq (s) | R3 LTSeq (s) |",
+        "|------|---------|-------------|-------------|-------------|",
+    ]
+
+    for run in history:
+        ts = run.get("timestamp", "")[:10]
+        sha = run.get("git_sha", "?")
+        rounds = {}
+        if run.get("bench_vs") and run["bench_vs"].get("rounds"):
+            for r in run["bench_vs"]["rounds"]:
+                name = r.get("round_name", "")
+                if "R1" in name:
+                    rounds["r1"] = r.get("ltseq", {}).get("median_s", "-")
+                elif "R2" in name:
+                    rounds["r2"] = r.get("ltseq", {}).get("median_s", "-")
+                elif "R3" in name:
+                    rounds["r3"] = r.get("ltseq", {}).get("median_s", "-")
+
+        r1 = f"{rounds.get('r1', '-')}"
+        r2 = f"{rounds.get('r2', '-')}"
+        r3 = f"{rounds.get('r3', '-')}"
+        lines.append(f"| {ts} | `{sha}` | {r1} | {r2} | {r3} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def compute_delta(history: list[dict], key: str) -> str:
+    """Compute delta vs previous run for a metric (e.g. 'r1_ltseq_s')."""
+    if len(history) < 2:
+        return "N/A"
+    current = _extract_metric(history[0], key)
+    previous = _extract_metric(history[1], key)
+    if current is None or previous is None:
+        return "N/A"
+    delta = current - previous
+    sign = "+" if delta > 0 else ""
+    return f"{sign}{delta:.3f}s"
+
+
+def _extract_metric(run: dict, key: str) -> float | None:
+    """Extract a metric like 'r1_ltseq_s' from a run summary."""
+    mapping = {"r1": "R1", "r2": "R2", "r3": "R3"}
+    parts = key.split("_")
+    if len(parts) < 2:
+        return None
+    round_key = parts[0]
+    round_name_prefix = mapping.get(round_key)
+    if not round_name_prefix:
+        return None
+    rounds = (run.get("bench_vs") or {}).get("rounds", [])
+    for r in rounds:
+        if round_name_prefix in r.get("round_name", ""):
+            return r.get("ltseq", {}).get("median_s")
+    return None


### PR DESCRIPTION
## Summary

- Adds `benchmarks/autoresearch/` — a six-module tool that automates the LTSeq performance research workflow
- Adds `[profile.flamegraph]` to `Cargo.toml` for readable Rust symbols in flamegraphs
- Adds `benchmarks/autoresearch/results/` to `.gitignore`

## What autoresearch does

The tool runs the full cycle automatically:

```
run benchmarks → profile hot rounds → extract hotspots
→ match against known patterns → generate hypotheses
→ save history → render Markdown report
```

**Modules:**

| File | Role |
|------|------|
| `runner.py` | CLI entry point, orchestrates the loop |
| `profiler.py` | Flamegraph generation (py-spy or perf+inferno) |
| `analyzer.py` | Parses flamegraph SVGs, extracts Top-N hotspot functions |
| `hypothesis.py` | Maps hotspot patterns to actionable optimization suggestions |
| `tracker.py` | Per-run JSON history for trend analysis |
| `report.py` | Markdown report with comparison tables, hotspot tables, hypotheses |

**Eight built-in optimization patterns** are pre-loaded (e.g. DataFusion GroupByExec partition count, Arrow `concat_batches` copy, `starts_with` missing Arrow kernel, SchemaProxy rebuild overhead).

## Usage

```bash
# Benchmark only (no profiling) — fastest
python benchmarks/autoresearch/runner.py --skip-profile

# Full research with flamegraphs on 1M-row sample
pip install py-spy
python benchmarks/autoresearch/runner.py --profile

# Specific round, full dataset
python benchmarks/autoresearch/runner.py --profile --full --round 1

# Trend report from history only
python benchmarks/autoresearch/runner.py --report-only

# Use perf+inferno instead of py-spy (better Rust symbol resolution)
maturin develop --profile flamegraph
python benchmarks/autoresearch/runner.py --profile --profiler perf
```

## Test plan

- [ ] `python -c "from benchmarks.autoresearch import runner, profiler, analyzer, hypothesis, tracker, report"` — all modules import cleanly
- [ ] `python benchmarks/autoresearch/runner.py --skip-profile --no-bench-core` — runs bench_vs.py and writes a report
- [ ] `python benchmarks/autoresearch/runner.py --report-only` — generates trend table from history

🤖 Generated with [Claude Code](https://claude.com/claude-code)