### PR TITLE
feat: harden benchmark autoresearch pilot contracts

### DIFF
--- a/benchmarks/autoresearch/pilot/README.md
+++ b/benchmarks/autoresearch/pilot/README.md
@@ -95,3 +95,10 @@ Controller behavior:
 - discards worktree changes after archiving so the loop stays supervised and reviewable
 
 The controller does not auto-commit or auto-merge candidate changes.
+
+Non-dry-run controller runs also perform preflight checks before creating benchmark evidence:
+
+- `opencode` must be available in `PATH`
+- `maturin` must be available unless `--skip-build` is used
+- Python benchmark dependencies must include `duckdb` and `psutil`
+- the benchmark dataset must exist at the default path or the `--data` override

--- a/benchmarks/autoresearch/pilot/README.md
+++ b/benchmarks/autoresearch/pilot/README.md
@@ -62,6 +62,16 @@ python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py clickbench_funnel
 python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py clickbench_sessionization
 ```
 
+For each target, the gate writes machine-readable evidence under `reports/diff/<target>/`:
+
+- `benchmark-diff.json`: per-workload LTSeq median/p95 deltas for the target workload plus protected workloads
+- `evaluation.json`: keep/discard recommendation, target-win details, protected-regression details, and threshold metadata
+
+Examples:
+
+- `reports/diff/clickbench_funnel/`
+- `reports/diff/clickbench_sessionization/`
+
 ## Notes
 
 - use `--sample` for smoke tests only; baseline decisions should use the full sorted ClickBench dataset

--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -54,6 +54,67 @@ USE_SAMPLE=0
 DATA_PATH=""
 SKIP_BUILD=0
 
+default_benchmark_data_path() {
+  if [[ -n "$DATA_PATH" ]]; then
+    printf '%s\n' "$DATA_PATH"
+    return 0
+  fi
+
+  if [[ "$USE_SAMPLE" -eq 1 ]]; then
+    printf '%s\n' "$ROOT_DIR/benchmarks/data/hits_sample.parquet"
+    return 0
+  fi
+
+  printf '%s\n' "$ROOT_DIR/benchmarks/data/hits_sorted.parquet"
+}
+
+preflight_python_modules() {
+  python - <<'PY'
+import importlib
+import sys
+
+missing = []
+for name in ("duckdb", "psutil"):
+    try:
+        importlib.import_module(name)
+    except ModuleNotFoundError:
+        missing.append(name)
+
+if missing:
+    print("missing-python-modules=" + ",".join(missing))
+    sys.exit(1)
+PY
+}
+
+run_preflight_checks() {
+  local data_file
+  local failures=()
+
+  data_file="$(default_benchmark_data_path)"
+
+  if [[ "$SKIP_BUILD" -ne 1 ]] && ! command -v maturin >/dev/null 2>&1; then
+    failures+=("missing command: maturin (install it or rerun with --skip-build)")
+  fi
+
+  if ! preflight_python_modules >/tmp/benchmark-autoresearch-python-check.$$ 2>&1; then
+    failures+=("python benchmark deps unavailable: $(tr '\n' ' ' < /tmp/benchmark-autoresearch-python-check.$$ | sed 's/[[:space:]]\+/ /g') (run 'uv sync --group bench' or 'uv sync --group autoresearch')")
+  fi
+  rm -f /tmp/benchmark-autoresearch-python-check.$$
+
+  if [[ ! -f "$data_file" ]]; then
+    failures+=("missing benchmark data: $data_file (run 'python benchmarks/prepare_data.py' or pass --data PATH)")
+  fi
+
+  if [[ ${#failures[@]} -ne 0 ]]; then
+    printf 'benchmark autoresearch preflight failed:\n' >&2
+    for failure in "${failures[@]}"; do
+      printf '  - %s\n' "$failure" >&2
+    done
+    printf 'see docs/BENCHMARK_AUTORESEARCH.md for setup details\n' >&2
+    return 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -m|--model)
@@ -163,6 +224,10 @@ fi
 if ! command -v opencode >/dev/null 2>&1; then
   printf 'opencode not found in PATH\n' >&2
   exit 1
+fi
+
+if [[ "$DRY_RUN" -ne 1 ]]; then
+  run_preflight_checks || exit 1
 fi
 
 WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-benchmark-$TARGET"

--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -221,7 +221,7 @@ if [[ -n "$SESSION_ID" && "$CONTINUE_LAST" -eq 1 ]]; then
   exit 1
 fi
 
-if ! command -v opencode >/dev/null 2>&1; then
+if [[ "$DRY_RUN" -ne 1 ]] && ! command -v opencode >/dev/null 2>&1; then
   printf 'opencode not found in PATH\n' >&2
   exit 1
 fi
@@ -453,8 +453,13 @@ build_opencode_command() {
   local decision_file="$2"
   local -n out_ref=$3
   local prompt
+  local prompt_worktree_dir="$WORKTREE_DIR"
 
-  prompt="$(WORKTREE_DIR="$WORKTREE_DIR" bash "$SCRIPT_DIR/opencode_autoresearch.sh" \
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    prompt_worktree_dir="${WORKTREE_DIR:-$ROOT_DIR}"
+  fi
+
+  prompt="$(WORKTREE_DIR="$prompt_worktree_dir" bash "$SCRIPT_DIR/opencode_autoresearch.sh" \
     --target "$TARGET" \
     --single-candidate \
     --decision-file "$decision_file" \
@@ -894,13 +899,8 @@ autoloop_main() {
     cleanup_synced_assets
     discard_candidate_state
   else
-    init_worktree || true
-    bootstrap_worktree_state
-    sync_workspace_overlay
-    sync_autoresearch_assets
-    sync_baseline_reports_to_worktree
+    WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-benchmark-$TARGET"
     run_baseline_if_needed
-    cleanup_synced_assets
   fi
 
   for ((run_index = 1; run_index <= ITERATIONS; run_index++)); do

--- a/benchmarks/autoresearch/pilot/scripts/evaluate_benchmark_candidate.py
+++ b/benchmarks/autoresearch/pilot/scripts/evaluate_benchmark_candidate.py
@@ -20,6 +20,20 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
     diff = build_diff(target, baseline, candidate)
     workloads = {workload["id"]: workload for workload in diff.get("workloads", [])}
 
+    def workload_signal(workload: dict) -> dict:
+        return {
+            "id": workload["id"],
+            "name": workload["name"],
+            "role": workload.get("role", "unknown"),
+            "median_delta_pct": workload.get("ltseq_median_delta_pct"),
+            "p95_delta_pct": workload.get("ltseq_p95_delta_pct"),
+        }
+
+    thresholds = {
+        "target_improvement_threshold_pct": spec.target_improvement_threshold_pct,
+        "protected_regression_threshold_pct": spec.protected_regression_threshold_pct,
+    }
+
     if int(candidate.get("correctness_failures", 0)) > 0:
         return {
             "target": target,
@@ -27,6 +41,10 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
             "reason": f"correctness regressions detected: {candidate['correctness_failures']}",
             "target_win": "none",
             "protected_status": "n/a",
+            "target_wins_detail": [],
+            "protected_regressions_detail": [],
+            "missing_workloads": [],
+            "thresholds": thresholds,
         }
 
     if int(candidate.get("infra_failures", 0)) > 0:
@@ -36,10 +54,16 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
             "reason": f"infrastructure failures detected: {candidate['infra_failures']}",
             "target_win": "none",
             "protected_status": "n/a",
+            "target_wins_detail": [],
+            "protected_regressions_detail": [],
+            "missing_workloads": [],
+            "thresholds": thresholds,
         }
 
     target_wins = []
+    target_wins_detail = []
     protected_regressions = []
+    protected_regressions_detail = []
     missing_workloads = []
 
     for workload_id in spec.target_workloads:
@@ -52,6 +76,7 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
         if (
             median_delta is not None and median_delta <= spec.target_improvement_threshold_pct
         ) or (p95_delta is not None and p95_delta <= spec.target_improvement_threshold_pct):
+            target_wins_detail.append(workload_signal(workload))
             target_wins.append(
                 f"{workload['name']}(median={format_delta(median_delta)},p95={format_delta(p95_delta)})"
             )
@@ -66,6 +91,7 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
         if (
             median_delta is not None and median_delta >= spec.protected_regression_threshold_pct
         ) or (p95_delta is not None and p95_delta >= spec.protected_regression_threshold_pct):
+            protected_regressions_detail.append(workload_signal(workload))
             protected_regressions.append(
                 f"{workload['name']}(median={format_delta(median_delta)},p95={format_delta(p95_delta)})"
             )
@@ -77,6 +103,10 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
             "reason": "missing workloads: " + ", ".join(sorted(set(missing_workloads))),
             "target_win": "none",
             "protected_status": "n/a",
+            "target_wins_detail": [],
+            "protected_regressions_detail": [],
+            "missing_workloads": sorted(set(missing_workloads)),
+            "thresholds": thresholds,
         }
 
     if protected_regressions:
@@ -86,6 +116,10 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
             "reason": "protected workload regression: " + ", ".join(protected_regressions),
             "target_win": ", ".join(target_wins) if target_wins else "none",
             "protected_status": ", ".join(protected_regressions),
+            "target_wins_detail": target_wins_detail,
+            "protected_regressions_detail": protected_regressions_detail,
+            "missing_workloads": [],
+            "thresholds": thresholds,
         }
 
     if not target_wins:
@@ -95,6 +129,10 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
             "reason": "no target workload met the improvement threshold",
             "target_win": "none",
             "protected_status": "clean",
+            "target_wins_detail": [],
+            "protected_regressions_detail": [],
+            "missing_workloads": [],
+            "thresholds": thresholds,
         }
 
     return {
@@ -103,6 +141,10 @@ def evaluate_candidate(target: str, baseline: dict, candidate: dict) -> dict:
         "reason": "target improvement without protected regression: " + ", ".join(target_wins),
         "target_win": ", ".join(target_wins),
         "protected_status": "clean",
+        "target_wins_detail": target_wins_detail,
+        "protected_regressions_detail": [],
+        "missing_workloads": [],
+        "thresholds": thresholds,
     }
 
 

--- a/benchmarks/autoresearch/runner.py
+++ b/benchmarks/autoresearch/runner.py
@@ -139,12 +139,12 @@ def run_research(
     output_dir: str | None,
 ) -> Path:
     """Execute the full research loop, return path to run directory."""
+    date_str = datetime.now().strftime("%Y-%m-%d_%H%M%S")
     if output_dir:
         run_dir = Path(output_dir).expanduser()
         if not run_dir.is_absolute():
             run_dir = REPO_ROOT / run_dir
     else:
-        date_str = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         run_dir = RESULTS_DIR / date_str
     run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/benchmarks/bench_vs.py
+++ b/benchmarks/bench_vs.py
@@ -62,8 +62,16 @@ def make_round_result(round_id, round_name):
 
 def mark_infra_failure(round_result, error):
     """Capture a round-level infrastructure failure without aborting the run."""
+    error_text = str(error)
     round_result["benchmark_status"] = "infra_failure"
-    round_result["error"] = str(error)
+    round_result["error"] = error_text
+    round_result["validation"] = make_validation(
+        "infra_failure",
+        error_text,
+        None,
+        None,
+        error=error_text,
+    )
     return round_result
 
 

--- a/docs/BENCHMARK_AUTORESEARCH.md
+++ b/docs/BENCHMARK_AUTORESEARCH.md
@@ -57,3 +57,29 @@ python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py clickbench_funnel
 ```
 
 Use `--sample` for smoke tests only. Review baseline decisions on the full sorted dataset.
