### PR TITLE
fix: stabilize benchmark autoresearch controller contracts

### DIFF
--- a/benchmarks/autoresearch/pilot/common.py
+++ b/benchmarks/autoresearch/pilot/common.py
@@ -71,6 +71,17 @@ def ensure_report_dirs() -> None:
         (REPORT_DIR / phase).mkdir(parents=True, exist_ok=True)
 
 
+def describe_dataset(data_file: str | None) -> str:
+    if not data_file:
+        return "unknown dataset"
+    data_path = Path(data_file)
+    if data_path.name == "hits_sample.parquet":
+        return "1M-row sample"
+    if data_path.name == "hits_sorted.parquet":
+        return "full dataset"
+    return f"custom dataset ({data_path})"
+
+
 def resolve_report_dir(phase: str, target: str) -> Path:
     return REPORT_DIR / phase / target
 
@@ -218,6 +229,7 @@ def build_benchmark_summary(target: str, runner_summary: dict) -> dict:
         "git_sha": runner_summary.get("git_sha"),
         "timestamp": runner_summary.get("timestamp"),
         "data_file": bench_vs.get("data_file"),
+        "dataset_label": describe_dataset(bench_vs.get("data_file")),
         "warmup": bench_vs.get("warmup"),
         "iterations": bench_vs.get("iterations"),
         "passed": passed,
@@ -233,6 +245,7 @@ def render_benchmark_result(summary: dict) -> str:
         "",
         f"- Target: `{summary['target']}`",
         f"- Git SHA: `{summary.get('git_sha', '?')}`",
+        f"- Dataset: {summary.get('dataset_label', describe_dataset(summary.get('data_file')))}",
         f"- Passed: `{summary.get('passed')}`",
         f"- Correctness failures: `{summary.get('correctness_failures')}`",
         f"- Infra failures: `{summary.get('infra_failures')}`",

--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -53,6 +53,13 @@ FORCE=0
 USE_SAMPLE=0
 DATA_PATH=""
 SKIP_BUILD=0
+WORKTREE_DIR=""
+BRANCH_DATE=""
+RESEARCH_BRANCH=""
+LOOP_LOG=""
+results_file=""
+issues_file=""
+base_overlay_manifest=""
 
 default_benchmark_data_path() {
   if [[ -n "$DATA_PATH" ]]; then
@@ -115,128 +122,134 @@ run_preflight_checks() {
   fi
 }
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -m|--model)
-      MODEL="${2:-}"
-      shift 2
-      ;;
-    -t|--target)
-      TARGET="${2:-}"
-      shift 2
-      ;;
-    --agent)
-      AGENT="${2:-}"
-      shift 2
-      ;;
-    --iterations)
-      ITERATIONS="${2:-}"
-      shift 2
-      ;;
-    --baseline)
-      RUN_BASELINE=1
-      shift
-      ;;
-    --attach)
-      ATTACH_URL="${2:-}"
-      shift 2
-      ;;
-    --session)
-      SESSION_ID="${2:-}"
-      shift 2
-      ;;
-    -c|--continue)
-      CONTINUE_LAST=1
-      shift
-      ;;
-    --fork)
-      FORK_SESSION=1
-      shift
-      ;;
-    --dangerously-skip-permissions)
-      SKIP_PERMISSIONS=1
-      shift
-      ;;
-    --sample)
-      USE_SAMPLE=1
-      shift
-      ;;
-    --data)
-      DATA_PATH="${2:-}"
-      shift 2
-      ;;
-    --skip-build)
-      SKIP_BUILD=1
-      shift
-      ;;
-    --sleep-seconds)
-      SLEEP_SECONDS="${2:-}"
-      shift 2
-      ;;
-    --log-prefix)
-      LOG_PREFIX="${2:-}"
-      shift 2
-      ;;
-    --print-prompt)
-      PRINT_PROMPT=1
-      shift
-      ;;
-    --dry-run)
-      DRY_RUN=1
-      shift
-      ;;
-    --force)
-      FORCE=1
-      shift
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      printf 'unknown option: %s\n\n' "$1" >&2
-      usage >&2
-      exit 1
-      ;;
-  esac
-done
+parse_autoloop_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -m|--model)
+        MODEL="${2:-}"
+        shift 2
+        ;;
+      -t|--target)
+        TARGET="${2:-}"
+        shift 2
+        ;;
+      --agent)
+        AGENT="${2:-}"
+        shift 2
+        ;;
+      --iterations)
+        ITERATIONS="${2:-}"
+        shift 2
+        ;;
+      --baseline)
+        RUN_BASELINE=1
+        shift
+        ;;
+      --attach)
+        ATTACH_URL="${2:-}"
+        shift 2
+        ;;
+      --session)
+        SESSION_ID="${2:-}"
+        shift 2
+        ;;
+      -c|--continue)
+        CONTINUE_LAST=1
+        shift
+        ;;
+      --fork)
+        FORK_SESSION=1
+        shift
+        ;;
+      --dangerously-skip-permissions)
+        SKIP_PERMISSIONS=1
+        shift
+        ;;
+      --sample)
+        USE_SAMPLE=1
+        shift
+        ;;
+      --data)
+        DATA_PATH="${2:-}"
+        shift 2
+        ;;
+      --skip-build)
+        SKIP_BUILD=1
+        shift
+        ;;
+      --sleep-seconds)
+        SLEEP_SECONDS="${2:-}"
+        shift 2
+        ;;
+      --log-prefix)
+        LOG_PREFIX="${2:-}"
+        shift 2
+        ;;
+      --print-prompt)
+        PRINT_PROMPT=1
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      --force)
+        FORCE=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        return 1
+        ;;
+      *)
+        printf 'unknown option: %s\n\n' "$1" >&2
+        usage >&2
+        return 2
+        ;;
+    esac
+  done
 
