### PR TITLE
fix: sync autoresearch worktrees to current base

### DIFF
--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -360,6 +360,33 @@ ensure_worktree_on_research() {
   fi
 }
 
+sync_research_branch_to_base() {
+  local base_ref
+  local worktree_ref
+  local base_short
+  local worktree_short
+
+  base_ref="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+  worktree_ref="$(git -C "$WORKTREE_DIR" rev-parse HEAD)"
+
+  if [[ "$worktree_ref" == "$base_ref" ]]; then
+    return 0
+  fi
+
+  base_short="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+  worktree_short="$(git -C "$WORKTREE_DIR" rev-parse --short HEAD)"
+
+  if git -C "$ROOT_DIR" merge-base --is-ancestor "$worktree_ref" "$base_ref"; then
+    append_loop_log "fast-forwarding research branch $RESEARCH_BRANCH from $worktree_short to $base_short"
+    git -C "$WORKTREE_DIR" merge --ff-only "$base_ref" >/dev/null
+    return 0
+  fi
+
+  printf 'research branch %s is at %s but current base is %s; remove the stale worktree/branch before rerunning\n' \
+    "$RESEARCH_BRANCH" "$worktree_short" "$base_short" >&2
+  return 1
+}
+
 sync_workspace_overlay() {
   local path
   : > "$base_overlay_manifest"
@@ -1070,6 +1097,7 @@ autoloop_main() {
     bootstrap_worktree_state
     ensure_worktree_clean
     ensure_worktree_on_research
+    sync_research_branch_to_base
     sync_workspace_overlay
     sync_autoresearch_assets
     sync_baseline_reports_to_worktree

--- a/py-ltseq/tests/test_benchmark_autoresearch_controller.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_controller.py
@@ -266,3 +266,106 @@ def test_run_baseline_if_needed_logs_reuse_for_matching_dataset(tmp_path):
     assert (tmp_path / "loop.log").read_text(encoding="utf-8").strip() == (
         "reusing baseline for clickbench_funnel on 1M-row sample"
     )
+
+
+def test_sync_research_branch_to_base_fast_forwards_stale_worktree(tmp_path):
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+
+    init_script = textwrap.dedent(
+        f"""
+        set -e
+        git init {repo!s} >/dev/null
+        git -C {repo!s} config user.name 'Test User'
+        git -C {repo!s} config user.email 'test@example.com'
+        printf 'base\n' > {repo!s}/tracked.txt
+        git -C {repo!s} add tracked.txt
+        git -C {repo!s} commit -m 'base' >/dev/null
+        git -C {repo!s} branch autoresearch-benchmark/clickbench_funnel-20260420
+        git -C {repo!s} worktree add {worktree!s} autoresearch-benchmark/clickbench_funnel-20260420 >/dev/null
+        printf 'root update\n' >> {repo!s}/tracked.txt
+        git -C {repo!s} add tracked.txt
+        git -C {repo!s} commit -m 'root update' >/dev/null
+        """
+    )
+    init_result = subprocess.run(["bash", "-lc", init_script], text=True, capture_output=True, check=False)
+    assert init_result.returncode == 0, init_result.stderr
+
+    before_head = subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert before_head.returncode == 0
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        ROOT_DIR={repo!s}
+        WORKTREE_DIR={worktree!s}
+        RESEARCH_BRANCH=autoresearch-benchmark/clickbench_funnel-20260420
+        LOOP_LOG={tmp_path / 'loop.log'!s}
+        sync_research_branch_to_base
+        git -C {worktree!s} rev-parse HEAD
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    after_head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert after_head.returncode == 0
+    assert result.returncode == 0, result.stderr
+    assert before_head.stdout.strip() != after_head.stdout.strip()
+    assert result.stdout.strip().endswith(after_head.stdout.strip())
+    assert "fast-forwarding research branch" in (tmp_path / "loop.log").read_text(encoding="utf-8")
+
+
+def test_sync_research_branch_to_base_rejects_diverged_worktree(tmp_path):
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+
+    init_script = textwrap.dedent(
+        f"""
+        set -e
+        git init {repo!s} >/dev/null
+        git -C {repo!s} config user.name 'Test User'
+        git -C {repo!s} config user.email 'test@example.com'
+        printf 'base\n' > {repo!s}/tracked.txt
+        git -C {repo!s} add tracked.txt
+        git -C {repo!s} commit -m 'base' >/dev/null
+        git -C {repo!s} branch autoresearch-benchmark/clickbench_funnel-20260420
+        git -C {repo!s} worktree add {worktree!s} autoresearch-benchmark/clickbench_funnel-20260420 >/dev/null
+        printf 'root update\n' >> {repo!s}/tracked.txt
+        git -C {repo!s} add tracked.txt
+        git -C {repo!s} commit -m 'root update' >/dev/null
+        printf 'worktree update\n' >> {worktree!s}/tracked.txt
+        git -C {worktree!s} add tracked.txt
+        git -C {worktree!s} commit -m 'worktree update' >/dev/null
+        """
+    )
+    init_result = subprocess.run(["bash", "-lc", init_script], text=True, capture_output=True, check=False)
+    assert init_result.returncode == 0, init_result.stderr
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        ROOT_DIR={repo!s}
+        WORKTREE_DIR={worktree!s}
+        RESEARCH_BRANCH=autoresearch-benchmark/clickbench_funnel-20260420
+        LOOP_LOG={tmp_path / 'loop.log'!s}
+        sync_research_branch_to_base
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    assert result.returncode != 0
+    assert "remove the stale worktree/branch before rerunning" in result.stderr


### PR DESCRIPTION
## Summary
- fast-forward reused autoresearch worktrees to the current root `HEAD` before running a new supervised benchmark loop
- fail explicitly when a reused research branch has diverged instead of silently continuing from a stale base
- add controller tests covering both the fast-forward and diverged-branch paths

## Testing
- uv run python -m pytest py-ltseq/tests/test_benchmark_autoresearch_controller.py py-ltseq/tests/test_benchmark_autoresearch_pilot.py -q
- PATH=.venv/bin:$PATH bash benchmarks/autoresearch/pilot/scripts/autoloop.sh --dry-run --force --sample --iterations 1 --sleep-seconds 0 --target clickbench_funnel

Related: #64