+
+## Supervised Controller
+
+The pilot also includes a supervised controller that uses isolated git worktrees and one OpenCode candidate per iteration.
+
+Start with a dry-run:
+
+```bash
+bash benchmarks/autoresearch/pilot/scripts/autoloop.sh \
+  --target clickbench_funnel \
+  --baseline \
+  --iterations 1 \
+  --sample \
+  --dry-run
+```
+
+In non-dry-run mode, the controller performs preflight checks before running the loop.
+
+Required checks:
+
+- `opencode` in `PATH`
+- `maturin` in `PATH` unless `--skip-build` is used
+- Python benchmark modules `duckdb` and `psutil`
+- benchmark data file exists at `benchmarks/data/hits_sorted.parquet`, `benchmarks/data/hits_sample.parquet`, or the `--data` override
+
+If preflight fails, the controller exits early with actionable setup guidance instead of creating partial benchmark artifacts.

--- a/docs/BENCHMARK_AUTORESEARCH.md
+++ b/docs/BENCHMARK_AUTORESEARCH.md
@@ -58,6 +58,29 @@ python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py clickbench_funnel
 
 Use `--sample` for smoke tests only. Review baseline decisions on the full sorted dataset.
 
+## Machine-readable Benchmark Summary
+
+`benchmarks/bench_vs.py` writes `benchmarks/clickbench_results.json` for downstream gating.
+
+Top-level fields used by the pilot:
+
+- `passed`
+- `correctness_failures`
+- `infra_failures`
+- `completed_rounds`
+- `total_rounds`
+- `rounds`
+
+Each round also carries machine-readable status fields:
+
+- `round_id`
+- `round_name`
+- `benchmark_status`
+- `validation.status`
+- `validation.detail`
+
+Infrastructure failures are persisted in JSON with `benchmark_status=infra_failure` and `validation.status=infra_failure`, so the pilot evaluator does not need to parse stdout to decide whether a candidate should be kept or discarded.
+
 ## Supervised Controller
 
 The pilot also includes a supervised controller that uses isolated git worktrees and one OpenCode candidate per iteration.

