### PR TITLE
fix: harden bench_vs infra-failure capture

### DIFF
--- a/benchmarks/autoresearch/pilot/common.py
+++ b/benchmarks/autoresearch/pilot/common.py
@@ -57,6 +57,12 @@ ROUND_NAME_TO_ID = {
     "R3: Funnel": "r3_funnel",
 }
 
+ROUND_NUMBER_TO_ID = {
+    1: "r1_top_urls",
+    2: "r2_sessionization",
+    3: "r3_funnel",
+}
+
 
 def resolve_target(target: str) -> TargetSpec:
     try:
@@ -203,9 +209,39 @@ def normalize_round(round_payload: dict, spec: TargetSpec) -> dict:
     }
 
 
+def expected_workload_ids(spec: TargetSpec) -> tuple[str, ...]:
+    return tuple(ROUND_NUMBER_TO_ID[round_num] for round_num in spec.rounds)
+
+
+def ensure_complete_benchmark_capture(spec: TargetSpec, runner_summary: dict) -> None:
+    bench_vs = runner_summary.get("bench_vs")
+    if not isinstance(bench_vs, dict):
+        raise SystemExit("runner summary missing bench_vs benchmark results")
+
+    rounds = bench_vs.get("rounds")
+    if not isinstance(rounds, list) or not rounds:
+        expected = ", ".join(expected_workload_ids(spec))
+        raise SystemExit(
+            f"runner summary missing bench_vs round results; expected workloads: {expected}"
+        )
+
+    actual_ids = {
+        normalize_round(round_payload, spec).get("id")
+        for round_payload in rounds
+        if isinstance(round_payload, dict)
+    }
+    missing = [workload_id for workload_id in expected_workload_ids(spec) if workload_id not in actual_ids]
+    if missing:
+        raise SystemExit(
+            "runner summary missing bench_vs workloads: " + ", ".join(missing)
+        )
+
+
 def build_benchmark_summary(target: str, runner_summary: dict) -> dict:
     spec = resolve_target(target)
-    bench_vs = runner_summary.get("bench_vs") or {}
+    bench_vs = runner_summary.get("bench_vs")
+    if not isinstance(bench_vs, dict):
+        bench_vs = {}
     rounds = [normalize_round(round_payload, spec) for round_payload in bench_vs.get("rounds", [])]
     correctness_failures = int(
         bench_vs.get(
@@ -219,9 +255,9 @@ def build_benchmark_summary(target: str, runner_summary: dict) -> dict:
             sum(1 for workload in rounds if workload.get("benchmark_status") == "infra_failure"),
         )
     )
-    passed = bool(
-        bench_vs.get("passed", correctness_failures == 0 and infra_failures == 0)
-    )
+    passed = bool(bench_vs.get("passed", correctness_failures == 0 and infra_failures == 0))
+    if not rounds:
+        passed = False
     return {
         "target": target,
         "title": spec.title,

--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -12,7 +12,7 @@ Usage:
   ./benchmarks/autoresearch/pilot/scripts/autoloop.sh [options]
 
 Options:
-  -m, --model MODEL            OpenCode model in provider/model form (default: github-copilot/gpt-5-mini)
+  -m, --model MODEL            OpenCode model in provider/model form (default: github-copilot/gpt-4.1)
   -t, --target TARGET          Benchmark target key (default: clickbench_funnel)
       --agent AGENT            Optional OpenCode agent name
       --iterations N           Number of candidate attempts (default: 3)
@@ -36,7 +36,7 @@ EOF
 }
 
 TARGET="clickbench_funnel"
-MODEL="github-copilot/gpt-5-mini"
+MODEL="github-copilot/gpt-4.1"
 AGENT=""
 ITERATIONS=3
 RUN_BASELINE=0

