### PR TITLE
fix: use paired (left_key, right_key) columns in join SQL generation

### DIFF
--- a/py-ltseq/tests/test_join.py
+++ b/py-ltseq/tests/test_join.py
@@ -3,6 +3,9 @@
 Tests the join() method which performs standard SQL-style hash joins.
 """
 
+import os
+import tempfile
+
 import pytest
 from ltseq import LTSeq
 
@@ -145,3 +148,97 @@ class TestJoinRegression:
         # Both should work
         assert isinstance(result1, LTSeq)
         assert isinstance(result2, LTSeq)
+
+
+class TestJoinAsymmetricKeys:
+    """Tests for join() with asymmetric key columns (left_key != right_key)."""
+
+    @pytest.fixture
+    def products_csv(self):
+        """Create a temporary CSV file with product data."""
+        content = """id,product_name,category
+1,Widget,A
+2,Gadget,B
+3,Gizmo,A
+4,Doohickey,C
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(content)
+            return f.name
+
+    @pytest.fixture
+    def order_items_csv(self):
+        """Create a temporary CSV file with order items referencing products by product_id."""
+        content = """order_id,product_id,quantity
+101,1,2
+102,2,1
+103,1,3
+104,3,1
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(content)
+            return f.name
+
+    def test_join_asymmetric_keys_inner(self, products_csv, order_items_csv):
+        """Inner join with different key column names (products.id == order_items.product_id)."""
+        products = LTSeq.read_csv(products_csv)
+        order_items = LTSeq.read_csv(order_items_csv)
+
+        result = products.join(
+            order_items, on=lambda p, o: p.id == o.product_id
+        )
+        df = result.to_pandas()
+
+        # All 4 order items match a product
+        assert len(df) == 4
+        # Should have columns from both tables
+        assert "product_name" in df.columns
+        assert "_other_quantity" in df.columns
+        # Verify correct matching: product_id=1 appears in orders 101 and 103
+        product_1_rows = df[df["id"] == 1]
+        assert len(product_1_rows) == 2
+
+    def test_join_asymmetric_keys_left(self, products_csv, order_items_csv):
+        """Left join with different key column names."""
+        products = LTSeq.read_csv(products_csv)
+        order_items = LTSeq.read_csv(order_items_csv)
+
+        result = products.join(
+            order_items, on=lambda p, o: p.id == o.product_id, how="left"
+        )
+        df = result.to_pandas()
+
+        # Product 4 (Doohickey) has no orders, but should appear with NULL
+        assert len(df) >= len(products)
+
+    def test_join_asymmetric_keys_right(self, products_csv, order_items_csv):
+        """Right join with different key column names."""
+        products = LTSeq.read_csv(products_csv)
+        order_items = LTSeq.read_csv(order_items_csv)
+
+        result = products.join(
+            order_items, on=lambda p, o: p.id == o.product_id, how="right"
+        )
+        df = result.to_pandas()
+
+        # Should have all order items
+        assert len(df) >= len(order_items)
+
+    def test_join_asymmetric_keys_full(self, products_csv, order_items_csv):
+        """Full join with different key column names."""
+        products = LTSeq.read_csv(products_csv)
+        order_items = LTSeq.read_csv(order_items_csv)
+
+        result = products.join(
+            order_items, on=lambda p, o: p.id == o.product_id, how="full"
+        )
+        df = result.to_pandas()
+
+        assert len(df) >= max(len(products), len(order_items))
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, products_csv, order_items_csv):
+        yield
+        for f in [products_csv, order_items_csv]:
+            if os.path.exists(f):
+                os.unlink(f)

--- a/src/ops/common.rs
+++ b/src/ops/common.rs
@@ -114,25 +114,25 @@ pub fn build_qualified_column_list(schema: &ArrowSchema, table_alias: &str) -> S
         .join(", ")
 }
 
-/// Build an AND-connected equality condition for multiple columns.
+/// Build an AND-connected equality condition for paired column names.
 ///
-/// Example: `t1."id" = t2."id" AND t1."year" = t2."year"`
+/// Example: `t1."id" = t2."product_id" AND t1."year" = t2."yr"`
 ///
 /// # Arguments
 /// * `left_alias` - Alias for left table
 /// * `right_alias` - Alias for right table
-/// * `columns` - Column names to compare
+/// * `key_pairs` - Paired (left_key, right_key) column names to compare
 ///
 /// # Returns
 /// AND-connected equality conditions
 pub fn build_equality_conditions(
     left_alias: &str,
     right_alias: &str,
-    columns: &[String],
+    key_pairs: &[(String, String)],
 ) -> String {
-    columns
+    key_pairs
         .iter()
-        .map(|c| format!("{}.\"{}\" = {}.\"{}\"", left_alias, c, right_alias, c))
+        .map(|(lk, rk)| format!("{}.\"{}\" = {}.\"{}\"", left_alias, lk, right_alias, rk))
         .collect::<Vec<_>>()
         .join(" AND ")
 }
@@ -361,9 +361,16 @@ mod tests {
     }
 
     #[test]
-    fn test_build_equality_conditions() {
-        let columns = vec!["id".to_string(), "year".to_string()];
-        let result = build_equality_conditions("L", "R", &columns);
+    fn test_build_equality_conditions_symmetric() {
+        let pairs = vec![("id".to_string(), "id".to_string()), ("year".to_string(), "year".to_string())];
+        let result = build_equality_conditions("L", "R", &pairs);
         assert_eq!(result, "L.\"id\" = R.\"id\" AND L.\"year\" = R.\"year\"");
+    }
+
+    #[test]
+    fn test_build_equality_conditions_asymmetric() {
+        let pairs = vec![("product_id".to_string(), "id".to_string())];
+        let result = build_equality_conditions("L", "R", &pairs);
+        assert_eq!(result, "L.\"product_id\" = R.\"id\"");
     }
 }

--- a/src/ops/join.rs
+++ b/src/ops/join.rs
@@ -253,7 +253,7 @@ struct JoinSqlConfig<'a> {
     right_table: &'a str,
     left_schema: &'a ArrowSchema,
     right_schema: &'a ArrowSchema,
-    left_keys: &'a [String],
+    key_pairs: &'a [(String, String)],
     join_type: JoinType,
     alias: &'a str,
 }
@@ -264,7 +264,7 @@ fn build_join_sql(cfg: &JoinSqlConfig<'_>) -> String {
     let right_table = cfg.right_table;
     let left_schema = cfg.left_schema;
     let right_schema = cfg.right_schema;
-    let left_keys = cfg.left_keys;
+    let key_pairs = cfg.key_pairs;
     let join_type = cfg.join_type;
     let alias = cfg.alias;
     // Build SELECT clause using common helpers
@@ -279,8 +279,8 @@ fn build_join_sql(cfg: &JoinSqlConfig<'_>) -> String {
     
     let select_clause = format!("{}, {}", left_cols, right_cols);
 
-    // Build ON clause using common helper
-    let on_clause = build_equality_conditions("L", "R", left_keys);
+    // Build ON clause using paired columns
+    let on_clause = build_equality_conditions("L", "R", key_pairs);
 
     format!(
         "SELECT {} FROM \"{}\" L {} \"{}\" R ON {}",
@@ -322,12 +322,17 @@ pub fn join_impl(
     let right_schema = get_schema_from_batches(&right_batches, stored_schema_right);
 
     // Parse and validate join keys
-    let (left_col_names, _right_col_names) = extract_and_validate_join_keys(
+    let (left_col_names, right_col_names) = extract_and_validate_join_keys(
         left_key_expr_dict,
         right_key_expr_dict,
         &left_schema,
         &right_schema,
     )?;
+
+    let key_pairs: Vec<(String, String)> = left_col_names
+        .into_iter()
+        .zip(right_col_names.into_iter())
+        .collect();
 
     // Register temp tables (RAII guard will handle cleanup)
     let table_guard = register_join_tables(
@@ -348,7 +353,7 @@ pub fn join_impl(
         right_table: right_name,
         left_schema: &left_schema,
         right_schema: &right_schema,
-        left_keys: &left_col_names,
+        key_pairs: &key_pairs,
         join_type,
         alias,
     });
@@ -368,15 +373,14 @@ fn build_semi_anti_join_sql(
     left_table: &str,
     right_table: &str,
     left_schema: &ArrowSchema,
-    left_keys: &[String],
-    _right_keys: &[String],
+    key_pairs: &[(String, String)],
     is_anti: bool,
 ) -> String {
     // Select all columns from left table only
     let select_cols = build_qualified_column_list(left_schema, "L");
 
-    // Build WHERE condition using common helper
-    let where_conditions = build_equality_conditions("L", "R", left_keys);
+    // Build WHERE condition using paired columns
+    let where_conditions = build_equality_conditions("L", "R", key_pairs);
 
     let exists_keyword = if is_anti { "NOT EXISTS" } else { "EXISTS" };
 
@@ -457,12 +461,16 @@ fn semi_anti_join_impl(
     let right_name = table_names[1];
 
     // Build and execute SQL query
+    let key_pairs: Vec<(String, String)> = left_col_names
+        .into_iter()
+        .zip(right_col_names.into_iter())
+        .collect();
+
     let sql_query = build_semi_anti_join_sql(
         left_name,
         right_name,
         &left_schema,
-        &left_col_names,
-        &right_col_names,
+        &key_pairs,
         is_anti,
     );
 

--- a/src/ops/set_ops.rs
+++ b/src/ops/set_ops.rs
@@ -325,7 +325,8 @@ pub fn is_subset_impl(
                 batches2,
             )?;
 
-            let where_cond = build_equality_conditions("t1", "t2", &compare_cols);
+            let compare_pairs: Vec<(String, String)> = compare_cols.iter().map(|c| (c.clone(), c.clone())).collect();
+            let where_cond = build_equality_conditions("t1", "t2", &compare_pairs);
             let sql = format!(
                 "SELECT COUNT(*) as cnt FROM \"{}\" t1 WHERE NOT EXISTS (SELECT 1 FROM \"{}\" t2 WHERE {})",
                 t1_name, t2_name, where_cond
@@ -398,7 +399,8 @@ fn set_operation_impl(
             )?;
 
             let select_cols = build_qualified_column_list(schema1, "t1");
-            let where_cond = build_equality_conditions("t1", "t2", &compare_cols);
+            let compare_pairs: Vec<(String, String)> = compare_cols.iter().map(|c| (c.clone(), c.clone())).collect();
+            let where_cond = build_equality_conditions("t1", "t2", &compare_pairs);
 
             let sql = match op {
                 SetOperation::Intersect => format!(


### PR DESCRIPTION
## Summary

Fixes #68 — joins with asymmetric key columns (where `left_key != right_key`, e.g., `orders.product_id == products.id`) silently produced wrong SQL like `L."product_id" = R."product_id"` instead of the correct `L."product_id" = R."id"`.

## Changes

- **`src/ops/common.rs`**: Changed `build_equality_conditions()` to accept `&[(String, String)]` key pairs instead of `&[String]`, so each pair specifies `(left_key, right_key)` independently.
- **`src/ops/join.rs`**: 
  - `JoinSqlConfig` now uses `key_pairs: &[(String, String)]` instead of `left_keys: &[String]`
  - `join_impl()` now zips `left_col_names` with `right_col_names` into `key_pairs` (previously `_right_col_names` was discarded)
  - `build_semi_anti_join_sql()` uses paired columns instead of just left keys
  - `semi_anti_join_impl()` constructs `key_pairs` from both key sets
- **`src/ops/set_ops.rs`**: Updated call sites to use symmetric pairs (same name on both sides).
- **`py-ltseq/tests/test_join.py`**: Added `TestJoinAsymmetricKeys` class with 4 tests (inner, left, right, full joins on asymmetric keys).

## Test Results

- 4 new asymmetric key join tests pass
- All 17 existing join tests pass
- All 25 semi/anti-join tests pass  
- All 27 set ops tests pass
- Rust unit tests (4) pass including new asymmetric equality conditions test
- Overall: 1327/1330 pass (3 pre-existing failures unrelated to this change)