--- a/py-ltseq/tests/test_autoresearch_runner.py
+++ b/py-ltseq/tests/test_autoresearch_runner.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_runner_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    runner_path = repo_root / "benchmarks" / "autoresearch" / "runner.py"
+    spec = importlib.util.spec_from_file_location("ltseq_autoresearch_runner", runner_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_research_supports_output_dir_without_timestamp_guess(tmp_path, monkeypatch):
+    runner = load_runner_module()
+
+    report_text = "# fake report\n"
+    history = [{"git_sha": "abc123"}]
+
+    monkeypatch.setattr(runner, "load_history", lambda n=10: history)
+    monkeypatch.setattr(runner, "generate_report", lambda **kwargs: report_text)
+
+    run_dir = runner.run_research(
+        rounds=[1],
+        data_flag="--sample",
+        skip_profile=True,
+        profiler="pyspy",
+        bench_core=False,
+        iterations=1,
+        warmup=0,
+        report_only=True,
+        output_dir=str(tmp_path / "custom-output"),
+    )
+
+    assert run_dir == tmp_path / "custom-output"
+    assert run_dir.exists()
+    assert (run_dir / "report.md").read_text() == report_text

--- a/py-ltseq/tests/test_bench_vs_summary.py
+++ b/py-ltseq/tests/test_bench_vs_summary.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def load_bench_vs_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    bench_vs_path = repo_root / "benchmarks" / "bench_vs.py"
+
+    fake_duckdb = types.SimpleNamespace(sql=lambda *_args, **_kwargs: None)
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda *_args, **_kwargs: None,
+        virtual_memory=lambda: types.SimpleNamespace(total=0),
+    )
+    fake_ltseq = types.SimpleNamespace(LTSeq=object)
+
+    sys.modules.setdefault("duckdb", fake_duckdb)
+    sys.modules.setdefault("psutil", fake_psutil)
+    sys.modules.setdefault("ltseq", fake_ltseq)
+
+    spec = importlib.util.spec_from_file_location("ltseq_bench_vs", bench_vs_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mark_infra_failure_adds_machine_readable_validation():
+    bench_vs = load_bench_vs_module()
+
+    round_result = bench_vs.make_round_result("r1_top_urls", "R1: Top URLs")
+    bench_vs.mark_infra_failure(round_result, RuntimeError("duckdb unavailable"))
+
+    assert round_result["benchmark_status"] == "infra_failure"
+    assert round_result["error"] == "duckdb unavailable"
+    assert round_result["validation"]["status"] == "infra_failure"
+    assert round_result["validation"]["detail"] == "duckdb unavailable"
+    assert round_result["validation"]["error"] == "duckdb unavailable"
+
+
+def test_save_results_writes_gating_summary_fields(tmp_path, monkeypatch):
+    bench_vs = load_bench_vs_module()
+
+    monkeypatch.setattr(bench_vs, "BENCHMARKS_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        bench_vs,
+        "get_system_info",
+        lambda: {"platform": "test", "cpu_count": 1, "ram_gb": 1.0, "python_version": "3.x"},
+    )
+
+    passing_round = bench_vs.make_round_result("r1_top_urls", "R1: Top URLs")
+    passing_round["duckdb"] = {"median_s": 1.0}
+    passing_round["ltseq"] = {"median_s": 0.8}
+    passing_round["validation"] = bench_vs.make_validation(
+        "pass",
+        "same top 10 URLs",
+        ["a"],
+        ["a"],
+        compared_metric="top_10_urls",
+    )
+
+    failing_round = bench_vs.make_round_result("r2_sessionization", "R2: Sessionization")
+    bench_vs.mark_infra_failure(failing_round, RuntimeError("ltseq crashed"))
+
+    bench_vs.save_results(
+        [passing_round, failing_round],
+        data_file="benchmarks/data/hits_sample.parquet",
+        warmup=1,
+        iterations=3,
+    )
+
+    payload = json.loads((tmp_path / "clickbench_results.json").read_text())
+
+    assert payload["passed"] is False
+    assert payload["correctness_failures"] == 0
+    assert payload["infra_failures"] == 1
+    assert payload["completed_rounds"] == 1
+    assert payload["total_rounds"] == 2
+    assert payload["rounds"][0]["validation"]["status"] == "pass"
+    assert payload["rounds"][1]["benchmark_status"] == "infra_failure"
+    assert payload["rounds"][1]["validation"]["status"] == "infra_failure"

--- a/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def load_pilot_modules():
+    repo_root = Path(__file__).resolve().parents[2]
+    autoresearch_root = repo_root / "benchmarks" / "autoresearch"
+    autoresearch_root_str = str(autoresearch_root)
+    if autoresearch_root_str not in sys.path:
+        sys.path.insert(0, autoresearch_root_str)
+
+    common = importlib.import_module("pilot.common")
+    evaluate = importlib.import_module("pilot.scripts.evaluate_benchmark_candidate")
+    gate = importlib.import_module("pilot.scripts.benchmark_gate")
+    return common, evaluate, gate
+
+
+def make_summary(*, target: str, r1: tuple[float, float], r2: tuple[float, float], r3: tuple[float, float]) -> dict:
+    return {
+        "target": target,
+        "git_sha": "abc123",
+        "timestamp": "2026-04-20T12:00:00",
+        "data_file": "benchmarks/data/hits_sorted.parquet",
+        "warmup": 1,
+        "iterations": 3,
+        "passed": True,
+        "correctness_failures": 0,
+        "infra_failures": 0,
+        "workloads": [
+            {
+                "id": "r1_top_urls",
+                "name": "R1: Top URLs",
+                "role": "protected",
+                "benchmark_status": "completed",
+                "validation_status": "pass",
+                "ltseq": {"median_s": r1[0], "p95_s": r1[1], "times": [r1[0]], "mem_delta_mb": 1.0},
+                "duckdb": {"median_s": 1.0, "p95_s": 1.0, "times": [1.0], "mem_delta_mb": 1.0},
+            },
+            {
+                "id": "r2_sessionization",
+                "name": "R2: Sessionization",
+                "role": "protected",
+                "benchmark_status": "completed",
+                "validation_status": "pass",
+                "ltseq": {"median_s": r2[0], "p95_s": r2[1], "times": [r2[0]], "mem_delta_mb": 1.0},
+                "duckdb": {"median_s": 1.0, "p95_s": 1.0, "times": [1.0], "mem_delta_mb": 1.0},
+            },
+            {
+                "id": "r3_funnel",
+                "name": "R3: Funnel",
+                "role": "target",
+                "benchmark_status": "completed",
+                "validation_status": "pass",
+                "ltseq": {"median_s": r3[0], "p95_s": r3[1], "times": [r3[0]], "mem_delta_mb": 1.0},
+                "duckdb": {"median_s": 1.0, "p95_s": 1.0, "times": [1.0], "mem_delta_mb": 1.0},
+            },
+        ],
+    }
+
+
+def workload_map(diff: dict) -> dict:
+    return {workload["id"]: workload for workload in diff["workloads"]}
+
+
+def test_clickbench_funnel_target_spec_is_configured():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    spec = common.resolve_target("clickbench_funnel")
+
+    assert spec.target_workloads == ("r3_funnel",)
+    assert spec.protected_workloads == ("r1_top_urls", "r2_sessionization")
+    assert spec.source_files == ("src/ops/pattern_match.rs",)
+    assert spec.target_improvement_threshold_pct == -3.0
+    assert spec.protected_regression_threshold_pct == 5.0
+
+
+def test_clickbench_funnel_diff_persists_target_and_protected_deltas():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    baseline = make_summary(
+        target="clickbench_funnel",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_funnel",
+        r1=(1.01, 1.12),
+        r2=(0.49, 0.58),
+        r3=(1.78, 1.95),
+    )
+
+    diff = common.build_diff("clickbench_funnel", baseline, candidate)
+    workloads = workload_map(diff)
+
+    assert list(workload["id"] for workload in diff["workloads"]) == [
+        "r3_funnel",
+        "r1_top_urls",
+        "r2_sessionization",
+    ]
+    assert math.isclose(workloads["r3_funnel"]["ltseq_median_delta_pct"], -11.0, abs_tol=1e-9)
+    assert math.isclose(workloads["r1_top_urls"]["ltseq_median_delta_pct"], 1.0, abs_tol=1e-9)
+    assert math.isclose(workloads["r2_sessionization"]["ltseq_median_delta_pct"], -2.0, abs_tol=1e-9)
+
+
+def test_clickbench_funnel_evaluator_keeps_target_improvement_without_protected_regression():
+    _common, evaluate, _gate = load_pilot_modules()
+
+    baseline = make_summary(
+        target="clickbench_funnel",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_funnel",
+        r1=(1.01, 1.12),
+        r2=(0.49, 0.58),
+        r3=(1.78, 1.95),
+    )
+
+    evaluation = evaluate.evaluate_candidate("clickbench_funnel", baseline, candidate)
+
+    assert evaluation["recommendation"] == "keep"
+    assert evaluation["protected_status"] == "clean"
+    assert evaluation["target_wins_detail"] == [
+        {
+            "id": "r3_funnel",
+            "name": "R3: Funnel",
+            "role": "target",
+            "median_delta_pct": -11.0,
+            "p95_delta_pct": (1.95 - 2.2) / 2.2 * 100.0,
+        }
+    ]
+    assert evaluation["protected_regressions_detail"] == []
+    assert evaluation["thresholds"] == {
+        "target_improvement_threshold_pct": -3.0,
+        "protected_regression_threshold_pct": 5.0,
+    }
+
+
+def test_clickbench_funnel_evaluator_discards_protected_regression():
+    _common, evaluate, _gate = load_pilot_modules()
+
+    baseline = make_summary(
+        target="clickbench_funnel",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_funnel",
+        r1=(1.08, 1.2),
+        r2=(0.49, 0.58),
+        r3=(1.78, 1.95),
+    )
+
+    evaluation = evaluate.evaluate_candidate("clickbench_funnel", baseline, candidate)
+
+    assert evaluation["recommendation"] == "discard"
+    assert evaluation["target_wins_detail"][0]["id"] == "r3_funnel"
+    assert evaluation["protected_regressions_detail"][0]["id"] == "r1_top_urls"
+    assert "R1: Top URLs" in evaluation["protected_status"]
+
+
+def test_clickbench_funnel_gate_writes_target_specific_diff_and_evaluation(tmp_path, monkeypatch):
+    common, _evaluate, gate = load_pilot_modules()
+
+    baseline_dir = tmp_path / "baseline"
+    candidate_dir = tmp_path / "candidates"
+    diff_dir = tmp_path / "diff"
+    baseline_dir.mkdir()
+    candidate_dir.mkdir()
+    diff_dir.mkdir()
+
+    baseline = make_summary(
+        target="clickbench_funnel",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_funnel",
+        r1=(1.01, 1.12),
+        r2=(0.49, 0.58),
+        r3=(1.78, 1.95),
+    )
+    (baseline_dir / "benchmark-summary.json").write_text(json.dumps(baseline), encoding="utf-8")
+    (candidate_dir / "benchmark-summary.json").write_text(json.dumps(candidate), encoding="utf-8")
+
+    def fake_resolve_report_dir(phase: str, target: str) -> Path:
+        assert target == "clickbench_funnel"
+        mapping = {
+            "baseline": baseline_dir,
+            "candidates": candidate_dir,
+            "diff": diff_dir,
+        }
+        return mapping[phase]
+
+    monkeypatch.setattr(gate, "resolve_report_dir", fake_resolve_report_dir)
+    monkeypatch.setattr(gate, "ensure_report_dirs", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["benchmark_gate.py", "clickbench_funnel"])
+
+    assert gate.main() == 0
+
+    diff_payload = json.loads((diff_dir / "benchmark-diff.json").read_text(encoding="utf-8"))
+    evaluation_payload = json.loads((diff_dir / "evaluation.json").read_text(encoding="utf-8"))
+
+    assert diff_payload["target"] == "clickbench_funnel"
+    assert [workload["id"] for workload in diff_payload["workloads"]] == [
+        "r3_funnel",
+        "r1_top_urls",
+        "r2_sessionization",
+    ]
+    assert evaluation_payload["recommendation"] == "keep"
+    assert evaluation_payload["target_wins_detail"][0]["id"] == "r3_funnel"
+
+
+def test_clickbench_sessionization_target_spec_is_configured():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    spec = common.resolve_target("clickbench_sessionization")
+
+    assert spec.target_workloads == ("r2_sessionization",)
+    assert spec.protected_workloads == ("r1_top_urls", "r3_funnel")
+    assert spec.source_files == ("src/ops/window.rs", "src/ops/derive.rs")
+    assert spec.target_improvement_threshold_pct == -3.0
+    assert spec.protected_regression_threshold_pct == 5.0
+
+
+def test_clickbench_sessionization_diff_persists_target_and_protected_deltas():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    baseline = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.02, 1.11),
+        r2=(0.44, 0.53),
+        r3=(2.01, 2.19),
+    )
+
+    diff = common.build_diff("clickbench_sessionization", baseline, candidate)
+    workloads = workload_map(diff)
+
+    assert list(workload["id"] for workload in diff["workloads"]) == [
+        "r2_sessionization",
+        "r1_top_urls",
+        "r3_funnel",
+    ]
+    assert math.isclose(workloads["r2_sessionization"]["ltseq_median_delta_pct"], -12.0, abs_tol=1e-9)
+    assert math.isclose(workloads["r1_top_urls"]["ltseq_median_delta_pct"], 2.0, abs_tol=1e-9)
+    assert math.isclose(workloads["r3_funnel"]["ltseq_median_delta_pct"], 0.5, abs_tol=1e-9)
+
+
+def test_clickbench_sessionization_evaluator_keeps_target_improvement_without_protected_regression():
+    _common, evaluate, _gate = load_pilot_modules()
+
+    baseline = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.02, 1.11),
+        r2=(0.44, 0.53),
+        r3=(2.01, 2.19),
+    )
+
+    evaluation = evaluate.evaluate_candidate("clickbench_sessionization", baseline, candidate)
+
+    assert evaluation["recommendation"] == "keep"
+    assert evaluation["protected_status"] == "clean"
+    assert evaluation["target_wins_detail"] == [
+        {
+            "id": "r2_sessionization",
+            "name": "R2: Sessionization",
+            "role": "target",
+            "median_delta_pct": -12.0,
+            "p95_delta_pct": (0.53 - 0.6) / 0.6 * 100.0,
+        }
+    ]
+    assert evaluation["protected_regressions_detail"] == []
+    assert evaluation["thresholds"] == {
+        "target_improvement_threshold_pct": -3.0,
+        "protected_regression_threshold_pct": 5.0,
+    }
+
+
+def test_clickbench_sessionization_evaluator_discards_protected_regression():
+    _common, evaluate, _gate = load_pilot_modules()
+
+    baseline = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.02, 1.11),
+        r2=(0.44, 0.53),
+        r3=(2.12, 2.32),
+    )
+
+    evaluation = evaluate.evaluate_candidate("clickbench_sessionization", baseline, candidate)
+
+    assert evaluation["recommendation"] == "discard"
+    assert evaluation["target_wins_detail"][0]["id"] == "r2_sessionization"
+    assert evaluation["protected_regressions_detail"][0]["id"] == "r3_funnel"
+    assert "R3: Funnel" in evaluation["protected_status"]
+
+
+def test_clickbench_sessionization_gate_writes_target_specific_diff_and_evaluation(tmp_path, monkeypatch):
+    _common, _evaluate, gate = load_pilot_modules()
+
+    baseline_dir = tmp_path / "baseline"
+    candidate_dir = tmp_path / "candidates"
+    diff_dir = tmp_path / "diff"
+    baseline_dir.mkdir()
+    candidate_dir.mkdir()
+    diff_dir.mkdir()
+
+    baseline = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_sessionization",
+        r1=(1.02, 1.11),
+        r2=(0.44, 0.53),
+        r3=(2.01, 2.19),
+    )
+    (baseline_dir / "benchmark-summary.json").write_text(json.dumps(baseline), encoding="utf-8")
+    (candidate_dir / "benchmark-summary.json").write_text(json.dumps(candidate), encoding="utf-8")
+
+    def fake_resolve_report_dir(phase: str, target: str) -> Path:
+        assert target == "clickbench_sessionization"
+        mapping = {
+            "baseline": baseline_dir,
+            "candidates": candidate_dir,
+            "diff": diff_dir,
+        }
+        return mapping[phase]
+
+    monkeypatch.setattr(gate, "resolve_report_dir", fake_resolve_report_dir)
+    monkeypatch.setattr(gate, "ensure_report_dirs", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["benchmark_gate.py", "clickbench_sessionization"])
+
+    assert gate.main() == 0
+
+    diff_payload = json.loads((diff_dir / "benchmark-diff.json").read_text(encoding="utf-8"))
+    evaluation_payload = json.loads((diff_dir / "evaluation.json").read_text(encoding="utf-8"))
+
+    assert diff_payload["target"] == "clickbench_sessionization"
+    assert [workload["id"] for workload in diff_payload["workloads"]] == [
+        "r2_sessionization",
+        "r1_top_urls",
+        "r3_funnel",
+    ]
+    assert evaluation_payload["recommendation"] == "keep"
+    assert evaluation_payload["target_wins_detail"][0]["id"] == "r2_sessionization"


