### PR TITLE
feat: add benchmark autoloop preflight checks

### DIFF
--- a/benchmarks/autoresearch/pilot/README.md
+++ b/benchmarks/autoresearch/pilot/README.md
@@ -95,3 +95,10 @@ Controller behavior:
 - discards worktree changes after archiving so the loop stays supervised and reviewable
 
 The controller does not auto-commit or auto-merge candidate changes.
+
+Non-dry-run controller runs also perform preflight checks before creating benchmark evidence:
+
+- `opencode` must be available in `PATH`
+- `maturin` must be available unless `--skip-build` is used
+- Python benchmark dependencies must include `duckdb` and `psutil`
+- the benchmark dataset must exist at the default path or the `--data` override

--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -54,6 +54,67 @@ USE_SAMPLE=0
 DATA_PATH=""
 SKIP_BUILD=0
 
+default_benchmark_data_path() {
+  if [[ -n "$DATA_PATH" ]]; then
+    printf '%s\n' "$DATA_PATH"
+    return 0
+  fi
+
+  if [[ "$USE_SAMPLE" -eq 1 ]]; then
+    printf '%s\n' "$ROOT_DIR/benchmarks/data/hits_sample.parquet"
+    return 0
+  fi
+
+  printf '%s\n' "$ROOT_DIR/benchmarks/data/hits_sorted.parquet"
+}
+
+preflight_python_modules() {
+  python - <<'PY'
+import importlib
+import sys
+
+missing = []
+for name in ("duckdb", "psutil"):
+    try:
+        importlib.import_module(name)
+    except ModuleNotFoundError:
+        missing.append(name)
+
+if missing:
+    print("missing-python-modules=" + ",".join(missing))
+    sys.exit(1)
+PY
+}
+
+run_preflight_checks() {
+  local data_file
+  local failures=()
+
+  data_file="$(default_benchmark_data_path)"
+
+  if [[ "$SKIP_BUILD" -ne 1 ]] && ! command -v maturin >/dev/null 2>&1; then
+    failures+=("missing command: maturin (install it or rerun with --skip-build)")
+  fi
+
+  if ! preflight_python_modules >/tmp/benchmark-autoresearch-python-check.$$ 2>&1; then
+    failures+=("python benchmark deps unavailable: $(tr '\n' ' ' < /tmp/benchmark-autoresearch-python-check.$$ | sed 's/[[:space:]]\+/ /g') (run 'uv sync --group bench' or 'uv sync --group autoresearch')")
+  fi
+  rm -f /tmp/benchmark-autoresearch-python-check.$$
+
+  if [[ ! -f "$data_file" ]]; then
+    failures+=("missing benchmark data: $data_file (run 'python benchmarks/prepare_data.py' or pass --data PATH)")
+  fi
+
+  if [[ ${#failures[@]} -ne 0 ]]; then
+    printf 'benchmark autoresearch preflight failed:\n' >&2
+    for failure in "${failures[@]}"; do
+      printf '  - %s\n' "$failure" >&2
+    done
+    printf 'see docs/BENCHMARK_AUTORESEARCH.md for setup details\n' >&2
+    return 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -m|--model)
@@ -163,6 +224,10 @@ fi
 if ! command -v opencode >/dev/null 2>&1; then
   printf 'opencode not found in PATH\n' >&2
   exit 1
+fi
+
+if [[ "$DRY_RUN" -ne 1 ]]; then
+  run_preflight_checks || exit 1
 fi
 
 WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-benchmark-$TARGET"

--- a/docs/BENCHMARK_AUTORESEARCH.md
+++ b/docs/BENCHMARK_AUTORESEARCH.md
@@ -57,3 +57,29 @@ python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py clickbench_funnel
 ```
 
 Use `--sample` for smoke tests only. Review baseline decisions on the full sorted dataset.
+
+## Supervised Controller
+
+The pilot also includes a supervised controller that uses isolated git worktrees and one OpenCode candidate per iteration.
+
+Start with a dry-run:
+
+```bash
+bash benchmarks/autoresearch/pilot/scripts/autoloop.sh \
+  --target clickbench_funnel \
+  --baseline \
+  --iterations 1 \
+  --sample \
+  --dry-run
+```
+
+In non-dry-run mode, the controller performs preflight checks before running the loop.
+
+Required checks:
+
+- `opencode` in `PATH`
+- `maturin` in `PATH` unless `--skip-build` is used
+- Python benchmark modules `duckdb` and `psutil`
+- benchmark data file exists at `benchmarks/data/hits_sorted.parquet`, `benchmarks/data/hits_sample.parquet`, or the `--data` override
+
+If preflight fails, the controller exits early with actionable setup guidance instead of creating partial benchmark artifacts.


### PR DESCRIPTION
## Summary
- add explicit non-dry-run preflight checks to the benchmark autoresearch autoloop
- fail early with actionable setup guidance when build tools, benchmark deps, or benchmark data are missing
- document controller preflight requirements in the pilot README and benchmark autoresearch guide

## Testing
- `bash benchmarks/autoresearch/pilot/scripts/autoloop.sh --target clickbench_funnel --iterations 1 --sample --dry-run`
- `bash benchmarks/autoresearch/pilot/scripts/autoloop.sh --target clickbench_funnel --iterations 1 --sample`
- `python -m py_compile benchmarks/autoresearch/pilot/scripts/extract_decision_from_stdout.py`

## Notes
- In the current environment, the non-dry-run command exits during preflight as expected because `maturin` and the Python `duckdb` module are not available.
- The preflight path is intended to avoid partial benchmark controller runs when the local setup is incomplete.