-resolve_target_brief "$TARGET" >/dev/null
+  return 0
+}
 
-for value_name in ITERATIONS SLEEP_SECONDS; do
-  value="${!value_name}"
-  if ! [[ "$value" =~ ^[0-9]+$ ]] || [[ "$value" -lt 0 ]]; then
-    printf '%s must be a non-negative integer\n' "$value_name" >&2
-    exit 1
+initialize_autoloop_state() {
+  resolve_target_brief "$TARGET" >/dev/null
+
+  for value_name in ITERATIONS SLEEP_SECONDS; do
+    value="${!value_name}"
+    if ! [[ "$value" =~ ^[0-9]+$ ]] || [[ "$value" -lt 0 ]]; then
+      printf '%s must be a non-negative integer\n' "$value_name" >&2
+      return 1
+    fi
+  done
+
+  if [[ "$ITERATIONS" -lt 1 ]]; then
+    printf '--iterations must be at least 1\n' >&2
+    return 1
   fi
-done
 
-if [[ "$ITERATIONS" -lt 1 ]]; then
-  printf '--iterations must be at least 1\n' >&2
-  exit 1
-fi
+  if [[ -n "$SESSION_ID" && "$CONTINUE_LAST" -eq 1 ]]; then
+    printf 'use either --continue or --session, not both\n' >&2
+    return 1
+  fi
 
-if [[ -n "$SESSION_ID" && "$CONTINUE_LAST" -eq 1 ]]; then
-  printf 'use either --continue or --session, not both\n' >&2
-  exit 1
-fi
+  if [[ "$DRY_RUN" -ne 1 ]] && ! command -v opencode >/dev/null 2>&1; then
+    printf 'opencode not found in PATH\n' >&2
+    return 1
+  fi
 
-if [[ "$DRY_RUN" -ne 1 ]] && ! command -v opencode >/dev/null 2>&1; then
-  printf 'opencode not found in PATH\n' >&2
-  exit 1
-fi
+  if [[ "$DRY_RUN" -ne 1 ]]; then
+    run_preflight_checks || return 1
+  fi
 
-if [[ "$DRY_RUN" -ne 1 ]]; then
-  run_preflight_checks || exit 1
-fi
-
-WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-benchmark-$TARGET"
-BRANCH_DATE="$(date '+%Y%m%d')"
-RESEARCH_BRANCH="autoresearch-benchmark/${TARGET}-${BRANCH_DATE}"
-LOOP_LOG="$(benchmark_log_path "$LOG_PREFIX-$TARGET")"
-results_file="$AR_DIR/results.tsv"
-issues_file="$AR_DIR/issues.tsv"
-base_overlay_manifest="$WORKTREE_DIR/.benchmark-autoresearch-base-overlay.txt"
+  WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-benchmark-$TARGET"
+  BRANCH_DATE="$(date '+%Y%m%d')"
+  RESEARCH_BRANCH="autoresearch-benchmark/${TARGET}-${BRANCH_DATE}"
+  LOOP_LOG="$(benchmark_log_path "$LOG_PREFIX-$TARGET")"
+  results_file="$AR_DIR/results.tsv"
+  issues_file="$AR_DIR/issues.tsv"
+  base_overlay_manifest="$WORKTREE_DIR/.benchmark-autoresearch-base-overlay.txt"
+}
 
 append_loop_log() {
   local line="$1"
@@ -283,6 +296,8 @@ is_registered_worktree() {
 }
 
 init_worktree() {
+  local base_ref
+
   if [[ -d "$WORKTREE_DIR" ]]; then
     if ! is_registered_worktree; then
       git -C "$ROOT_DIR" worktree prune >/dev/null 2>&1 || true
@@ -297,8 +312,9 @@ init_worktree() {
 
   printf 'creating new worktree: %s\n' "$WORKTREE_DIR"
   mkdir -p "$(dirname "$WORKTREE_DIR")"
+  base_ref="$(git -C "$ROOT_DIR" rev-parse HEAD)"
   if ! git -C "$ROOT_DIR" rev-parse --verify "$RESEARCH_BRANCH" >/dev/null 2>&1; then
-    git -C "$ROOT_DIR" branch "$RESEARCH_BRANCH"
+    git -C "$ROOT_DIR" branch "$RESEARCH_BRANCH" "$base_ref"
   fi
   git -C "$ROOT_DIR" worktree add "$WORKTREE_DIR" "$RESEARCH_BRANCH"
 }
@@ -502,6 +518,23 @@ build_benchmark_args() {
   fi
 }
 
+describe_requested_dataset() {
+  local data_file
+  data_file="$(default_benchmark_data_path)"
+
+  case "$(basename "$data_file")" in
+    hits_sample.parquet)
+      printf '1M-row sample\n'
+      ;;
+    hits_sorted.parquet)
+      printf 'full dataset\n'
+      ;;
+    *)
+      printf 'custom dataset (%s)\n' "$data_file"
+      ;;
+  esac
+}
+
 baseline_matches_requested_data() {
   local baseline_summary="$1"
   local requested_data_file="$2"
@@ -696,16 +729,19 @@ run_baseline_if_needed() {
   local baseline_summary="$REPORT_DIR/baseline/$TARGET/benchmark-summary.json"
   local bench_args=()
   local requested_data_file
+  local dataset_label
 
   build_benchmark_args bench_args
   requested_data_file="$(default_benchmark_data_path)"
+  dataset_label="$(describe_requested_dataset)"
   if [[ "$RUN_BASELINE" -eq 0 && -f "$baseline_summary" ]]; then
     if baseline_matches_requested_data "$baseline_summary" "$requested_data_file"; then
+      append_loop_log "reusing baseline for $TARGET on $dataset_label"
       return 0
     fi
-    append_loop_log "existing baseline dataset does not match requested data; refreshing baseline for $TARGET"
+    append_loop_log "existing baseline dataset does not match requested data; refreshing baseline for $TARGET on $dataset_label"
   fi
-  append_loop_log "running baseline for $TARGET"
+  append_loop_log "running baseline for $TARGET on $dataset_label"
   if [[ "$DRY_RUN" -eq 1 ]]; then
     printf 'baseline command: (cd %q && python benchmarks/autoresearch/pilot/scripts/benchmark_baseline.py %q' "$WORKTREE_DIR" "$TARGET"
     printf ' %q' "${bench_args[@]}"
@@ -732,6 +768,9 @@ validate_candidate_scope() {
       .benchmark-autoresearch-*)
         continue
         ;;
+      .opencode/*)
+        continue
+        ;;
       benchmarks/autoresearch/pilot/*)
         continue
         ;;
@@ -750,15 +789,26 @@ validate_candidate_scope() {
     esac
   done < <(git -C "$WORKTREE_DIR" status --porcelain --untracked-files=all)
 
+  if [[ "$invalid" -ne 0 ]]; then
+    return 1
+  fi
   if [[ "$changed" -eq 0 ]]; then
     printf 'no in-scope production changes detected\n' > "$out_file"
     return 1
   fi
-  if [[ "$invalid" -ne 0 ]]; then
-    return 1
-  fi
   rm -f "$out_file"
   return 0
+}
+
+scope_failure_reason() {
+  local scope_file="$1"
+
+  if [[ ! -s "$scope_file" ]] || [[ "$(tr -d '\r' < "$scope_file")" == "no in-scope production changes detected" ]]; then
+    printf 'empty-or-noop-changes\n'
+    return 0
+  fi
+
+  printf 'out-of-scope-changes\n'
 }
 
 next_run_dir() {
@@ -873,6 +923,8 @@ run_iteration() {
 
   if [[ ! -f "$decision_file" ]]; then
     if ! recover_decision_from_stdout "$stdout_log" "$decision_file"; then
+      clear_root_phase_reports candidates
+      clear_root_phase_reports diff
       append_issue "harness" "benchmarks/autoresearch/pilot/scripts/autoloop.sh" "Benchmark autoresearch run produced no usable decision artifact" "run ${run_index} did not emit a recoverable decision block" "Tighten prompt compliance or fallback parsing for benchmark controller"
       discard_candidate_state
       return 1
@@ -900,13 +952,16 @@ run_iteration() {
   fi
 
   if ! validate_candidate_scope "$scope_file"; then
+    local scope_reason
+
+    scope_reason="$(scope_failure_reason "$scope_file")"
     clear_root_phase_reports candidates
     clear_root_phase_reports diff
-    printf 'recommendation=discard\nreason=out-of-scope-or-empty-changes\ntarget_win=none\nprotected_status=n/a\nevidence=%s\n' "$(tr '\n' ';' < "$scope_file")" > "$eval_file"
+    printf 'recommendation=discard\nreason=%s\ntarget_win=none\nprotected_status=n/a\nevidence=%s\n' "$scope_reason" "$(tr '\n' ';' < "$scope_file")" > "$eval_file"
     mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
     run_dir="${archived[0]}"
     patch_path="${archived[1]}"
-    record_result "$base_ref" "$status" "discard" "$scenario" "none" "n/a" "out-of-scope-or-empty-changes" "$run_dir" "$patch_path"
+    record_result "$base_ref" "$status" "discard" "$scenario" "none" "n/a" "$scope_reason" "$run_dir" "$patch_path"
     discard_candidate_state
     return 0
   fi
@@ -932,6 +987,7 @@ run_iteration() {
     cd "$WORKTREE_DIR"
     python benchmarks/autoresearch/pilot/scripts/benchmark_gate.py "$TARGET" >/dev/null
   ); then
+    clear_root_phase_reports candidates
     clear_root_phase_reports diff
     printf '{"recommendation":"discard","reason":"benchmark-gate-command-failed","target_win":"none","protected_status":"n/a"}\n' > "$eval_file"
     mapfile -t archived < <(archive_run_artifacts "$run_index" "$decision_file" "$stdout_log" "$eval_file")
@@ -983,6 +1039,19 @@ PY
 }
 
 autoloop_main() {
+  local parse_status
+
+  parse_autoloop_args "$@"
+  parse_status=$?
+  if [[ "$parse_status" -eq 1 ]]; then
+    return 0
+  fi
+  if [[ "$parse_status" -ne 0 ]]; then
+    return "$parse_status"
+  fi
+
+  initialize_autoloop_state || return 1
+
   cd "$ROOT_DIR"
 
   if [[ "$PRINT_PROMPT" -eq 1 ]]; then
@@ -993,7 +1062,7 @@ autoloop_main() {
   ensure_report_dirs
   ensure_results_file
   ensure_issue_file
-  append_loop_log "target=$TARGET research_branch=$RESEARCH_BRANCH worktree=$WORKTREE_DIR model=${MODEL:-default}"
+  append_loop_log "target=$TARGET dataset=$(describe_requested_dataset) research_branch=$RESEARCH_BRANCH worktree=$WORKTREE_DIR model=${MODEL:-default}"
 
   if [[ "$DRY_RUN" -ne 1 ]]; then
     ensure_main_clean

--- a/benchmarks/autoresearch/pilot/scripts/benchmark_gate.py
+++ b/benchmarks/autoresearch/pilot/scripts/benchmark_gate.py
@@ -12,6 +12,7 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
     from pilot.common import (
         build_diff,
+        clean_output_dir,
         ensure_report_dirs,
         load_json,
         render_diff,
@@ -23,6 +24,7 @@ if __package__ in (None, ""):
 else:
     from ..common import (
         build_diff,
+        clean_output_dir,
         ensure_report_dirs,
         load_json,
         render_diff,
@@ -53,7 +55,7 @@ def main() -> int:
     baseline_dir = resolve_report_dir("baseline", spec.key)
     candidate_dir = resolve_report_dir("candidates", spec.key)
     diff_dir = resolve_report_dir("diff", spec.key)
-    diff_dir.mkdir(parents=True, exist_ok=True)
+    clean_output_dir(diff_dir)
 
     baseline = load_json(baseline_dir / "benchmark-summary.json")
     candidate = load_json(candidate_dir / "benchmark-summary.json")

--- a/benchmarks/autoresearch/runner.py
+++ b/benchmarks/autoresearch/runner.py
@@ -150,7 +150,6 @@ def describe_dataset(data_flag: str) -> str:
         return f"custom dataset ({data_path})"
     return "full dataset"
 
-
 def run_research(
     rounds: list[int],
     data_flag: str,

--- a/py-ltseq/tests/test_benchmark_autoresearch_controller.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_controller.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def autoloop_path() -> Path:
+    return repo_root() / "benchmarks" / "autoresearch" / "pilot" / "scripts" / "autoloop.sh"
+
+
+def run_autoloop_shell(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-lc", script],
+        cwd=repo_root(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def write_summary(path: Path, data_file: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"data_file": data_file}), encoding="utf-8")
+
+
+def test_baseline_matches_requested_data_rejects_dataset_mismatch(tmp_path):
+    baseline_summary = tmp_path / "benchmark-summary.json"
+    write_summary(baseline_summary, "benchmarks/data/hits_sample.parquet")
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        ROOT_DIR={repo_root()!s}
+        if baseline_matches_requested_data {baseline_summary!s} {repo_root() / 'benchmarks/data/hits_sorted.parquet'!s}; then
+          exit 0
+        fi
+        exit 7
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    assert result.returncode == 7
+
+
+def test_validate_candidate_scope_allows_overlay_and_synced_assets_only(tmp_path):
+    worktree = tmp_path / "worktree"
+    (worktree / ".git").mkdir(parents=True)
+    (worktree / ".opencode").mkdir()
+    (worktree / "benchmarks" / "autoresearch" / "pilot").mkdir(parents=True)
+    (worktree / ".opencode" / "session.json").write_text("{}", encoding="utf-8")
+    (worktree / "benchmarks" / "autoresearch" / "pilot" / "README.md").write_text("pilot", encoding="utf-8")
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        TARGET=clickbench_funnel
+        WORKTREE_DIR={worktree!s}
+        base_overlay_manifest={tmp_path / 'overlay.txt'!s}
+        : > "$base_overlay_manifest"
+        git() {{
+          if [[ "$*" == *"status --porcelain --untracked-files=all"* ]]; then
+            printf '?? .opencode/session.json\n'
+            printf '?? benchmarks/autoresearch/pilot/README.md\n'
+            return 0
+          fi
+          command git "$@"
+        }}
+        scope_file={tmp_path / 'scope.txt'!s}
+        if validate_candidate_scope "$scope_file"; then
+          exit 0
+        fi
+        printf 'scope=%s\n' "$(cat "$scope_file")"
+        exit 9
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    assert result.returncode == 9
+    assert "scope=no in-scope production changes detected" in result.stdout
+
+
+def test_validate_candidate_scope_distinguishes_empty_from_out_of_scope(tmp_path):
+    worktree = tmp_path / "worktree"
+    (worktree / ".git").mkdir(parents=True)
+
+    empty_script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        TARGET=clickbench_funnel
+        WORKTREE_DIR={worktree!s}
+        base_overlay_manifest={tmp_path / 'overlay-empty.txt'!s}
+        : > "$base_overlay_manifest"
+        git() {{
+          if [[ "$*" == *"status --porcelain --untracked-files=all"* ]]; then
+            return 0
+          fi
+          command git "$@"
+        }}
+        scope_file={tmp_path / 'scope-empty.txt'!s}
+        validate_candidate_scope "$scope_file" || true
+        printf '%s' "$(scope_failure_reason "$scope_file")"
+        """
+    )
+    empty_result = run_autoloop_shell(empty_script)
+
+    out_of_scope_script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        TARGET=clickbench_funnel
+        WORKTREE_DIR={worktree!s}
+        base_overlay_manifest={tmp_path / 'overlay-oos.txt'!s}
+        : > "$base_overlay_manifest"
+        git() {{
+          if [[ "$*" == *"status --porcelain --untracked-files=all"* ]]; then
+            printf ' M src/lib.rs\n'
+            return 0
+          fi
+          command git "$@"
+        }}
+        scope_file={tmp_path / 'scope-oos.txt'!s}
+        validate_candidate_scope "$scope_file" || true
+        printf '%s\n%s' "$(scope_failure_reason "$scope_file")" "$(cat "$scope_file")"
+        """
+    )
+    out_of_scope_result = run_autoloop_shell(out_of_scope_script)
+
+    assert empty_result.returncode == 0
+    assert empty_result.stdout == "empty-or-noop-changes"
+    assert out_of_scope_result.returncode == 0
+    assert out_of_scope_result.stdout.startswith("out-of-scope-changes\n")
+    assert out_of_scope_result.stdout.endswith("src/lib.rs")
+
+
+def test_run_iteration_clears_root_candidate_and_diff_on_gate_failure(tmp_path):
+    worktree = tmp_path / "worktree"
+    report_dir = tmp_path / "reports"
+    logs_dir = report_dir / "logs"
+    fake_bin_dir = tmp_path / "bin"
+    root_candidate_dir = report_dir / "candidates" / "clickbench_funnel"
+    root_diff_dir = report_dir / "diff" / "clickbench_funnel"
+    baseline_dir = worktree / "benchmarks" / "autoresearch" / "pilot" / "reports" / "baseline" / "clickbench_funnel"
+    candidate_dir = worktree / "benchmarks" / "autoresearch" / "pilot" / "reports" / "candidates" / "clickbench_funnel"
+    diff_dir = worktree / "benchmarks" / "autoresearch" / "pilot" / "reports" / "diff" / "clickbench_funnel"
+    runs_dir = report_dir / "runs" / "clickbench_funnel"
+
+    logs_dir.mkdir(parents=True)
+    root_candidate_dir.mkdir(parents=True)
+    root_diff_dir.mkdir(parents=True)
+    baseline_dir.mkdir(parents=True)
+    candidate_dir.mkdir(parents=True)
+    diff_dir.mkdir(parents=True)
+    runs_dir.mkdir(parents=True)
+    fake_bin_dir.mkdir(parents=True)
+    (worktree / ".git").mkdir(parents=True)
+    (root_candidate_dir / "stale.txt").write_text("candidate", encoding="utf-8")
+    (root_diff_dir / "stale.txt").write_text("diff", encoding="utf-8")
+    (candidate_dir / "benchmark-summary.json").write_text("{}", encoding="utf-8")
+    (baseline_dir / "benchmark-summary.json").write_text("{}", encoding="utf-8")
+    (fake_bin_dir / "python").write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$1\" == \"benchmarks/autoresearch/pilot/scripts/benchmark_candidate.py\" ]]; then\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [[ \"$1\" == \"benchmarks/autoresearch/pilot/scripts/benchmark_gate.py\" ]]; then\n"
+        "  exit 1\n"
+        "fi\n"
+        "exec /usr/bin/python \"$@\"\n",
+        encoding="utf-8",
+    )
+    (fake_bin_dir / "python").chmod(0o755)
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        TARGET=clickbench_funnel
+        DRY_RUN=0
+        ROOT_DIR={repo_root()!s}
+        REPORT_DIR={report_dir!s}
+        WORKTREE_DIR={worktree!s}
+        export PATH={fake_bin_dir!s}:$PATH
+        LOG_PREFIX=test-log
+        LOOP_LOG={logs_dir / 'loop.log'!s}
+        results_file={tmp_path / 'results.tsv'!s}
+        issues_file={tmp_path / 'issues.tsv'!s}
+        base_overlay_manifest={tmp_path / 'overlay.txt'!s}
+        : > "$base_overlay_manifest"
+        benchmark_log_path() {{
+          printf '%s/%s.log\n' {logs_dir!s} "$1"
+        }}
+        run_single_candidate() {{
+          local _run_index="$1"
+          local decision_file="$2"
+          local stdout_log="$3"
+          printf 'status=keep\nscenario=controller-test\nreason=proceed\nevidence=ok\n' > "$decision_file"
+          printf 'stdout\n' > "$stdout_log"
+        }}
+        validate_candidate_scope() {{ return 0; }}
+        build_benchmark_args() {{ local -n out_ref=$1; out_ref=(); }}
+        archive_run_artifacts() {{
+          local run_dir={runs_dir / 'run-001'!s}
+          mkdir -p "$run_dir"
+          : > "$run_dir/patch.diff"
+          printf '%s\n%s\n' "$run_dir" "$run_dir/patch.diff"
+        }}
+        discard_candidate_state() {{ :; }}
+        append_issue() {{ :; }}
+        record_issue_from_decision() {{ :; }}
+        append_loop_log() {{ :; }}
+        git() {{
+          if [[ "$*" == *"rev-parse --short HEAD"* ]]; then
+            printf 'abc123\n'
+            return 0
+          fi
+          command git "$@"
+        }}
+        run_iteration 1
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    assert result.returncode == 0
+    assert list(root_candidate_dir.iterdir()) == []
+    assert list(root_diff_dir.iterdir()) == []
+    results_lines = (tmp_path / "results.tsv").read_text(encoding="utf-8").splitlines()
+    assert results_lines[0].startswith("base_ref\ttarget\tmodel_status")
+    assert "benchmark-gate-command-failed" in results_lines[1]
+
+
+def test_run_baseline_if_needed_logs_reuse_for_matching_dataset(tmp_path):
+    report_dir = tmp_path / "reports"
+    baseline_summary = report_dir / "baseline" / "clickbench_funnel" / "benchmark-summary.json"
+    baseline_summary.parent.mkdir(parents=True)
+    write_summary(baseline_summary, "benchmarks/data/hits_sample.parquet")
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        TARGET=clickbench_funnel
+        USE_SAMPLE=1
+        RUN_BASELINE=0
+        DRY_RUN=0
+        ROOT_DIR={repo_root()!s}
+        REPORT_DIR={report_dir!s}
+        WORKTREE_DIR={tmp_path / 'worktree'!s}
+        logs_file={tmp_path / 'loop.log'!s}
+        append_loop_log() {{ printf '%s\n' "$1" >> "$logs_file"; }}
+        build_benchmark_args() {{ local -n out_ref=$1; out_ref=(); }}
+        archive_baseline_reports_from_worktree() {{ :; }}
+        python() {{ exit 99; }}
+        run_baseline_if_needed
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    assert result.returncode == 0
+    assert (tmp_path / "loop.log").read_text(encoding="utf-8").strip() == (
+        "reusing baseline for clickbench_funnel on 1M-row sample"
+    )

--- a/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
@@ -69,6 +69,30 @@ def workload_map(diff: dict) -> dict:
     return {workload["id"]: workload for workload in diff["workloads"]}
 
 
+def test_build_benchmark_summary_records_dataset_label_for_custom_data():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    runner_summary = {
+        "git_sha": "abc123",
+        "timestamp": "2026-04-20T12:00:00",
+        "bench_vs": {
+            "data_file": "/tmp/custom-bench.parquet",
+            "warmup": 1,
+            "iterations": 3,
+            "passed": True,
+            "correctness_failures": 0,
+            "infra_failures": 0,
+            "rounds": [],
+        },
+    }
+
+    summary = common.build_benchmark_summary("clickbench_funnel", runner_summary)
+
+    assert summary["dataset_label"] == "custom dataset (/tmp/custom-bench.parquet)"
+    rendered = common.render_benchmark_result(summary)
+    assert "- Dataset: custom dataset (/tmp/custom-bench.parquet)" in rendered
+
+
 def test_clickbench_funnel_target_spec_is_configured():
     common, _evaluate, _gate = load_pilot_modules()
 
@@ -222,6 +246,52 @@ def test_clickbench_funnel_gate_writes_target_specific_diff_and_evaluation(tmp_p
     ]
     assert evaluation_payload["recommendation"] == "keep"
     assert evaluation_payload["target_wins_detail"][0]["id"] == "r3_funnel"
+
+
+def test_clickbench_funnel_gate_replaces_stale_diff_artifacts(tmp_path, monkeypatch):
+    _common, _evaluate, gate = load_pilot_modules()
+
+    baseline_dir = tmp_path / "baseline"
+    candidate_dir = tmp_path / "candidates"
+    diff_dir = tmp_path / "diff"
+    baseline_dir.mkdir()
+    candidate_dir.mkdir()
+    diff_dir.mkdir()
+    (diff_dir / "stale.txt").write_text("stale", encoding="utf-8")
+
+    baseline = make_summary(
+        target="clickbench_funnel",
+        r1=(1.0, 1.1),
+        r2=(0.5, 0.6),
+        r3=(2.0, 2.2),
+    )
+    candidate = make_summary(
+        target="clickbench_funnel",
+        r1=(1.01, 1.12),
+        r2=(0.49, 0.58),
+        r3=(1.78, 1.95),
+    )
+    (baseline_dir / "benchmark-summary.json").write_text(json.dumps(baseline), encoding="utf-8")
+    (candidate_dir / "benchmark-summary.json").write_text(json.dumps(candidate), encoding="utf-8")
+
+    def fake_resolve_report_dir(phase: str, target: str) -> Path:
+        assert target == "clickbench_funnel"
+        mapping = {
+            "baseline": baseline_dir,
+            "candidates": candidate_dir,
+            "diff": diff_dir,
+        }
+        return mapping[phase]
+
+    monkeypatch.setattr(gate, "resolve_report_dir", fake_resolve_report_dir)
+    monkeypatch.setattr(gate, "ensure_report_dirs", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["benchmark_gate.py", "clickbench_funnel"])
+
+    assert gate.main() == 0
+
+    assert not (diff_dir / "stale.txt").exists()
+    assert (diff_dir / "benchmark-diff.json").exists()
+    assert (diff_dir / "evaluation.json").exists()
 
 
 def test_clickbench_sessionization_target_spec_is_configured():


### PR DESCRIPTION
## Summary
- keep benchmark autoresearch root candidate/diff artifacts aligned with the latest valid run, including gate failure, discard, and archive paths
- block silent baseline reuse across sample, full, and custom datasets while making dataset labeling explicit in controller outputs and benchmark summaries
- add controller contract tests for dataset mismatch, scope validation, overlay exemptions, and failure-path cleanup

## Testing
- uv run --locked python -m pytest py-ltseq/tests/test_bench_vs_summary.py py-ltseq/tests/test_benchmark_autoresearch_pilot.py py-ltseq/tests/test_benchmark_autoresearch_controller.py py-ltseq/tests/test_autoresearch_report.py py-ltseq/tests/test_autoresearch_runner.py -q
- bash benchmarks/autoresearch/pilot/scripts/autoloop.sh --dry-run --force --sample --iterations 1 --sleep-seconds 0 --target clickbench_funnel
- bash benchmarks/autoresearch/pilot/scripts/autoloop.sh --dry-run --force --sample --iterations 1 --sleep-seconds 0 --target clickbench_sessionization

Closes #56
Closes #57
Closes #58
Closes #59