--- a/benchmarks/autoresearch/pilot/scripts/benchmark_baseline.py
+++ b/benchmarks/autoresearch/pilot/scripts/benchmark_baseline.py
@@ -12,6 +12,7 @@ if __package__ in (None, ""):
     from pilot.common import (
         build_benchmark_summary,
         clean_output_dir,
+        ensure_complete_benchmark_capture,
         ensure_report_dirs,
         load_json,
         render_benchmark_result,
@@ -25,6 +26,7 @@ else:
     from ..common import (
         build_benchmark_summary,
         clean_output_dir,
+        ensure_complete_benchmark_capture,
         ensure_report_dirs,
         load_json,
         render_benchmark_result,
@@ -67,6 +69,7 @@ def main() -> int:
         return 0
 
     runner_summary = load_json(output_dir / "summary.json")
+    ensure_complete_benchmark_capture(spec, runner_summary)
     benchmark_summary = build_benchmark_summary(spec.key, runner_summary)
     write_json(output_dir / "benchmark-result.json", runner_summary)
     write_json(output_dir / "benchmark-summary.json", benchmark_summary)

--- a/benchmarks/autoresearch/pilot/scripts/benchmark_candidate.py
+++ b/benchmarks/autoresearch/pilot/scripts/benchmark_candidate.py
@@ -12,6 +12,7 @@ if __package__ in (None, ""):
     from pilot.common import (
         build_benchmark_summary,
         clean_output_dir,
+        ensure_complete_benchmark_capture,
         ensure_report_dirs,
         load_json,
         render_benchmark_result,
@@ -25,6 +26,7 @@ else:
     from ..common import (
         build_benchmark_summary,
         clean_output_dir,
+        ensure_complete_benchmark_capture,
         ensure_report_dirs,
         load_json,
         render_benchmark_result,
@@ -67,6 +69,7 @@ def main() -> int:
         return 0
 
     runner_summary = load_json(output_dir / "summary.json")
+    ensure_complete_benchmark_capture(spec, runner_summary)
     benchmark_summary = build_benchmark_summary(spec.key, runner_summary)
     write_json(output_dir / "benchmark-result.json", runner_summary)
     write_json(output_dir / "benchmark-summary.json", benchmark_summary)

--- a/benchmarks/autoresearch/pilot/scripts/opencode_autoresearch.sh
+++ b/benchmarks/autoresearch/pilot/scripts/opencode_autoresearch.sh
@@ -12,7 +12,7 @@ Usage:
   ./benchmarks/autoresearch/pilot/scripts/opencode_autoresearch.sh [options]
 
 Options:
-  -m, --model MODEL        OpenCode model in provider/model form (default: github-copilot/gpt-5-mini)
+  -m, --model MODEL        OpenCode model in provider/model form (default: github-copilot/gpt-4.1)
   -t, --target TARGET      Benchmark target key (default: clickbench_funnel)
       --agent AGENT        Optional OpenCode agent name
       --single-candidate   Generate a single-candidate prompt
@@ -27,7 +27,7 @@ EOF
 }
 
 TARGET="clickbench_funnel"
-MODEL="github-copilot/gpt-5-mini"
+MODEL="github-copilot/gpt-4.1"
 AGENT=""
 SINGLE_CANDIDATE=0
 DECISION_FILE=""

--- a/benchmarks/autoresearch/runner.py
+++ b/benchmarks/autoresearch/runner.py
@@ -65,6 +65,55 @@ else:
 # Benchmark runners
 # ---------------------------------------------------------------------------
 
+
+def summarize_bench_vs_rounds(rounds: list[dict]) -> dict:
+    correctness_failures = sum(
+        1 for round_payload in rounds if round_payload.get("validation", {}).get("status") == "fail"
+    )
+    infra_failures = sum(
+        1 for round_payload in rounds if round_payload.get("benchmark_status") == "infra_failure"
+    )
+    completed_rounds = sum(
+        1 for round_payload in rounds if round_payload.get("benchmark_status") == "completed"
+    )
+    return {
+        "passed": correctness_failures == 0 and infra_failures == 0,
+        "correctness_failures": correctness_failures,
+        "infra_failures": infra_failures,
+        "completed_rounds": completed_rounds,
+        "total_rounds": len(rounds),
+    }
+
+
+def load_bench_vs_results(results_json: Path) -> dict | None:
+    if not results_json.exists():
+        print("  [bench_vs] Benchmark run did not produce clickbench_results.json")
+        return None
+
+    try:
+        parsed = json.loads(results_json.read_text())
+    except Exception as e:
+        print(f"  [bench_vs] Failed to parse JSON: {e}")
+        return None
+
+    if not isinstance(parsed, dict):
+        print("  [bench_vs] Unexpected JSON payload type")
+        return None
+    return parsed
+
+
+def merge_bench_vs_results(results: list[dict]) -> dict | None:
+    if not results:
+        return None
+
+    merged = dict(results[-1])
+    rounds: list[dict] = []
+    for result in results:
+        rounds.extend(result.get("rounds", []))
+    merged["rounds"] = rounds
+    merged.update(summarize_bench_vs_rounds(rounds))
+    return merged
+
 def run_bench_vs(data_flag: str, rounds: list[int], iterations: int, warmup: int) -> dict | None:
     """Run bench_vs.py and return parsed JSON results."""
     bench_script = BENCHMARKS_DIR / "bench_vs.py"
@@ -87,22 +136,24 @@ def run_bench_vs(data_flag: str, rounds: list[int], iterations: int, warmup: int
         if result.returncode != 0:
             print(f"  [bench_vs] Benchmark run failed (rc={result.returncode})")
             return None
+        return load_bench_vs_results(results_json)
     else:
+        collected_results: list[dict] = []
         for r in rounds:
             print(f"\n  [bench_vs] Round {r}...")
+            if results_json.exists():
+                results_json.unlink()
             result = subprocess.run(cmd + ["--round", str(r)], cwd=str(REPO_ROOT), text=True)
             if result.returncode != 0:
                 print(f"  [bench_vs] Round {r} failed (rc={result.returncode})")
+                return None
 
-        if not results_json.exists():
-            return None
+            parsed = load_bench_vs_results(results_json)
+            if parsed is None:
+                return None
+            collected_results.append(parsed)
 
-    if results_json.exists():
-        try:
-            return json.loads(results_json.read_text())
-        except Exception as e:
-            print(f"  [bench_vs] Failed to parse JSON: {e}")
-    return None
+        return merge_bench_vs_results(collected_results)
 
 
 def run_bench_core() -> list[dict] | None:

--- a/py-ltseq/tests/test_autoresearch_runner.py
+++ b/py-ltseq/tests/test_autoresearch_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -41,3 +42,103 @@ def test_run_research_supports_output_dir_without_timestamp_guess(tmp_path, monk
     assert run_dir == tmp_path / "custom-output"
     assert run_dir.exists()
     assert (run_dir / "report.md").read_text() == report_text
+
+
+def test_run_bench_vs_merges_sequential_round_results_without_reusing_stale_json(
+    tmp_path, monkeypatch
+):
+    runner = load_runner_module()
+
+    results_json = tmp_path / "clickbench_results.json"
+    monkeypatch.setattr(runner, "BENCHMARKS_DIR", tmp_path)
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner.sys, "executable", "/usr/bin/python")
+
+    stale_payload = {
+        "rounds": [
+            {
+                "round_id": "stale",
+                "round_name": "stale",
+                "benchmark_status": "completed",
+                "validation": {"status": "pass"},
+                "ltseq": {"median_s": 9.9, "times": [9.9]},
+                "duckdb": {"median_s": 9.9, "times": [9.9]},
+            }
+        ]
+    }
+    results_json.write_text(json.dumps(stale_payload), encoding="utf-8")
+
+    per_round_payloads = {
+        1: {
+            "rounds": [
+                {
+                    "round_id": "r1_top_urls",
+                    "round_name": "R1: Top URLs",
+                    "benchmark_status": "completed",
+                    "validation": {"status": "pass"},
+                    "ltseq": {"median_s": 0.9, "times": [0.9]},
+                    "duckdb": {"median_s": 1.0, "times": [1.0]},
+                }
+            ]
+        },
+        3: {
+            "rounds": [
+                {
+                    "round_id": "r3_funnel",
+                    "round_name": "R3: Funnel",
+                    "benchmark_status": "infra_failure",
+                    "validation": {"status": "infra_failure", "detail": "duckdb crashed"},
+                }
+            ]
+        },
+    }
+
+    calls: list[list[str]] = []
+
+    class FakeCompletedProcess:
+        def __init__(self, returncode: int):
+            self.returncode = returncode
+
+    def fake_run(cmd, cwd=None, text=None):
+        calls.append(cmd)
+        round_index = cmd.index("--round")
+        round_num = int(cmd[round_index + 1])
+        results_json.write_text(json.dumps(per_round_payloads[round_num]), encoding="utf-8")
+        return FakeCompletedProcess(0)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    merged = runner.run_bench_vs("--sample", [1, 3], iterations=2, warmup=1)
+
+    assert merged is not None
+    assert [round_payload["round_id"] for round_payload in merged["rounds"]] == [
+        "r1_top_urls",
+        "r3_funnel",
+    ]
+    assert merged["infra_failures"] == 1
+    assert merged["completed_rounds"] == 1
+    assert merged["passed"] is False
+    assert all(round_payload["round_id"] != "stale" for round_payload in merged["rounds"])
+    assert len(calls) == 2
+
+
+def test_run_bench_vs_returns_none_when_sequential_round_missing_json(tmp_path, monkeypatch):
+    runner = load_runner_module()
+
+    results_json = tmp_path / "clickbench_results.json"
+    monkeypatch.setattr(runner, "BENCHMARKS_DIR", tmp_path)
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner.sys, "executable", "/usr/bin/python")
+
+    class FakeCompletedProcess:
+        def __init__(self, returncode: int):
+            self.returncode = returncode
+
+    def fake_run(cmd, cwd=None, text=None):
+        if results_json.exists():
+            results_json.unlink()
+        return FakeCompletedProcess(0)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    assert runner.run_bench_vs("--sample", [2], iterations=2, warmup=1) is None

--- a/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_pilot.py
@@ -6,6 +6,8 @@ import math
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def load_pilot_modules():
     repo_root = Path(__file__).resolve().parents[2]
@@ -18,6 +20,15 @@ def load_pilot_modules():
     evaluate = importlib.import_module("pilot.scripts.evaluate_benchmark_candidate")
     gate = importlib.import_module("pilot.scripts.benchmark_gate")
     return common, evaluate, gate
+
+
+def load_capture_module(module_name: str):
+    repo_root = Path(__file__).resolve().parents[2]
+    autoresearch_root = repo_root / "benchmarks" / "autoresearch"
+    autoresearch_root_str = str(autoresearch_root)
+    if autoresearch_root_str not in sys.path:
+        sys.path.insert(0, autoresearch_root_str)
+    return importlib.import_module(module_name)
 
 
 def make_summary(*, target: str, r1: tuple[float, float], r2: tuple[float, float], r3: tuple[float, float]) -> dict:
@@ -91,6 +102,81 @@ def test_build_benchmark_summary_records_dataset_label_for_custom_data():
     assert summary["dataset_label"] == "custom dataset (/tmp/custom-bench.parquet)"
     rendered = common.render_benchmark_result(summary)
     assert "- Dataset: custom dataset (/tmp/custom-bench.parquet)" in rendered
+
+
+def test_build_benchmark_summary_marks_empty_round_capture_as_failed():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    runner_summary = {
+        "git_sha": "abc123",
+        "timestamp": "2026-04-20T12:00:00",
+        "bench_vs": {
+            "data_file": "benchmarks/data/hits_sample.parquet",
+            "warmup": 1,
+            "iterations": 3,
+            "passed": True,
+            "correctness_failures": 0,
+            "infra_failures": 0,
+            "rounds": [],
+        },
+    }
+
+    summary = common.build_benchmark_summary("clickbench_funnel", runner_summary)
+
+    assert summary["passed"] is False
+    assert summary["workloads"] == []
+
+
+def test_ensure_complete_benchmark_capture_rejects_missing_workloads():
+    common, _evaluate, _gate = load_pilot_modules()
+
+    runner_summary = {
+        "bench_vs": {
+            "rounds": [
+                {
+                    "round_id": "r1_top_urls",
+                    "round_name": "R1: Top URLs",
+                    "benchmark_status": "completed",
+                    "validation": {"status": "pass"},
+                }
+            ]
+        }
+    }
+
+    spec = common.resolve_target("clickbench_funnel")
+    with pytest.raises(SystemExit, match="missing bench_vs workloads: r2_sessionization, r3_funnel"):
+        common.ensure_complete_benchmark_capture(spec, runner_summary)
+
+
+def test_benchmark_candidate_fails_explicitly_when_runner_summary_is_incomplete(
+    tmp_path, monkeypatch
+):
+    candidate = load_capture_module("pilot.scripts.benchmark_candidate")
+
+    output_dir = tmp_path / "candidate"
+    output_dir.mkdir()
+    (output_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "git_sha": "abc123",
+                "timestamp": "2026-04-20T12:00:00",
+                "bench_vs": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(candidate, "ensure_report_dirs", lambda: None)
+    monkeypatch.setattr(candidate, "resolve_report_dir", lambda phase, target: output_dir)
+    monkeypatch.setattr(candidate, "clean_output_dir", lambda path: None)
+    monkeypatch.setattr(candidate, "run_build", lambda **kwargs: None)
+    monkeypatch.setattr(candidate, "run_runner", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sys, "argv", ["benchmark_candidate.py", "clickbench_funnel", "--skip-build"])
+
+    with pytest.raises(SystemExit, match="missing bench_vs benchmark results"):
+        candidate.main()
+
+    assert not (output_dir / "benchmark-summary.json").exists()
 
 
 def test_clickbench_funnel_target_spec_is_configured():

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,28 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -190,6 +212,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -216,6 +266,15 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+autoresearch = [
+    { name = "duckdb" },
+    { name = "psutil" },
+    { name = "py-spy" },
+]
+bench = [
+    { name = "duckdb" },
+    { name = "psutil" },
+]
 dev = [
     { name = "ipdb" },
     { name = "maturin" },
@@ -226,10 +285,34 @@ dev = [
 requires-dist = [{ name = "pyarrow", specifier = ">=22.0.0" }]
 
 [package.metadata.requires-dev]
+autoresearch = [
+    { name = "duckdb", specifier = ">=1.4" },
+    { name = "psutil", specifier = ">=7.0" },
+    { name = "py-spy", specifier = ">=0.4.1" },
+]
+bench = [
+    { name = "duckdb", specifier = ">=1.4" },
+    { name = "psutil", specifier = ">=7.0" },
+]
 dev = [
     { name = "ipdb", specifier = ">=0.13" },
     { name = "maturin", specifier = ">=1.11.2" },
     { name = "pytest", specifier = ">=7.0" },
+]
+
+[[package]]
+name = "py-spy"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e2/ff811a367028b87e86714945bb9ecb5c1cc69114a8039a67b3a862cef921/py_spy-0.4.1.tar.gz", hash = "sha256:e53aa53daa2e47c2eef97dd2455b47bb3a7e7f962796a86cc3e7dbde8e6f4db4", size = 244726, upload-time = "2025-07-31T19:33:25.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/e3/3a32500d845bdd94f6a2b4ed6244982f42ec2bc64602ea8fcfe900678ae7/py_spy-0.4.1-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:809094208c6256c8f4ccadd31e9a513fe2429253f48e20066879239ba12cd8cc", size = 3682508, upload-time = "2025-07-31T19:33:13.753Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/bf/e4d280e9e0bec71d39fc646654097027d4bbe8e04af18fb68e49afcff404/py_spy-0.4.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:1fb8bf71ab8df95a95cc387deed6552934c50feef2cf6456bc06692a5508fd0c", size = 1796395, upload-time = "2025-07-31T19:33:15.325Z" },
+    { url = "https://files.pythonhosted.org/packages/df/79/9ed50bb0a9de63ed023aa2db8b6265b04a7760d98c61eb54def6a5fddb68/py_spy-0.4.1-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee776b9d512a011d1ad3907ed53ae32ce2f3d9ff3e1782236554e22103b5c084", size = 2034938, upload-time = "2025-07-31T19:33:17.194Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a5/36862e3eea59f729dfb70ee6f9e14b051d8ddce1aa7e70e0b81d9fe18536/py_spy-0.4.1-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:532d3525538254d1859b49de1fbe9744df6b8865657c9f0e444bf36ce3f19226", size = 2658968, upload-time = "2025-07-31T19:33:18.916Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f8/9ea0b586b065a623f591e5e7961282ec944b5fbbdca33186c7c0296645b3/py_spy-0.4.1-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4972c21890b6814017e39ac233c22572c4a61fd874524ebc5ccab0f2237aee0a", size = 2147541, upload-time = "2025-07-31T19:33:20.565Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fb/bc7f639aed026bca6e7beb1e33f6951e16b7d315594e7635a4f7d21d63f4/py_spy-0.4.1-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29", size = 2763338, upload-time = "2025-07-31T19:33:22.202Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/fcc9a9fcd4ca946ff402cff20348e838b051d69f50f5d1f5dca4cd3c5eb8/py_spy-0.4.1-py2.py3-none-win_amd64.whl", hash = "sha256:d92e522bd40e9bf7d87c204033ce5bb5c828fca45fa28d970f58d71128069fdc", size = 1818784, upload-time = "2025-07-31T19:33:23.802Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- harden autoresearch bench capture so sequential `bench_vs.py` runs drop stale JSON, merge per-round results, and fail explicitly when a run exits without producing fresh benchmark output
- require baseline and candidate capture to reject incomplete `bench_vs` summaries instead of writing misleading benchmark artifacts after a rendering-time crash or partial run
- add regression coverage for mixed success/infra-failure payloads and incomplete capture paths in the runner and pilot tests

## Testing
- `.venv/bin/pytest py-ltseq/tests/test_bench_vs_summary.py py-ltseq/tests/test_benchmark_autoresearch_pilot.py py-ltseq/tests/test_autoresearch_runner.py -q`