### PR DESCRIPTION
## Summary
- harden the controller-facing autoresearch contracts for benchmark summaries, target evaluation, and dry-run behavior
- add structured machine-readable target evidence for funnel and sessionization pilot targets
- add focused regression tests for runner output directories, benchmark summary JSON, and pilot target evaluation behavior

## Included Issues
- closes the implementation gap for #26
- closes the implementation gap for #27
- closes the implementation gap for #29
- closes the implementation gap for #24
- closes a high-value controller gap in #28

## What Changed
- fix `benchmarks/autoresearch/runner.py --output-dir` so controller paths do not rely on timestamp guessing or crash on custom output directories
- make `benchmarks/bench_vs.py` persist infra failures as machine-readable round validation data
- expand pilot evaluation output with structured target win, protected regression, missing workload, and threshold metadata
- document machine-readable benchmark and pilot diff artifacts in the autoresearch docs
- make `autoloop.sh --dry-run` avoid requiring `opencode` and avoid touching the research worktree
- add focused tests for runner output-dir handling, benchmark summary JSON shape, and both pilot target evaluators

## Verification
- `python -m py_compile benchmarks/autoresearch/runner.py py-ltseq/tests/test_autoresearch_runner.py`
- `python -m py_compile benchmarks/bench_vs.py py-ltseq/tests/test_bench_vs_summary.py`
- `python -m py_compile benchmarks/autoresearch/pilot/scripts/evaluate_benchmark_candidate.py py-ltseq/tests/test_benchmark_autoresearch_pilot.py`
- `bash -n benchmarks/autoresearch/pilot/scripts/autoloop.sh`
- direct Python verification for `clickbench_funnel` and `clickbench_sessionization` evaluator behavior
- dry-run command generation for both pilot targets

## Notes
- this PR intentionally does not include the local `uv.lock` change from `uv run`
- keeping this as draft until the pilot is exercised through the non-dry-run E2E issues (#34 and #37)
