### PR TITLE
fix: harden benchmark autoresearch e2e paths

### DIFF
--- a/benchmarks/autoresearch/pilot/common.sh
+++ b/benchmarks/autoresearch/pilot/common.sh
@@ -66,12 +66,13 @@ resolve_target_sources() {
 
 resolve_target_source_paths() {
   local target="$1"
+  local base_dir="${2:-$ROOT_DIR}"
   local source_paths=()
   local source
 
   while IFS= read -r source; do
     [[ -z "$source" ]] && continue
-    source_paths+=("$ROOT_DIR/$source")
+    source_paths+=("$base_dir/$source")
   done < <(resolve_target_sources "$target" | tr ' ' '\n')
 
   printf '%s' "${source_paths[*]}"
@@ -104,7 +105,7 @@ render_prompt_template_with_decision() {
   rules_file="$worktree_dir/$(resolve_program_rules)"
   candidate_script="$worktree_dir/benchmarks/autoresearch/pilot/scripts/benchmark_candidate.py"
   gate_script="$worktree_dir/benchmarks/autoresearch/pilot/scripts/benchmark_gate.py"
-  source_files="$(resolve_target_source_paths "$target")"
+  source_files="$(resolve_target_source_paths "$target" "$worktree_dir")"
   rendered="$(<"$template_path")"
   rendered="${rendered//\{\{TARGET\}\}/$target}"
   rendered="${rendered//\{\{SOURCE_FILES\}\}/$source_files}"

--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -409,8 +409,46 @@ sync_baseline_reports_to_worktree() {
     return 0
   fi
 
+  rm -rf "$worktree_baseline_dir"
   mkdir -p "$worktree_baseline_dir"
   cp -R "$root_baseline_dir/." "$worktree_baseline_dir/"
+}
+
+phase_dir_has_artifacts() {
+  local phase_dir="$1"
+  local entry
+  local had_nullglob=0
+  local had_dotglob=0
+
+  [[ -d "$phase_dir" ]] || return 1
+
+  if shopt -q nullglob; then
+    had_nullglob=1
+  fi
+  if shopt -q dotglob; then
+    had_dotglob=1
+  fi
+  shopt -s nullglob dotglob
+  for entry in "$phase_dir"/*; do
+    if [[ "$(basename "$entry")" == ".gitkeep" ]]; then
+      continue
+    fi
+    if [[ "$had_nullglob" -eq 0 ]]; then
+      shopt -u nullglob
+    fi
+    if [[ "$had_dotglob" -eq 0 ]]; then
+      shopt -u dotglob
+    fi
+    return 0
+  done
+
+  if [[ "$had_nullglob" -eq 0 ]]; then
+    shopt -u nullglob
+  fi
+  if [[ "$had_dotglob" -eq 0 ]]; then
+    shopt -u dotglob
+  fi
+  return 1
 }
 
 archive_baseline_reports_from_worktree() {
@@ -426,18 +464,74 @@ archive_baseline_reports_from_worktree() {
   cp -R "$worktree_baseline_dir/." "$root_baseline_dir/"
 }
 
+archive_phase_reports_from_worktree() {
+  local phase="$1"
+  local root_phase_dir="$REPORT_DIR/$phase/$TARGET"
+  local worktree_phase_dir="$WORKTREE_DIR/benchmarks/autoresearch/pilot/reports/$phase/$TARGET"
+
+  if ! phase_dir_has_artifacts "$worktree_phase_dir"; then
+    return 0
+  fi
+
+  rm -rf "$root_phase_dir"
+  mkdir -p "$root_phase_dir"
+  cp -R "$worktree_phase_dir/." "$root_phase_dir/"
+}
+
+clear_root_phase_reports() {
+  local phase="$1"
+  local root_phase_dir="$REPORT_DIR/$phase/$TARGET"
+
+  rm -rf "$root_phase_dir"
+  mkdir -p "$root_phase_dir"
+}
+
 build_benchmark_args() {
   local -n out_ref=$1
+  local data_file
   out_ref=()
+
+  data_file="$(default_benchmark_data_path)"
+  out_ref+=(--data "$data_file")
+
   if [[ "$USE_SAMPLE" -eq 1 ]]; then
-    out_ref+=(--sample)
-  fi
-  if [[ -n "$DATA_PATH" ]]; then
-    out_ref+=(--data "$DATA_PATH")
+    :
   fi
   if [[ "$SKIP_BUILD" -eq 1 ]]; then
     out_ref+=(--skip-build)
   fi
+}
+
+baseline_matches_requested_data() {
+  local baseline_summary="$1"
+  local requested_data_file="$2"
+
+  [[ -f "$baseline_summary" ]] || return 1
+
+  python3 - <<'PY' "$baseline_summary" "$requested_data_file" "$ROOT_DIR"
+import json
+import os
+import sys
+
+summary_path, requested_data_file, repo_root = sys.argv[1:4]
+
+try:
+    with open(summary_path, encoding="utf-8") as handle:
+        data_file = json.load(handle).get("data_file")
+except Exception:
+    raise SystemExit(1)
+
+if not data_file:
+    raise SystemExit(1)
+
+def resolve(path: str) -> str:
+    if os.path.isabs(path):
+        return os.path.realpath(path)
+    return os.path.realpath(os.path.join(repo_root, path))
+
+if resolve(data_file) != resolve(requested_data_file):
+    raise SystemExit(1)
+PY
 }
 
 print_prompt() {
@@ -601,9 +695,15 @@ record_issue_from_decision() {
 run_baseline_if_needed() {
   local baseline_summary="$REPORT_DIR/baseline/$TARGET/benchmark-summary.json"
   local bench_args=()
+  local requested_data_file
+
   build_benchmark_args bench_args
+  requested_data_file="$(default_benchmark_data_path)"
   if [[ "$RUN_BASELINE" -eq 0 && -f "$baseline_summary" ]]; then
-    return 0
+    if baseline_matches_requested_data "$baseline_summary" "$requested_data_file"; then
+      return 0
+    fi
+    append_loop_log "existing baseline dataset does not match requested data; refreshing baseline for $TARGET"
   fi
   append_loop_log "running baseline for $TARGET"
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -625,6 +725,9 @@ validate_candidate_scope() {
   : > "$out_file"
   while IFS= read -r status; do
     path="${status:3}"
+    if path_in_base_overlay "$path"; then
+      continue
+    fi
     case "$path" in
       .benchmark-autoresearch-*)
         continue
@@ -633,9 +736,6 @@ validate_candidate_scope() {
         continue
         ;;
       src/*|py-ltseq/*)
-        if path_in_base_overlay "$path"; then
-          continue
-        fi
         if [[ "$path" == *"_test.py" || "$path" == *"_test.rs" ]] || ! is_target_allowed_perf_file "$path"; then
           printf '%s\n' "$path" >> "$out_file"
           invalid=1
@@ -712,11 +812,11 @@ archive_run_artifacts() {
   fi
   "${diff_cmd[@]}" > "$patch_path"
 
-  if [[ -d "$worktree_report_root/candidates/$TARGET" ]]; then
+  if phase_dir_has_artifacts "$worktree_report_root/candidates/$TARGET"; then
     mkdir -p "$run_dir/candidate"
     cp -R "$worktree_report_root/candidates/$TARGET/." "$run_dir/candidate/"
   fi
-  if [[ -d "$worktree_report_root/diff/$TARGET" ]]; then
+  if phase_dir_has_artifacts "$worktree_report_root/diff/$TARGET"; then
     mkdir -p "$run_dir/diff"
     cp -R "$worktree_report_root/diff/$TARGET/." "$run_dir/diff/"
   fi
@@ -788,6 +888,8 @@ run_iteration() {
   record_issue_from_decision "$decision_file"
 
   if [[ "$status" != "keep" ]]; then
+    clear_root_phase_reports candidates
+    clear_root_phase_reports diff
     printf 'recommendation=discard\nreason=%s\ntarget_win=none\nprotected_status=n/a\nevidence=%s\n' "$reason" "$evidence" > "$eval_file"
     mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
     run_dir="${archived[0]}"
@@ -798,6 +900,8 @@ run_iteration() {
   fi
 
   if ! validate_candidate_scope "$scope_file"; then
+    clear_root_phase_reports candidates
+    clear_root_phase_reports diff
     printf 'recommendation=discard\nreason=out-of-scope-or-empty-changes\ntarget_win=none\nprotected_status=n/a\nevidence=%s\n' "$(tr '\n' ';' < "$scope_file")" > "$eval_file"
     mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
     run_dir="${archived[0]}"
@@ -813,6 +917,8 @@ run_iteration() {
     cd "$WORKTREE_DIR"
     python benchmarks/autoresearch/pilot/scripts/benchmark_candidate.py "$TARGET" "${bench_args[@]}"
   ); then
+    clear_root_phase_reports candidates
+    clear_root_phase_reports diff
     printf '{"recommendation":"discard","reason":"benchmark-candidate-command-failed","target_win":"none","protected_status":"n/a"}\n' > "$eval_file"
     mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
     run_dir="${archived[0]}"
@@ -826,6 +932,7 @@ run_iteration() {
     cd "$WORKTREE_DIR"
     python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py "$TARGET" >/dev/null
   ); then
+    clear_root_phase_reports diff
     printf '{"recommendation":"discard","reason":"benchmark-gate-command-failed","target_win":"none","protected_status":"n/a"}\n' > "$eval_file"
     mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
     run_dir="${archived[0]}"
@@ -843,6 +950,8 @@ run_iteration() {
   mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
   run_dir="${archived[0]}"
   patch_path="${archived[1]}"
+  archive_phase_reports_from_worktree candidates
+  archive_phase_reports_from_worktree diff
   recommendation="$(python3 - <<'PY' "$eval_file"
 import json, sys
 data = json.load(open(sys.argv[1]))

--- a/benchmarks/autoresearch/report.py
+++ b/benchmarks/autoresearch/report.py
@@ -12,6 +12,21 @@ from .hypothesis import render_hypotheses
 from .tracker import render_trend_table
 
 
+def describe_dataset(data_flag: str, data_file: str | None = None) -> str:
+    if data_file:
+        data_path = Path(data_file)
+        if data_path.name == "hits_sample.parquet":
+            return "1M-row sample"
+        if data_path.name == "hits_sorted.parquet":
+            return "full dataset"
+        return f"custom dataset ({data_path})"
+    if data_flag == "--sample":
+        return "1M-row sample"
+    if data_flag.startswith("--data="):
+        return f"custom dataset ({data_flag.split('=', 1)[1]})"
+    return "full dataset"
+
+
 def generate_report(
     run_dir: Path,
     bench_vs_results: dict | None,
@@ -23,7 +38,8 @@ def generate_report(
 ) -> str:
     now = datetime.now().strftime("%Y-%m-%d %H:%M")
     git_sha = (history[0].get("git_sha", "?") if history else "?")
-    dataset_label = "1M-row sample" if "sample" in data_flag else "full dataset"
+    data_file = (bench_vs_results or {}).get("data_file") if bench_vs_results else None
+    dataset_label = describe_dataset(data_flag, data_file)
 
     lines = [
         f"# LTSeq autoresearch report — {now}",

--- a/benchmarks/autoresearch/runner.py
+++ b/benchmarks/autoresearch/runner.py
@@ -70,6 +70,10 @@ def run_bench_vs(data_flag: str, rounds: list[int], iterations: int, warmup: int
     bench_script = BENCHMARKS_DIR / "bench_vs.py"
     results_json = BENCHMARKS_DIR / "clickbench_results.json"
 
+    # Avoid reusing stale benchmark output from a previous successful run.
+    if results_json.exists():
+        results_json.unlink()
+
     cmd = [sys.executable, str(bench_script), "--iterations", str(iterations), "--warmup", str(warmup)]
     if data_flag == "--sample":
         cmd.append("--sample")
@@ -79,13 +83,19 @@ def run_bench_vs(data_flag: str, rounds: list[int], iterations: int, warmup: int
     # If all three rounds, run once together to get the combined JSON
     if sorted(rounds) == [1, 2, 3]:
         print("\n  [bench_vs] Running all rounds...")
-        subprocess.run(cmd, cwd=str(REPO_ROOT), text=True)
+        result = subprocess.run(cmd, cwd=str(REPO_ROOT), text=True)
+        if result.returncode != 0:
+            print(f"  [bench_vs] Benchmark run failed (rc={result.returncode})")
+            return None
     else:
         for r in rounds:
             print(f"\n  [bench_vs] Round {r}...")
             result = subprocess.run(cmd + ["--round", str(r)], cwd=str(REPO_ROOT), text=True)
             if result.returncode != 0:
                 print(f"  [bench_vs] Round {r} failed (rc={result.returncode})")
+
+        if not results_json.exists():
+            return None
 
     if results_json.exists():
         try:
@@ -127,6 +137,20 @@ def run_bench_core() -> list[dict] | None:
 # Main research loop
 # ---------------------------------------------------------------------------
 
+
+def describe_dataset(data_flag: str) -> str:
+    if data_flag == "--sample":
+        return "1M-row sample"
+    if data_flag.startswith("--data="):
+        data_path = Path(data_flag.split("=", 1)[1])
+        if data_path.name == "hits_sample.parquet":
+            return "1M-row sample"
+        if data_path.name == "hits_sorted.parquet":
+            return "full dataset"
+        return f"custom dataset ({data_path})"
+    return "full dataset"
+
+
 def run_research(
     rounds: list[int],
     data_flag: str,
@@ -148,7 +172,7 @@ def run_research(
         run_dir = RESULTS_DIR / date_str
     run_dir.mkdir(parents=True, exist_ok=True)
 
-    dataset_label = "1M-row sample" if data_flag == "--sample" else "full dataset"
+    dataset_label = describe_dataset(data_flag)
 
     print(f"\n{'='*60}")
     print(f"LTSeq autoresearch — {date_str}")

--- a/benchmarks/bench_vs.py
+++ b/benchmarks/bench_vs.py
@@ -181,12 +181,17 @@ def duckdb_top_url(data_file):
 
 
 def ltseq_top_url(t):
-    """LTSeq: agg by url, sort descending, slice top 10."""
+    """LTSeq: agg by url, sort descending, slice top 10.
+
+    Use Arrow materialization instead of pandas so benchmark validation does not
+    depend on an optional pandas install.
+    """
     return (
         t.agg(by=lambda r: r.url, cnt=lambda g: g.url.count())
         .sort("cnt", desc=True)
         .slice(0, 10)
-        .collect()
+        .to_arrow()
+        .to_pylist()
     )
 
 
@@ -313,9 +318,14 @@ def print_results_table(results):
 
     for r in results:
         name = r["round_name"]
-        duck_t = r["duckdb"]["median_s"]
-        ltseq_t = r["ltseq"]["median_s"]
-        if ltseq_t > 0 and duck_t > 0:
+        duck_t = r.get("duckdb", {}).get("median_s")
+        ltseq_t = r.get("ltseq", {}).get("median_s")
+        if (
+            isinstance(ltseq_t, (int, float))
+            and isinstance(duck_t, (int, float))
+            and ltseq_t > 0
+            and duck_t > 0
+        ):
             speedup = duck_t / ltseq_t
             speedup_str = f"{speedup:.1f}x"
             if speedup > 1:
@@ -326,8 +336,10 @@ def print_results_table(results):
             speedup_str = "N/A"
 
         loc_sql, loc_py = loc_data.get(name, (0, 0))
+        duck_display = f"{duck_t:>10.3f}s" if isinstance(duck_t, (int, float)) else f"{'n/a':>11}"
+        ltseq_display = f"{ltseq_t:>10.3f}s" if isinstance(ltseq_t, (int, float)) else f"{'n/a':>11}"
         print(
-            f"{name:<25} | {duck_t:>10.3f}s | {ltseq_t:>10.3f}s | {speedup_str:>8} | {loc_sql:>7} | {loc_py:>6}"
+            f"{name:<25} | {duck_display} | {ltseq_display} | {speedup_str:>8} | {loc_sql:>7} | {loc_py:>6}"
         )
 
     print()

--- a/py-ltseq/tests/test_autoresearch_report.py
+++ b/py-ltseq/tests/test_autoresearch_report.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def load_report_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+    return importlib.import_module("benchmarks.autoresearch.report")
+
+
+def test_generate_report_labels_explicit_sample_data_as_sample():
+    report = load_report_module()
+
+    rendered = report.generate_report(
+        run_dir=Path("results/test-run"),
+        bench_vs_results={"data_file": "benchmarks/data/hits_sample.parquet", "rounds": []},
+        bench_core_results=None,
+        hotspots={},
+        hypotheses=[],
+        history=[],
+        data_flag="--data=benchmarks/data/hits_sample.parquet",
+    )
+
+    assert "**Dataset**: 1M-row sample" in rendered
+
+
+def test_generate_report_labels_custom_data_path():
+    report = load_report_module()
+
+    rendered = report.generate_report(
+        run_dir=Path("results/test-run"),
+        bench_vs_results={"data_file": "/tmp/custom-bench.parquet", "rounds": []},
+        bench_core_results=None,
+        hotspots={},
+        hypotheses=[],
+        history=[],
+        data_flag="--data=/tmp/custom-bench.parquet",
+    )
+
+    assert "**Dataset**: custom dataset (/tmp/custom-bench.parquet)" in rendered

--- a/py-ltseq/tests/test_bench_vs_summary.py
+++ b/py-ltseq/tests/test_bench_vs_summary.py
@@ -85,3 +85,28 @@ def test_save_results_writes_gating_summary_fields(tmp_path, monkeypatch):
     assert payload["rounds"][0]["validation"]["status"] == "pass"
     assert payload["rounds"][1]["benchmark_status"] == "infra_failure"
     assert payload["rounds"][1]["validation"]["status"] == "infra_failure"
+
+
+def test_print_results_table_handles_infra_failure_rounds(capsys):
+    bench_vs = load_bench_vs_module()
+
+    passing_round = bench_vs.make_round_result("r3_funnel", "R3: Funnel")
+    passing_round["duckdb"] = {"median_s": 0.5}
+    passing_round["ltseq"] = {"median_s": 0.25}
+    passing_round["validation"] = bench_vs.make_validation(
+        "pass",
+        "both engines returned 123 matches",
+        123,
+        123,
+        compared_metric="funnel_match_count",
+    )
+
+    failing_round = bench_vs.make_round_result("r1_top_urls", "R1: Top URLs")
+    bench_vs.mark_infra_failure(failing_round, RuntimeError("pandas unavailable"))
+
+    bench_vs.print_results_table([failing_round, passing_round])
+
+    output = capsys.readouterr().out
+    assert "R1: Top URLs" in output
+    assert "R3: Funnel" in output
+    assert "n/a" in output

--- a/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
@@ -21,6 +21,8 @@ def load_pilot_modules():
 
 
 def make_summary(*, target: str, r1: tuple[float, float], r2: tuple[float, float], r3: tuple[float, float]) -> dict:
+    target_workload = "r3_funnel" if target == "clickbench_funnel" else "r2_sessionization"
+
     return {
         "target": target,
         "git_sha": "abc123",
@@ -35,7 +37,7 @@ def make_summary(*, target: str, r1: tuple[float, float], r2: tuple[float, float
             {
                 "id": "r1_top_urls",
                 "name": "R1: Top URLs",
-                "role": "protected",
+                "role": "target" if target_workload == "r1_top_urls" else "protected",
                 "benchmark_status": "completed",
                 "validation_status": "pass",
                 "ltseq": {"median_s": r1[0], "p95_s": r1[1], "times": [r1[0]], "mem_delta_mb": 1.0},
@@ -44,7 +46,7 @@ def make_summary(*, target: str, r1: tuple[float, float], r2: tuple[float, float
             {
                 "id": "r2_sessionization",
                 "name": "R2: Sessionization",
-                "role": "protected",
+                "role": "target" if target_workload == "r2_sessionization" else "protected",
                 "benchmark_status": "completed",
                 "validation_status": "pass",
                 "ltseq": {"median_s": r2[0], "p95_s": r2[1], "times": [r2[0]], "mem_delta_mb": 1.0},
@@ -53,7 +55,7 @@ def make_summary(*, target: str, r1: tuple[float, float], r2: tuple[float, float
             {
                 "id": "r3_funnel",
                 "name": "R3: Funnel",
-                "role": "target",
+                "role": "target" if target_workload == "r3_funnel" else "protected",
                 "benchmark_status": "completed",
                 "validation_status": "pass",
                 "ltseq": {"median_s": r3[0], "p95_s": r3[1], "times": [r3[0]], "mem_delta_mb": 1.0},
@@ -128,15 +130,16 @@ def test_clickbench_funnel_evaluator_keeps_target_improvement_without_protected_
 
     assert evaluation["recommendation"] == "keep"
     assert evaluation["protected_status"] == "clean"
-    assert evaluation["target_wins_detail"] == [
-        {
-            "id": "r3_funnel",
-            "name": "R3: Funnel",
-            "role": "target",
-            "median_delta_pct": -11.0,
-            "p95_delta_pct": (1.95 - 2.2) / 2.2 * 100.0,
-        }
-    ]
+    assert len(evaluation["target_wins_detail"]) == 1
+    assert evaluation["target_wins_detail"][0]["id"] == "r3_funnel"
+    assert evaluation["target_wins_detail"][0]["name"] == "R3: Funnel"
+    assert evaluation["target_wins_detail"][0]["role"] == "target"
+    assert math.isclose(evaluation["target_wins_detail"][0]["median_delta_pct"], -11.0, abs_tol=1e-9)
+    assert math.isclose(
+        evaluation["target_wins_detail"][0]["p95_delta_pct"],
+        (1.95 - 2.2) / 2.2 * 100.0,
+        abs_tol=1e-9,
+    )
     assert evaluation["protected_regressions_detail"] == []
     assert evaluation["thresholds"] == {
         "target_improvement_threshold_pct": -3.0,
@@ -282,15 +285,16 @@ def test_clickbench_sessionization_evaluator_keeps_target_improvement_without_pr
 
     assert evaluation["recommendation"] == "keep"
     assert evaluation["protected_status"] == "clean"
-    assert evaluation["target_wins_detail"] == [
-        {
-            "id": "r2_sessionization",
-            "name": "R2: Sessionization",
-            "role": "target",
-            "median_delta_pct": -12.0,
-            "p95_delta_pct": (0.53 - 0.6) / 0.6 * 100.0,
-        }
-    ]
+    assert len(evaluation["target_wins_detail"]) == 1
+    assert evaluation["target_wins_detail"][0]["id"] == "r2_sessionization"
+    assert evaluation["target_wins_detail"][0]["name"] == "R2: Sessionization"
+    assert evaluation["target_wins_detail"][0]["role"] == "target"
+    assert math.isclose(evaluation["target_wins_detail"][0]["median_delta_pct"], -12.0, abs_tol=1e-9)
+    assert math.isclose(
+        evaluation["target_wins_detail"][0]["p95_delta_pct"],
+        (0.53 - 0.6) / 0.6 * 100.0,
+        abs_tol=1e-9,
+    )
     assert evaluation["protected_regressions_detail"] == []
     assert evaluation["thresholds"] == {
         "target_improvement_threshold_pct": -3.0,


### PR DESCRIPTION
## Summary
- fix benchmark autoresearch controller e2e lifecycle issues around worktree prompts, baseline matching, and root artifact retention
- make benchmark reporting and validation robust to explicit data paths and infra-failure rounds without pandas
- add focused regression tests covering report labeling, infra-failure table rendering, and pilot evaluator fixtures

## Verification
- `/home/ruoshi/code/github/ltseq/.venv/bin/pytest py-ltseq/tests/test_bench_vs_summary.py py-ltseq/tests/test_benchmark_autoresearch_pilot.py py-ltseq/tests/test_autoresearch_report.py -q`
- non-dry-run `clickbench_funnel` autoloop verification for success-path artifact persistence, baseline dataset refresh, and failed-path stale artifact clearing