### PR TITLE
fix: remove silent materialization paths for issue 69

### DIFF
--- a/benchmarks/bench_pandas_bypass.py
+++ b/benchmarks/bench_pandas_bypass.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+LTSeq Pandas Bypass Benchmark
+================================
+
+Benchmarks the 5 hotspots from GitHub issue #69 that previously materialized
+data through pandas/pyarrow, bypassing the Rust execution engine. After the
+Phase 1 optimization, these paths now use Arrow directly (avoiding pandas
+round-trips) or delegate to Rust-native operations.
+
+Hotspots benchmarked:
+  1. NestedTable.__len__ — was len(to_pandas()), now len(LTSeq) -> Rust count()
+  2. SQLPartitionedTable._compute_keys — was to_pandas()+iterrows(), now to_arrow()+to_pylist()
+  3. PartitionedTable._materialize_partitions — was to_pandas()+_from_rows(), now to_arrow()+take()
+  4. contain() — was to_pandas(), now to_arrow()+to_pylist()
+  5. stateful_scan() — was to_pandas()+iterrows(), now to_arrow()+column dict iteration
+
+Each benchmark is measured at 3 scales (10K, 100K, 1M rows) with warmup +
+multiple iterations, matching the style of bench_core.py.
+
+Usage:
+    # Full benchmark (1M rows)
+    uv run python benchmarks/bench_pandas_bypass.py
+
+    # Quick run (10K and 100K only)
+    uv run python benchmarks/bench_pandas_bypass.py --quick
+
+    # Scale overrides
+    uv run python benchmarks/bench_pandas_bypass.py --scales 10000 100000 1000000
+"""
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+
+sys.path.insert(0, str(os.path.join(os.path.dirname(__file__), "..", "py-ltseq")))
+
+from ltseq import LTSeq  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Infra
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchResult:
+    name: str
+    scale: int
+    median_ms: float
+    times_ms: list[float] = field(default_factory=list)
+    mem_delta_mb: float = 0.0
+
+
+def benchmark_fn(name, scale, fn, warmup=1, iterations=5):
+    """Run fn with warmup, return median time + memory delta."""
+    import gc
+
+    import psutil
+
+    for _ in range(warmup):
+        fn()
+
+    gc.collect()
+    proc = psutil.Process(os.getpid())
+    times = []
+    peak_mem = 0
+
+    for _ in range(iterations):
+        gc.collect()
+        mem_before = proc.memory_info().rss / (1024**2)
+        t0 = time.perf_counter()
+        fn()
+        t1 = time.perf_counter()
+        mem_after = proc.memory_info().rss / (1024**2)
+        elapsed_ms = (t1 - t0) * 1000
+        times.append(elapsed_ms)
+        peak_mem = max(peak_mem, mem_after - mem_before)
+
+    median = sorted(times)[len(times) // 2]
+    return BenchResult(
+        name=name,
+        scale=scale,
+        median_ms=round(median, 2),
+        times_ms=[round(t, 2) for t in times],
+        mem_delta_mb=round(peak_mem, 1),
+    )
+
+
+def generate_csv(path, num_rows, num_categories=20):
+    """Generate a CSV with id, category, value, amount columns."""
+    import random
+
+    random.seed(42)
+    categories = [f"cat_{i}" for i in range(num_categories)]
+
+    with open(path, "w") as f:
+        f.write("id,category,value,amount\n")
+        for i in range(num_rows):
+            cat = random.choice(categories)
+            val = random.randint(1, 1000)
+            amt = round(random.uniform(10.0, 5000.0), 2)
+            f.write(f"{i},{cat},{val},{amt}\n")
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 1: NestedTable.__len__
+# Previously: len(self._ltseq.to_pandas()) — materializes entire DF just to count
+# Now: len(self._ltseq) — delegates to Rust count()
+# ---------------------------------------------------------------------------
+
+
+def bench_nested_len(csv_path):
+    t = LTSeq.read_csv(csv_path)
+    grouped = t.group_ordered(lambda r: r.category)
+    return len(grouped)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 2: SQLPartitionedTable.keys() / _compute_keys()
+# Previously: distinct.to_pandas() then iterrows()
+# Now: distinct.to_arrow() then column.to_pylist()
+# ---------------------------------------------------------------------------
+
+
+def bench_partition_keys(csv_path):
+    t = LTSeq.read_csv(csv_path)
+    partitions = t.partition("category")
+    return len(partitions.keys())
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 3: PartitionedTable._materialize_partitions()
+# Previously: to_pandas() -> dict of rows -> _from_rows()
+# Now: to_arrow() -> group by indices -> take() -> from_arrow()
+# ---------------------------------------------------------------------------
+
+
+def bench_partition_materialize(csv_path):
+    t = LTSeq.read_csv(csv_path)
+    partitions = t.partition(by=lambda r: r.category)
+    keys = partitions.keys()
+    return len(keys)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 4: contain()
+# Previously: to_pandas() then set(df[col].tolist())
+# Now: to_arrow() then set(pa_table.column(col).to_pylist())
+# ---------------------------------------------------------------------------
+
+
+def bench_contain(csv_path):
+    t = LTSeq.read_csv(csv_path)
+    cat_values = ["cat_0", "cat_5", "cat_10", "cat_15", "cat_19"]
+    return t.contain("category", *cat_values)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 5: stateful_scan()
+# Previously: df = to_pandas(), iterrows(), pa.Table.from_pandas()
+# Now: pa_table = to_arrow(), column dict iteration, pa.table() construction
+# ---------------------------------------------------------------------------
+
+
+def bench_stateful_scan(csv_path):
+    t = LTSeq.read_csv(csv_path).sort("id")
+    result = t.stateful_scan(
+        func=lambda s, r: s + float(r["value"]),
+        init=0.0,
+        output_col="cum_value",
+    )
+    return len(result)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def print_results(results: list[BenchResult]):
+    print("\n" + "=" * 90)
+    print("PANDAS BYPASS BENCHMARK RESULTS")
+    print("=" * 90)
+    header = (
+        f"{'Benchmark':<40} {'Scale':>8} {'Median(ms)':>12} "
+        f"{'Min(ms)':>10} {'Max(ms)':>10} {'Mem Δ(MB)':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for r in results:
+        print(
+            f"{r.name:<40} {r.scale:>8,} {r.median_ms:>12.2f} "
+            f"{min(r.times_ms):>10.2f} {max(r.times_ms):>10.2f} "
+            f"{r.mem_delta_mb:>12.1f}"
+        )
+
+    print("=" * 90)
+
+
+def collect_host_info():
+    info = {
+        "os": f"{platform.system()} {platform.release()}",
+        "python": platform.python_version(),
+        "processor": platform.processor() or "unknown",
+        "cpu_count": os.cpu_count(),
+    }
+    try:
+        import psutil
+
+        info["ram_gb"] = round(psutil.virtual_memory().total / (1024**3), 1)
+    except ImportError:
+        pass
+    try:
+        info["git_commit"] = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True, timeout=5
+        ).strip()
+    except Exception:
+        pass
+    try:
+        rustc = subprocess.check_output(["rustc", "--version"], text=True, timeout=5).strip()
+        info["rustc"] = rustc.split()[1] if len(rustc.split()) > 1 else rustc
+    except Exception:
+        pass
+    return info
+
+
+BENCHMARKS = [
+    ("nested_len", bench_nested_len),
+    ("partition_keys_sql", bench_partition_keys),
+    ("partition_materialize", bench_partition_materialize),
+    ("contain", bench_contain),
+    ("stateful_scan", bench_stateful_scan),
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LTSeq Pandas Bypass Benchmark")
+    parser.add_argument(
+        "--quick", action="store_true", help="Only run 10K and 100K scales"
+    )
+    parser.add_argument(
+        "--scales",
+        nargs="+",
+        type=int,
+        default=[10_000, 100_000, 1_000_000],
+        help="Row counts to benchmark (default: 10K 100K 1M)",
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=1, help="Warmup iterations (default: 1)"
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=5, help="Timed iterations (default: 5)"
+    )
+    args = parser.parse_args()
+
+    if args.quick:
+        args.scales = [10_000, 100_000]
+
+    print("LTSeq Pandas Bypass Benchmark")
+    print("=" * 90)
+    print(f"Scales: {args.scales}")
+    print(f"Warmup: {args.warmup}, Iterations: {args.iterations}")
+    print(f"Host: {platform.processor()} | {os.cpu_count()} cores")
+    try:
+        import psutil
+
+        print(f"RAM: {psutil.virtual_memory().total / (1024**3):.0f}GB")
+    except ImportError:
+        pass
+    print()
+
+    results: list[BenchResult] = []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for scale in args.scales:
+            csv_path = os.path.join(tmpdir, f"bench_{scale}.csv")
+            print(f"Generating {scale:,} rows... ", end="", flush=True)
+            generate_csv(csv_path, scale)
+            print("done.")
+
+            for bench_name, bench_fn in BENCHMARKS:
+                label = f"{bench_name}_{scale // 1000}k" if scale < 1_000_000 else f"{bench_name}_{scale // 1000}k"
+                print(f"  {label:<40}", end="", flush=True)
+                r = benchmark_fn(
+                    label, scale, lambda p=csv_path: bench_fn(p),
+                    warmup=args.warmup, iterations=args.iterations,
+                )
+                print(f"  {r.median_ms:>8.2f} ms")
+                results.append(r)
+
+    print_results(results)
+
+    output = {
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "host": collect_host_info(),
+        "scales": args.scales,
+        "warmup": args.warmup,
+        "iterations": args.iterations,
+        "results": [
+            {
+                "name": r.name,
+                "scale": r.scale,
+                "median_ms": r.median_ms,
+                "times_ms": r.times_ms,
+                "mem_delta_mb": r.mem_delta_mb,
+            }
+            for r in results
+        ],
+    }
+    results_path = os.path.join(os.path.dirname(__file__), "pandas_bypass_results.json")
+    with open(results_path, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults saved to {results_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/pandas_bypass_results.json
+++ b/benchmarks/pandas_bypass_results.json
@@ -1,0 +1,216 @@
+{
+  "timestamp": "2026-04-21 22:33:42",
+  "host": {
+    "os": "Linux 6.18.21-1-cachyos-lts",
+    "python": "3.14.4",
+    "processor": "unknown",
+    "cpu_count": 32,
+    "ram_gb": 125.1,
+    "git_commit": "4ddc409",
+    "rustc": "1.93.1"
+  },
+  "scales": [
+    10000,
+    100000,
+    1000000
+  ],
+  "warmup": 1,
+  "iterations": 5,
+  "results": [
+    {
+      "name": "nested_len_10k",
+      "scale": 10000,
+      "median_ms": 2.54,
+      "times_ms": [
+        3.04,
+        2.35,
+        2.54,
+        2.43,
+        2.75
+      ],
+      "mem_delta_mb": 1.2
+    },
+    {
+      "name": "partition_keys_sql_10k",
+      "scale": 10000,
+      "median_ms": 4.78,
+      "times_ms": [
+        5.47,
+        4.78,
+        4.52,
+        4.3,
+        5.73
+      ],
+      "mem_delta_mb": 1.9
+    },
+    {
+      "name": "partition_materialize_10k",
+      "scale": 10000,
+      "median_ms": 29.24,
+      "times_ms": [
+        29.51,
+        29.14,
+        29.24,
+        29.68,
+        27.95
+      ],
+      "mem_delta_mb": 0.9
+    },
+    {
+      "name": "contain_10k",
+      "scale": 10000,
+      "median_ms": 6.66,
+      "times_ms": [
+        7.5,
+        7.37,
+        6.66,
+        6.34,
+        6.37
+      ],
+      "mem_delta_mb": 0
+    },
+    {
+      "name": "stateful_scan_10k",
+      "scale": 10000,
+      "median_ms": 15.24,
+      "times_ms": [
+        15.62,
+        15.02,
+        14.99,
+        15.24,
+        15.37
+      ],
+      "mem_delta_mb": 0.4
+    },
+    {
+      "name": "nested_len_100k",
+      "scale": 100000,
+      "median_ms": 5.83,
+      "times_ms": [
+        6.28,
+        5.83,
+        5.06,
+        6.3,
+        5.28
+      ],
+      "mem_delta_mb": 0.6
+    },
+    {
+      "name": "partition_keys_sql_100k",
+      "scale": 100000,
+      "median_ms": 9.64,
+      "times_ms": [
+        9.15,
+        10.21,
+        9.6,
+        10.68,
+        9.64
+      ],
+      "mem_delta_mb": 3.0
+    },
+    {
+      "name": "partition_materialize_100k",
+      "scale": 100000,
+      "median_ms": 152.38,
+      "times_ms": [
+        156.49,
+        152.6,
+        150.9,
+        152.38,
+        151.05
+      ],
+      "mem_delta_mb": 3.6
+    },
+    {
+      "name": "contain_100k",
+      "scale": 100000,
+      "median_ms": 43.16,
+      "times_ms": [
+        42.69,
+        43.16,
+        43.68,
+        44.21,
+        43.04
+      ],
+      "mem_delta_mb": 0
+    },
+    {
+      "name": "stateful_scan_100k",
+      "scale": 100000,
+      "median_ms": 128.68,
+      "times_ms": [
+        130.49,
+        128.68,
+        128.99,
+        127.17,
+        127.51
+      ],
+      "mem_delta_mb": 3.1
+    },
+    {
+      "name": "nested_len_1000k",
+      "scale": 1000000,
+      "median_ms": 8.22,
+      "times_ms": [
+        8.72,
+        8.22,
+        7.18,
+        8.35,
+        7.75
+      ],
+      "mem_delta_mb": 8.0
+    },
+    {
+      "name": "partition_keys_sql_1000k",
+      "scale": 1000000,
+      "median_ms": 10.58,
+      "times_ms": [
+        11.22,
+        11.48,
+        10.58,
+        10.04,
+        10.23
+      ],
+      "mem_delta_mb": 2.9
+    },
+    {
+      "name": "partition_materialize_1000k",
+      "scale": 1000000,
+      "median_ms": 1506.88,
+      "times_ms": [
+        1521.79,
+        1490.96,
+        1502.13,
+        1506.88,
+        1510.48
+      ],
+      "mem_delta_mb": 60.4
+    },
+    {
+      "name": "contain_1000k",
+      "scale": 1000000,
+      "median_ms": 375.54,
+      "times_ms": [
+        375.54,
+        374.49,
+        382.2,
+        378.53,
+        369.46
+      ],
+      "mem_delta_mb": 5.7
+    },
+    {
+      "name": "stateful_scan_1000k",
+      "scale": 1000000,
+      "median_ms": 1213.99,
+      "times_ms": [
+        1207.48,
+        1213.99,
+        1199.25,
+        1222.16,
+        1217.71
+      ],
+      "mem_delta_mb": 116.3
+    }
+  ]
+}

--- a/py-ltseq/ltseq/advanced_ops.py
+++ b/py-ltseq/ltseq/advanced_ops.py
@@ -225,8 +225,8 @@ class SetOpsMixin:
         if not values:
             return True
 
-        df = self.to_pandas()
-        col_values = set(df[key_col].tolist())
+        pa_table = self.to_arrow()
+        col_values = set(pa_table.column(key_col).to_pylist())
         return all(v in col_values for v in values)
 
     def is_subset(self, other: "LTSeq", on: Callable | None = None) -> bool:
@@ -354,25 +354,18 @@ class AdvancedOpsMixin:
 
         try:
             result_inner = self._inner.search_first(expr_dict)
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"search_first() failed: {e}. "
+                f"The predicate could not be transpiled to a DataFusion expression. "
+                f"Use simpler expressions (column comparisons, boolean logic) that the "
+                f"expression system can handle."
+            ) from e
 
-            result = LTSeq()
-            result._inner = result_inner
-            result._schema = self._schema.copy()
-            return result
-        except Exception:
-            # Fallback to Python iteration
-            df = self.to_pandas()
-            for idx, row in df.iterrows():
-                single_row_df = df.iloc[[idx]]
-                rows = single_row_df.to_dict("records")
-                try:
-                    single_ltseq = LTSeq._from_rows(rows, self._schema)
-                    result_filtered = single_ltseq.filter(predicate)
-                    if len(result_filtered) > 0:
-                        return result_filtered
-                except Exception:
-                    continue
-            return LTSeq._from_rows([], self._schema)
+        result = LTSeq()
+        result._inner = result_inner
+        result._schema = self._schema.copy()
+        return result
 
     def pivot(
         self,
@@ -455,6 +448,12 @@ class AdvancedOpsMixin:
         Returns:
             New LTSeq with state column added
 
+        Notes:
+            This is an explicit small-table convenience API. It materializes the
+            full table into Arrow and executes the transition function row-by-row
+            in Python, so it does not preserve DataFusion laziness or pushdown.
+            Prefer Rust/DataFusion-native transforms when possible.
+
         Example:
             >>> result = t.sort("date").stateful_scan(
             ...     func=lambda s, r: s * (1 + r["rate"]),
@@ -462,6 +461,8 @@ class AdvancedOpsMixin:
             ...     output_col="cumulative_return"
             ... )
         """
+        import warnings
+
         from .core import LTSeq
 
         if not self._schema:
@@ -478,40 +479,49 @@ class AdvancedOpsMixin:
                 f"Use a different name or remove the existing column first."
             )
 
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError(
-                "stateful_scan() requires pandas. Install with: pip install pandas"
-            )
+        warnings.warn(
+            "stateful_scan() is a small-table convenience API that materializes "
+            "the table into Arrow and executes row-by-row in Python. It does not "
+            "preserve lazy DataFusion execution.",
+            UserWarning,
+            stacklevel=2,
+        )
 
-        df = self.to_pandas()
+        import pyarrow as pa
 
-        if df.empty:
+        pa_table = self.to_arrow()
+
+        if pa_table.num_rows == 0:
             return self._handle_empty_scan(init, output_col)
+
+        col_names = pa_table.schema.names
+        columns = {name: pa_table.column(name).to_pylist() for name in col_names}
 
         state = init
         results = []
 
-        for idx, row in df.iterrows():
-            row_dict = row.to_dict()
+        for row_idx in range(pa_table.num_rows):
+            row_dict = {name: columns[name][row_idx] for name in col_names}
             try:
                 state = func(state, row_dict)
                 results.append(state)
             except Exception as e:
                 raise RuntimeError(
-                    f"State transition function failed at row {idx}: {e}"
+                    f"State transition function failed at row {row_idx}: {e}"
                 ) from e
 
-        import pyarrow as pa
-
-        df[output_col] = results
         result_schema = self._schema.copy()
         result_schema[output_col] = self._infer_type_from_value(
             results[0] if results else init
         )
 
-        result = LTSeq.from_arrow(pa.Table.from_pandas(df, preserve_index=False))
+        new_columns = {
+            name: pa_table.column(name) for name in col_names
+        }
+        new_columns[output_col] = pa.array(results)
+        result_table = pa.table(new_columns)
+
+        result = LTSeq.from_arrow(result_table)
         result._schema = result_schema
         result._sort_keys = self._sort_keys
         return result

--- a/py-ltseq/ltseq/grouping/nested_table.py
+++ b/py-ltseq/ltseq/grouping/nested_table.py
@@ -1,10 +1,9 @@
 """NestedTable class for group-ordered operations."""
 
-import re
 import textwrap
 from typing import TYPE_CHECKING, Any, Callable
 
-from .proxies import GroupProxy, RowProxy
+from .proxies import FilterGroupProxy, FilterExpr
 from .sql_parsing import (
     DeriveSQLParser,
     FilterSQLParser,
@@ -65,16 +64,13 @@ class NestedTable:
         self._group_filter = None
         self._group_derive = None
 
-        # Store group assignments for rows (used when filter() is applied)
-        self._group_assignments = None
-
         # SQL parsers
         self._filter_parser = FilterSQLParser()
         self._derive_parser = DeriveSQLParser()
 
     def __len__(self) -> int:
         """Return the number of rows in the grouped table."""
-        return len(self._ltseq.to_pandas())
+        return len(self._ltseq)
 
     def to_pandas(self) -> Any:
         """Convert the grouped table to a pandas DataFrame."""
@@ -161,7 +157,18 @@ class NestedTable:
             >>> grouped.filter(lambda g: g.first().price > 100)
             >>> grouped.filter(lambda g: g.all(lambda r: r.amount > 0))
         """
-        # Try SQL-based approach first
+        # Try proxy-based expression capture first (works in all contexts)
+        try:
+            proxy = FilterGroupProxy()
+            result = group_predicate(proxy)
+            if isinstance(result, FilterExpr):
+                where_clause = result.to_sql()
+                if where_clause:
+                    return self._filter_via_sql(where_clause)
+        except Exception:
+            pass
+
+        # Fall back to source-code-based SQL parsing
         try:
             where_clause = self._filter_parser.try_parse_filter_to_sql(group_predicate)
             if where_clause:
@@ -169,107 +176,133 @@ class NestedTable:
         except Exception:
             pass
 
-        # Fall back to pandas-based evaluation
-        return self._filter_via_pandas(group_predicate)
+        raise ValueError(
+            "group_ordered().filter() could not parse the predicate expression into SQL. "
+            "Supported patterns include:\n"
+            "  - g.count() > N, g.count() < N, g.count() >= N, etc.\n"
+            "  - g.first().column op value (e.g., g.first().price > 100)\n"
+            "  - g.last().column op value\n"
+            "  - g.max('column') op value, g.min(), g.sum(), g.avg()\n"
+            "  - g.all(lambda r: r.col op val), g.any(...), g.none(...)\n"
+            "  - Combinations with & (AND) and | (OR)\n"
+            "Complex Python expressions that cannot be transpiled are not supported.\n"
+            "If you need a predicate that cannot be expressed this way, consider "
+            "using .flatten() and then .filter() on the flattened result."
+        )
 
     def _filter_via_sql(self, where_clause: str) -> "NestedTable":
-        """Filter using SQL WHERE clause with window functions."""
-        flattened = self.flatten()
-        filtered_inner = flattened._inner.filter_where(where_clause)
+        """Filter using SQL WHERE clause with window functions.
 
-        result_ltseq = self._ltseq.__class__()
-        result_ltseq._inner = filtered_inner
-        result_ltseq._schema = flattened._schema.copy()
+        Window functions cannot appear in SQL WHERE clauses. We extract all
+        window function expressions from the where_clause, add them as derived
+        columns via derive_window_sql, then filter on the simplified condition
+        using only column references.
+        """
+        import re
 
-        result_nested = NestedTable(
-            result_ltseq, self._grouping_lambda, is_sorted=self._is_sorted
-        )
-        return result_nested
+        _FILTER_COL = "__filter_cond__"
 
-    def _filter_via_pandas(self, group_predicate: Callable) -> "NestedTable":
-        """Filter using pandas iteration (fallback for complex predicates)."""
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError(
-                "filter() requires pandas. Install it with: pip install pandas"
+        # Find all window function expressions in the where_clause.
+        # Strategy: find each "OVER (PARTITION BY __group_id__...)" pattern,
+        # then scan backwards past any whitespace and matching parens to find
+        # the start of the window function expression (e.g. "COUNT(*)",
+        # "MIN(CASE WHEN ... END)", etc.)
+        window_exprs = []
+        simplified = where_clause
+
+        pattern = r'OVER\s*\(\s*PARTITION\s+BY\s+__group_id__'
+        pos = 0
+        while True:
+            m = re.search(pattern, simplified[pos:])
+            if not m:
+                break
+            over_start = pos + m.start()
+
+            # Find the closing paren of OVER(...)
+            # First find opening paren after OVER
+            rest = simplified[over_start + len("OVER"):]
+            paren_m = re.match(r'\s*\(', rest)
+            if not paren_m:
+                break
+            paren_open = over_start + len("OVER") + paren_m.end() - 1
+
+            # Find matching closing paren
+            depth = 1
+            i = paren_open + 1
+            while i < len(simplified) and depth > 0:
+                if simplified[i] == '(':
+                    depth += 1
+                elif simplified[i] == ')':
+                    depth -= 1
+                i += 1
+            window_end = i  # exclusive (character after closing paren)
+
+            # Scan backwards from OVER keyword to find expr start.
+            # Skip whitespace immediately before OVER, then walk backwards
+            # through any parenthesized expression and function name.
+            j = over_start - 1
+            # Skip whitespace before OVER
+            while j >= 0 and simplified[j] in (' ', '\t', '\n'):
+                j -= 1
+            # Now walk backwards through matching parens and identifier chars
+            paren_depth = 0
+            while j >= 0:
+                ch = simplified[j]
+                if ch == ')':
+                    paren_depth += 1
+                elif ch == '(':
+                    if paren_depth == 0:
+                        break
+                    paren_depth -= 1
+                elif paren_depth == 0 and not (ch.isalnum() or ch in ('_', '.', '*', '"', "'")):
+                    break
+                j -= 1
+            expr_start = j + 1
+
+            window_expr = simplified[expr_start:window_end]
+            col_name = f"{_FILTER_COL}_{len(window_exprs)}"
+            window_exprs.append((col_name, window_expr))
+
+            # Replace the window expression with the column reference
+            simplified = simplified[:expr_start] + f'"{col_name}"' + simplified[window_end:]
+            # Continue scanning after the replacement
+            pos = expr_start + len(f'"{col_name}"')
+
+        if not window_exprs:
+            raise ValueError(
+                f"No window functions found in filter condition: {where_clause}"
             )
 
-        df = self._ltseq.to_pandas()
+        # Build the derive expressions dict
+        filter_exprs = {col_name: expr for col_name, expr in window_exprs}
 
-        # Add __group_id__ column
-        group_values = []
-        group_id = 0
-        prev_group_val = None
+        flattened = self.flatten()
 
-        for idx, row in df.iterrows():
-            row_proxy = RowProxy(row.to_dict())
-            group_val = self._grouping_lambda(row_proxy)
+        # Step 1: Add filter conditions as derived columns
+        derived_inner = flattened._inner.derive_window_sql(filter_exprs)
 
-            if prev_group_val is None or group_val != prev_group_val:
-                group_id += 1
-                prev_group_val = group_val
+        derived_ltseq = flattened.__class__()
+        derived_ltseq._inner = derived_inner
+        derived_schema = flattened._schema.copy()
+        for col_name in filter_exprs:
+            derived_schema[col_name] = "int64"
+        derived_ltseq._schema = derived_schema
 
-            group_values.append(group_id)
+        # Step 2: Filter on the simplified condition
+        filter_condition = simplified
+        filtered_inner = derived_ltseq._inner.filter_where(filter_condition)
 
-        df["__group_id__"] = group_values
-        df["__group_count__"] = df.groupby("__group_id__").transform("size")
+        # Step 3: Remove filter and internal columns via select
+        original_cols = list(self._ltseq._schema.keys())
+        result_ltseq = derived_ltseq.__class__()
+        result_ltseq._inner = filtered_inner
+        result_ltseq._schema = derived_schema
 
-        # Evaluate predicate for each group
-        group_by_id = df.groupby("__group_id__")
-        passing_group_ids = set()
-
-        for gid, group_df in group_by_id:
-            group_proxy = GroupProxy(group_df, self)
-
-            try:
-                result = group_predicate(group_proxy)
-                if result:
-                    passing_group_ids.add(gid)
-            except AttributeError as e:
-                supported_methods = """
-Supported group methods:
-- g.count() - number of rows in group
-- g.first().column - first row's column value
-- g.last().column - last row's column value
-- g.max('column') - maximum value in column
-- g.min('column') - minimum value in column
-- g.sum('column') - sum of column values
-- g.avg('column') - average of column values
-"""
-                raise ValueError(
-                    f"Error evaluating filter predicate on group {gid}: {e}\n{supported_methods}"
-                )
-            except Exception as e:
-                raise ValueError(
-                    f"Error evaluating filter predicate on group {gid}: {e}"
-                )
-
-        # Filter to keep only passing groups
-        filtered_df = df[df["__group_id__"].isin(list(passing_group_ids))]
-
-        # Store group assignments
-        group_assignments = {}
-        for original_idx, (_, row) in enumerate(filtered_df.iterrows()):
-            group_assignments[original_idx] = int(row["__group_id__"])
-
-        # Remove internal columns
-        result_cols = [c for c in filtered_df.columns if not c.startswith("__")]
-        result_df = filtered_df[result_cols]
-
-        # Convert back to LTSeq
-        import pyarrow as pa
-
-        schema = self._ltseq._schema.copy()
-        result_ltseq = self._ltseq.__class__.from_arrow(
-            pa.Table.from_pandas(result_df, preserve_index=False)
-        )
-        result_ltseq._schema = schema
+        result_ltseq = result_ltseq.select(*original_cols)
 
         result_nested = NestedTable(
             result_ltseq, self._grouping_lambda, is_sorted=self._is_sorted
         )
-        result_nested._group_assignments = group_assignments
         return result_nested
 
     def derive(self, group_mapper: Callable) -> "LTSeq":
@@ -293,10 +326,6 @@ Supported group methods:
             ...     "end": g.last().date,
             ... })
         """
-        # Use pandas when we have stored group assignments from filter()
-        if self._group_assignments is not None:
-            return self._derive_via_pandas_with_stored_groups(group_mapper)
-
         flattened = self.flatten()
 
         # Try proxy-based expression capture first (works in all contexts)
@@ -409,146 +438,6 @@ Supported group methods:
         result._inner = flattened._inner.derive_window_sql(derive_exprs)
 
         return result
-
-    def _derive_via_pandas_with_stored_groups(self, group_mapper: Callable) -> "LTSeq":
-        """Derive columns using pandas when we have stored group assignments."""
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError(
-                "derive() with stored group assignments requires pandas. "
-                "Install it with: pip install pandas"
-            )
-
-        # Try proxy-based capture first (works in REPL, Jupyter, and files)
-        derive_exprs = None
-        try:
-            derive_exprs = self._capture_derive_via_proxy(group_mapper)
-        except Exception:
-            pass
-
-        if not derive_exprs:
-            # Fall back to source code parsing
-            import ast
-            import inspect
-
-            source = None
-            try:
-                source = inspect.getsource(group_mapper)
-            except (OSError, TypeError):
-                raise ValueError(
-                    "Cannot parse derive expression: proxy-based capture failed and "
-                    "source is not available (common in REPL/Jupyter). "
-                    "Use g.count(), g.first().col, g.last().col, g.max('col'), etc."
-                )
-
-            source_dedented = textwrap.dedent(source)
-            source_to_parse = extract_lambda_from_chain(source_dedented)
-
-            try:
-                tree = ast.parse(source_to_parse)
-            except SyntaxError:
-                try:
-                    tree = ast.parse(f"({source_to_parse})", mode="eval")
-                except SyntaxError:
-                    raise ValueError(
-                        f"Cannot parse derive lambda expression. Source: {source_to_parse}"
-                    )
-
-            schema = self._ltseq._schema.copy()
-            derive_exprs = self._derive_parser.extract_derive_expressions(tree, schema)
-
-            if not derive_exprs:
-                raise ValueError(get_unsupported_derive_error(source))
-
-        df = self._ltseq.to_pandas()
-
-        df["__rn__"] = range(len(df))
-        group_values = [self._group_assignments[i] for i in range(len(df))]
-        df["__group_id__"] = group_values
-
-        for col_name, sql_expr in derive_exprs.items():
-            try:
-                df[col_name] = self._evaluate_sql_expr_in_pandas(df, sql_expr)
-            except Exception as e:
-                raise ValueError(f"Error evaluating derived column '{col_name}': {e}")
-
-        df = df.drop(columns=["__group_id__", "__rn__"])
-
-        result_schema = self._ltseq._schema.copy()
-        for col_name in derive_exprs.keys():
-            result_schema[col_name] = "Unknown"
-
-        import pyarrow as pa
-
-        result = self._ltseq.__class__.from_arrow(
-            pa.Table.from_pandas(df, preserve_index=False)
-        )
-        result._schema = result_schema
-
-        return result
-
-    def _evaluate_sql_expr_in_pandas(self, df, sql_expr: str):
-        """Evaluate SQL-like window function expression in pandas."""
-        # Handle arithmetic expressions recursively
-        if sql_expr.startswith("(") and sql_expr.endswith(")"):
-            inner = sql_expr[1:-1]
-
-            paren_depth = 0
-            for i, char in enumerate(inner):
-                if char == "(":
-                    paren_depth += 1
-                elif char == ")":
-                    paren_depth -= 1
-                elif paren_depth == 0 and char in ["+", "-", "*", "/"]:
-                    left_expr = inner[:i].strip()
-                    op = char
-                    right_expr = inner[i + 1 :].strip()
-
-                    left_result = self._evaluate_sql_expr_in_pandas(df, left_expr)
-                    right_result = self._evaluate_sql_expr_in_pandas(df, right_expr)
-
-                    if op == "+":
-                        return left_result + right_result
-                    elif op == "-":
-                        return left_result - right_result
-                    elif op == "*":
-                        return left_result * right_result
-                    elif op == "/":
-                        return left_result / right_result
-
-        # Handle COUNT(*)
-        if "COUNT(*)" in sql_expr and "PARTITION BY __group_id__" in sql_expr:
-            return df.groupby("__group_id__").transform("size")
-
-        # Handle FIRST_VALUE(col) — column name may be bare or double-quoted
-        if "FIRST_VALUE" in sql_expr:
-            match = re.search(r'FIRST_VALUE\s*\("?(\w+)"?\)', sql_expr)
-            if match:
-                col_name = match.group(1)
-                return df.groupby("__group_id__")[col_name].transform("first")
-
-        # Handle LAST_VALUE(col) — column name may be bare or double-quoted
-        if "LAST_VALUE" in sql_expr:
-            match = re.search(r'LAST_VALUE\s*\("?(\w+)"?\)', sql_expr)
-            if match:
-                col_name = match.group(1)
-                return df.groupby("__group_id__")[col_name].transform("last")
-
-        # Handle MAX/MIN/SUM/AVG — column name may be bare or double-quoted
-        for agg_sql, agg_pandas in [
-            ("MAX", "max"),
-            ("MIN", "min"),
-            ("SUM", "sum"),
-            ("AVG", "mean"),
-        ]:
-            if agg_sql in sql_expr:
-                match = re.search(f'{agg_sql}\\s*\\("?(\\w+)"?\\)', sql_expr)
-                if match:
-                    col_name = match.group(1)
-                    return df.groupby("__group_id__")[col_name].transform(agg_pandas)
-
-        return df.eval(sql_expr)
 
 
 class _LazyFirstLTSeq:

--- a/py-ltseq/ltseq/grouping/proxies/__init__.py
+++ b/py-ltseq/ltseq/grouping/proxies/__init__.py
@@ -3,5 +3,6 @@
 from .row_proxy import RowProxy
 from .group_proxy import GroupProxy
 from .derive_proxy import DeriveGroupProxy
+from .filter_proxy import FilterGroupProxy, FilterExpr
 
-__all__ = ["RowProxy", "GroupProxy", "DeriveGroupProxy"]
+__all__ = ["RowProxy", "GroupProxy", "DeriveGroupProxy", "FilterGroupProxy", "FilterExpr"]

--- a/py-ltseq/ltseq/grouping/proxies/filter_proxy.py
+++ b/py-ltseq/ltseq/grouping/proxies/filter_proxy.py
@@ -1,0 +1,369 @@
+"""FilterGroupProxy - Proxy class for capturing filter predicates.
+
+Captures group-level filter expressions like g.count() > 2 as serializable
+expression trees, enabling proxy-based filter capture that works in all contexts
+(pytest, REPL, exec) without requiring source code inspection.
+"""
+
+from typing import Callable
+
+from ..expr import (
+    GroupExpr,
+    GroupCountExpr,
+    GroupAggExpr,
+    GroupRowColumnExpr,
+    DeriveRowProxy,
+)
+
+
+class _RawSQL:
+    """Wrapper for raw SQL that should not be quoted."""
+    __slots__ = ("sql",)
+
+    def __init__(self, sql: str):
+        self.sql = sql
+
+
+class FilterExpr:
+    """A captured filter predicate (comparison expression).
+
+    Represents expressions like g.count() > 2, g.first().price == 100, etc.
+    Can be converted to a SQL WHERE clause for execution in the Rust engine.
+    """
+
+    def __init__(self, left, op: str, right):
+        self.left = left
+        self.op = op
+        self.right = right
+
+    def to_sql(self) -> str:
+        """Convert this filter expression to a SQL WHERE clause."""
+        left_sql = self._operand_to_sql(self.left)
+        if self.op == "NOT":
+            return f"NOT ({left_sql})"
+        right_sql = self._operand_to_sql(self.right)
+        if self.op == "AND":
+            return f"({left_sql}) AND ({right_sql})"
+        elif self.op == "OR":
+            return f"({left_sql}) OR ({right_sql})"
+        else:
+            return f"{left_sql} {self.op} {right_sql}"
+
+    def _operand_to_sql(self, operand) -> str:
+        if isinstance(operand, _RawSQL):
+            return operand.sql
+        elif isinstance(operand, GroupExpr):
+            from ..sql_parsing import group_expr_to_sql
+
+            return group_expr_to_sql(operand.serialize())
+        elif isinstance(operand, FilterExpr):
+            return operand.to_sql()
+        elif isinstance(operand, str):
+            escaped = operand.replace("'", "''")
+            return f"'{escaped}'"
+        elif isinstance(operand, bool):
+            return "TRUE" if operand else "FALSE"
+        elif operand is None:
+            return "NULL"
+        else:
+            return str(operand)
+
+    def __and__(self, other: "FilterExpr") -> "FilterExpr":
+        """Combine two filter expressions with AND."""
+        return FilterExpr(self, "AND", other)
+
+    def __or__(self, other: "FilterExpr") -> "FilterExpr":
+        """Combine two filter expressions with OR."""
+        return FilterExpr(self, "OR", other)
+
+    def __invert__(self) -> "FilterExpr":
+        """Negate a filter expression with NOT."""
+        return FilterExpr(self, "NOT", None)
+
+
+class _ComparableGroupExpr(GroupExpr):
+    """Mixin-like base that adds comparison operators to GroupExpr subclasses.
+
+    When a comparison like g.count() > 2 is evaluated, Python calls __gt__
+    which returns a FilterExpr capturing the operation.
+    """
+
+    def __gt__(self, other) -> FilterExpr:
+        return FilterExpr(self, ">", other)
+
+    def __ge__(self, other) -> FilterExpr:
+        return FilterExpr(self, ">=", other)
+
+    def __lt__(self, other) -> FilterExpr:
+        return FilterExpr(self, "<", other)
+
+    def __le__(self, other) -> FilterExpr:
+        return FilterExpr(self, "<=", other)
+
+    def __eq__(self, other) -> FilterExpr:  # type: ignore[override]
+        return FilterExpr(self, "=", other)
+
+    def __ne__(self, other) -> FilterExpr:  # type: ignore[override]
+        return FilterExpr(self, "!=", other)
+
+
+class FilterGroupProxy:
+    """Proxy for capturing filter predicates without executing them.
+
+    When passed to a filter lambda, this proxy captures operations like
+    g.count() > 2 as FilterExpr objects that can be converted to SQL.
+
+    Example:
+        proxy = FilterGroupProxy()
+        result = filter_lambda(proxy)
+        # result is a FilterExpr
+        sql = result.to_sql()  # "COUNT(*) OVER (...) > 2"
+    """
+
+    def count(self) -> GroupCountExpr:
+        """Capture g.count() expression."""
+        return _FilterableGroupCountExpr()
+
+    def first(self) -> DeriveRowProxy:
+        """Capture g.first() - returns proxy for column access."""
+        return _FilterableDeriveRowProxy("first")
+
+    def last(self) -> DeriveRowProxy:
+        """Capture g.last() - returns proxy for column access."""
+        return _FilterableDeriveRowProxy("last")
+
+    def max(self, column: str) -> GroupAggExpr:
+        """Capture g.max('column') expression."""
+        return _FilterableGroupAggExpr("max", column)
+
+    def min(self, column: str) -> GroupAggExpr:
+        """Capture g.min('column') expression."""
+        return _FilterableGroupAggExpr("min", column)
+
+    def sum(self, column: str) -> GroupAggExpr:
+        """Capture g.sum('column') expression."""
+        return _FilterableGroupAggExpr("sum", column)
+
+    def avg(self, column: str) -> GroupAggExpr:
+        """Capture g.avg('column') expression."""
+        return _FilterableGroupAggExpr("avg", column)
+
+    def all(self, predicate: Callable) -> FilterExpr:
+        """Capture g.all(lambda r: r.col op val) expression.
+
+        Translates to MIN(CASE WHEN predicate THEN 1 ELSE 0 END) OVER (...) = 1
+        """
+        inner_sql = _capture_inner_predicate_proxy(predicate)
+        if inner_sql:
+            case_expr = _RawSQL(f"MIN(CASE WHEN {inner_sql} THEN 1 ELSE 0 END) OVER (PARTITION BY __group_id__)")
+            return FilterExpr(case_expr, "=", 1)
+        inner_sql = _capture_inner_predicate_source(predicate)
+        if inner_sql:
+            case_expr = _RawSQL(f"MIN(CASE WHEN {inner_sql} THEN 1 ELSE 0 END) OVER (PARTITION BY __group_id__)")
+            return FilterExpr(case_expr, "=", 1)
+        raise ValueError(
+            "g.all() predicate could not be captured. "
+            "Use simple column comparisons like g.all(lambda r: r.col > val)."
+        )
+
+    def any(self, predicate: Callable) -> FilterExpr:
+        """Capture g.any(lambda r: r.col op val) expression.
+
+        Translates to MAX(CASE WHEN predicate THEN 1 ELSE 0 END) OVER (...) = 1
+        """
+        inner_sql = _capture_inner_predicate_proxy(predicate)
+        if inner_sql:
+            case_expr = _RawSQL(f"MAX(CASE WHEN {inner_sql} THEN 1 ELSE 0 END) OVER (PARTITION BY __group_id__)")
+            return FilterExpr(case_expr, "=", 1)
+        inner_sql = _capture_inner_predicate_source(predicate)
+        if inner_sql:
+            case_expr = _RawSQL(f"MAX(CASE WHEN {inner_sql} THEN 1 ELSE 0 END) OVER (PARTITION BY __group_id__)")
+            return FilterExpr(case_expr, "=", 1)
+        raise ValueError(
+            "g.any() predicate could not be captured. "
+            "Use simple column comparisons like g.any(lambda r: r.col > val)."
+        )
+
+    def none(self, predicate: Callable) -> FilterExpr:
+        """Capture g.none(lambda r: r.col op val) expression.
+
+        Translates to MAX(CASE WHEN predicate THEN 1 ELSE 0 END) OVER (...) = 0
+        """
+        inner_sql = _capture_inner_predicate_proxy(predicate)
+        if inner_sql:
+            case_expr = _RawSQL(f"MAX(CASE WHEN {inner_sql} THEN 1 ELSE 0 END) OVER (PARTITION BY __group_id__)")
+            return FilterExpr(case_expr, "=", 0)
+        inner_sql = _capture_inner_predicate_source(predicate)
+        if inner_sql:
+            case_expr = _RawSQL(f"MAX(CASE WHEN {inner_sql} THEN 1 ELSE 0 END) OVER (PARTITION BY __group_id__)")
+            return FilterExpr(case_expr, "=", 0)
+        raise ValueError(
+            "g.none() predicate could not be captured. "
+            "Use simple column comparisons like g.none(lambda r: r.col > val)."
+        )
+
+
+class _InnerColumnProxy:
+    """Proxy for capturing column references in inner predicates.
+
+    When passed to a lambda like lambda r: r.value > 0, this proxy
+    captures r.value as a column name and the comparison as SQL.
+    """
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return _InnerColumnRef(name)
+
+    def __gt__(self, other):
+        raise TypeError("Compare column attributes, not the row proxy itself")
+
+    def __lt__(self, other):
+        raise TypeError("Compare column attributes, not the row proxy itself")
+
+
+class _InnerColumnRef:
+    """A reference to a column captured from the inner predicate proxy."""
+
+    def __init__(self, column: str):
+        self._column = column
+
+    def __gt__(self, other):
+        return _InnerPredicateExpr(self, ">", other)
+
+    def __ge__(self, other):
+        return _InnerPredicateExpr(self, ">=", other)
+
+    def __lt__(self, other):
+        return _InnerPredicateExpr(self, "<", other)
+
+    def __le__(self, other):
+        return _InnerPredicateExpr(self, "<=", other)
+
+    def __eq__(self, other):
+        return _InnerPredicateExpr(self, "=", other)
+
+    def __ne__(self, other):
+        return _InnerPredicateExpr(self, "!=", other)
+
+
+class _InnerPredicateExpr:
+    """A captured inner predicate expression like 'value > 0'."""
+
+    def __init__(self, left, op: str, right=None):
+        self.left = left
+        self.op = op
+        self.right = right
+
+    def to_sql(self) -> str:
+        left_sql = self._operand_to_sql(self.left)
+        right_sql = self._operand_to_sql(self.right) if self.right is not None else None
+        if self.op == "AND":
+            return f"({left_sql}) AND ({right_sql})"
+        elif self.op == "OR":
+            return f"({left_sql}) OR ({right_sql})"
+        else:
+            return f"{left_sql} {self.op} {right_sql}"
+
+    def _operand_to_sql(self, operand) -> str:
+        if isinstance(operand, _InnerPredicateExpr):
+            return operand.to_sql()
+        elif isinstance(operand, _InnerColumnRef):
+            return operand._column
+        elif isinstance(operand, str):
+            escaped = operand.replace("'", "''")
+            return f"'{escaped}'"
+        elif isinstance(operand, bool):
+            return "TRUE" if operand else "FALSE"
+        elif operand is None:
+            return "NULL"
+        else:
+            return str(operand)
+
+    def __and__(self, other: "_InnerPredicateExpr") -> "_InnerPredicateExpr":
+        return _InnerPredicateExpr(self, "AND", other)
+
+    def __or__(self, other: "_InnerPredicateExpr") -> "_InnerPredicateExpr":
+        return _InnerPredicateExpr(self, "OR", other)
+
+
+def _capture_inner_predicate_proxy(predicate: Callable) -> str | None:
+    """Try to capture an inner predicate using a proxy object.
+
+    Passes a _InnerColumnProxy to the predicate lambda, so that
+    lambda r: r.value > 0 becomes "value > 0" as SQL.
+    """
+    try:
+        proxy = _InnerColumnProxy()
+        result = predicate(proxy)
+        if isinstance(result, _InnerPredicateExpr):
+            return result.to_sql()
+    except Exception:
+        pass
+    return None
+
+
+def _capture_inner_predicate_source(predicate: Callable) -> str | None:
+    """Try to capture an inner predicate lambda (r.col op val) as SQL.
+
+    Uses source code inspection and the FilterSQLParser's inner predicate logic.
+    Falls back to this when proxy-based capture fails (e.g. for complex expressions).
+    """
+    import ast
+    from ..sql_parsing import FilterSQLParser, extract_lambda_from_chain
+
+    parser = FilterSQLParser()
+
+    try:
+        import inspect
+        source = inspect.getsource(predicate).strip()
+    except (OSError, TypeError):
+        return None
+
+    if "lambda" in source:
+        source = extract_lambda_from_chain(source)
+        colon_idx = source.index(":")
+        body = source[colon_idx + 1:].strip()
+    else:
+        body = source
+        if body.startswith("return "):
+            body = body[7:].strip()
+
+    try:
+        tree = ast.parse(body, mode="eval")
+        return parser._ast_inner_predicate_to_sql(tree.body)
+    except Exception:
+        return None
+
+
+# Filterable variants that support comparison operators
+
+class _FilterableGroupCountExpr(GroupCountExpr, _ComparableGroupExpr):
+    """GroupCountExpr that also supports comparison operators for filter capture."""
+    pass
+
+
+class _FilterableGroupAggExpr(GroupAggExpr, _ComparableGroupExpr):
+    """GroupAggExpr that also supports comparison operators for filter capture."""
+
+    def __init__(self, func: str, column: str):
+        super().__init__(func, column)
+
+
+class _FilterableGroupRowColumnExpr(GroupRowColumnExpr, _ComparableGroupExpr):
+    """GroupRowColumnExpr that also supports comparison operators for filter capture."""
+
+    def __init__(self, row_type: str, column: str):
+        super().__init__(row_type, column)
+
+
+class _FilterableDeriveRowProxy(DeriveRowProxy):
+    """DeriveRowProxy that returns filterable column expressions."""
+
+    def __init__(self, row_type: str):
+        super().__init__(row_type)
+
+    def __getattr__(self, name: str) -> _FilterableGroupRowColumnExpr:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return _FilterableGroupRowColumnExpr(self._row_type, name)

--- a/py-ltseq/ltseq/joins.py
+++ b/py-ltseq/ltseq/joins.py
@@ -8,30 +8,6 @@ if TYPE_CHECKING:
 from .expr import SchemaProxy
 
 
-def _pandas_join_fallback(
-    df1: Any, df2: Any, left_key: str, right_key: str, how: str, suffix: str
-) -> Any:
-    """Execute join using pandas as fallback."""
-    import pandas as pd
-
-    pandas_how = "outer" if how == "full" else how
-    common_cols = sorted(set(df1.columns) & set(df2.columns))
-
-    if left_key == right_key and left_key in common_cols:
-        merged = pd.merge(df1, df2, on=left_key, how=pandas_how, suffixes=("", suffix))
-    else:
-        merged = pd.merge(
-            df1,
-            df2,
-            left_on=left_key,
-            right_on=right_key,
-            how=pandas_how,
-            suffixes=("", suffix),
-        )
-
-    return merged
-
-
 def _validate_join_inputs(self_table: Any, other: Any, how: str) -> None:
     """Validate join inputs and return error if invalid."""
     if not self_table._schema:
@@ -99,46 +75,17 @@ class JoinMixin:
                 other._inner, left_key_expr, right_key_expr, jtype, "_other"
             )
         except RuntimeError as e:
-            import warnings
-
-            warnings.warn(
-                f"Rust {method_name} failed: {e}. Falling back to pandas.",
-                RuntimeWarning,
-            )
-            return self._join_pandas_fallback(other, on, how, left_key_expr)
+            raise RuntimeError(
+                f"Rust {method_name} failed: {e}. "
+                f"This typically indicates an unsupported join expression. "
+                f"Simplify your join condition (e.g., use lambda a, b: a.col == b.col)."
+            ) from e
 
         result = LTSeq()
         result._inner = joined_inner
         result._schema = _build_join_result_schema(
             self._schema, other._schema, "_other"
         )
-        return result
-
-    def _join_pandas_fallback(
-        self, other: "LTSeq", on: Callable, how: str, left_key_expr: dict[str, Any]
-    ) -> "LTSeq":
-        """Fallback join implementation using pandas."""
-        from .core import LTSeq
-
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError(
-                "join() fallback requires pandas. Install with: pip install pandas"
-            )
-
-        df1 = self.to_pandas()
-        df2 = other.to_pandas()
-
-        left_key = left_key_expr.get("name", "")
-        right_key = left_key  # Simplified - assume same key name
-
-        import pyarrow as pa
-
-        merged = _pandas_join_fallback(df1, df2, left_key, right_key, how, "_other")
-        result_schema = _build_join_result_schema(self._schema, other._schema, "_other")
-        result = LTSeq.from_arrow(pa.Table.from_pandas(merged, preserve_index=False))
-        result._schema = result_schema
         return result
 
     def join(
@@ -246,13 +193,11 @@ class JoinMixin:
                 other._inner, left_key_expr, right_key_expr, jtype, "_other"
             )
         except RuntimeError as e:
-            import warnings
-
-            warnings.warn(
-                f"Rust merge join failed: {e}. Falling back to pandas.",
-                RuntimeWarning,
-            )
-            return self._join_pandas_fallback(other, on, how, left_key_expr)
+            raise RuntimeError(
+                f"Rust merge join failed: {e}. "
+                f"Ensure both tables are sorted by the join key, or use join() "
+                f"without strategy='merge' for unsorted data."
+            ) from e
 
         result = LTSeq()
         result._inner = joined_inner

--- a/py-ltseq/ltseq/mutation_mixin.py
+++ b/py-ltseq/ltseq/mutation_mixin.py
@@ -1,4 +1,8 @@
-"""Copy-on-write row-level mutation operations for LTSeq."""
+"""Copy-on-write row-level mutation operations for LTSeq.
+
+Delegates to Rust-native implementations for maximum performance.
+All operations return new LTSeq instances — the original is never modified.
+"""
 
 from typing import Any, Callable, TYPE_CHECKING
 
@@ -27,8 +31,6 @@ class MutationMixin:
             >>> t2 = t.insert(0, {"id": 99, "name": "Alice"})   # prepend
             >>> t2 = t.insert(len(t), {"id": 99, "name": "Bob"}) # append
         """
-        import pyarrow as pa
-
         from .core import LTSeq
 
         if not self._schema:
@@ -36,23 +38,10 @@ class MutationMixin:
                 "Schema not initialized. Call read_csv() first to populate the schema."
             )
 
-        pa_table = self.to_arrow()
-        pos = max(0, min(pos, len(pa_table)))
-
-        # Build single-row Arrow table matching the existing schema.
-        # Infer type from the Python value first, then cast to the column type
-        # so that implicit coercions (e.g. "0.00" str → float64) work correctly.
-        new_row_arrays = {
-            field.name: pa.array([row_dict.get(field.name)]).cast(field.type)
-            for field in pa_table.schema
-        }
-        new_row = pa.table(new_row_arrays, schema=pa_table.schema)
-
-        result_table = pa.concat_tables(
-            [pa_table.slice(0, pos), new_row, pa_table.slice(pos)]
-        )
-        result = LTSeq.from_arrow(result_table)
-        result._schema = self._schema
+        result_inner = self._inner.insert_row(pos, row_dict)
+        result = LTSeq()
+        result._inner = result_inner
+        result._schema = self._schema.copy()
         result._sort_keys = None
         return result
 
@@ -72,8 +61,6 @@ class MutationMixin:
             >>> t2 = t.delete(lambda r: r.status == "deleted")
             >>> t2 = t.delete(0)   # remove first row
         """
-        import pyarrow as pa
-
         from .core import LTSeq
 
         if not self._schema:
@@ -85,18 +72,12 @@ class MutationMixin:
             pred = predicate_or_pos
             return self.filter(lambda r, _p=pred: ~_p(r))
 
-        # integer positional delete
+        # integer positional delete — delegate to Rust
         pos = int(predicate_or_pos)
-        pa_table = self.to_arrow()
-
-        if 0 <= pos < len(pa_table):
-            # Keep rows before and after pos
-            pa_table = pa.concat_tables(
-                [pa_table.slice(0, pos), pa_table.slice(pos + 1)]
-            ) if pos < len(pa_table) - 1 else pa_table.slice(0, pos)
-
-        result = LTSeq.from_arrow(pa_table)
-        result._schema = self._schema
+        result_inner = self._inner.delete_rows(pos)
+        result = LTSeq()
+        result._inner = result_inner
+        result._schema = self._schema.copy()
         result._sort_keys = None
         return result
 
@@ -109,7 +90,7 @@ class MutationMixin:
 
         Args:
             predicate: Lambda returning a boolean expression (same style as filter())
-            **updates: Keyword arguments mapping column_name → new_value (literal or Expr)
+            **updates: Keyword arguments mapping column_name -> new_value (literal or Expr)
 
         Returns:
             New LTSeq with matching rows updated; the original is unchanged.
@@ -118,6 +99,8 @@ class MutationMixin:
             >>> t2 = t.update(lambda r: r.age > 65, discount=0.2)
             >>> t2 = t.update(lambda r: r.status == "old", status="archived")
         """
+        from .core import LTSeq
+
         if not self._schema:
             raise ValueError(
                 "Schema not initialized. Call read_csv() first to populate the schema."
@@ -126,28 +109,11 @@ class MutationMixin:
         if not updates:
             return self
 
-        import pyarrow as pa
-        import pyarrow.compute as pc
-
-        from .core import LTSeq
-
-        # Derive a boolean mask column, then apply updates using Arrow compute
-        _MASK = "__ltseq_update_mask__"
-        with_mask = self.derive(**{_MASK: predicate})
-        pa_table = with_mask.to_arrow()
-
-        mask_idx = pa_table.schema.get_field_index(_MASK)
-        mask_col = pa_table.column(mask_idx).cast(pa.bool_())
-        pa_table = pa_table.remove_column(mask_idx)
-
-        for col_name, new_val in updates.items():
-            idx = pa_table.schema.get_field_index(col_name)
-            if idx >= 0:
-                new_arr = pc.if_else(mask_col, new_val, pa_table.column(idx))
-                pa_table = pa_table.set_column(idx, col_name, new_arr)
-
-        result = LTSeq.from_arrow(pa_table)
-        result._schema = self._schema
+        expr_dict = self._capture_expr(predicate)
+        result_inner = self._inner.conditional_update(expr_dict, updates)
+        result = LTSeq()
+        result._inner = result_inner
+        result._schema = self._schema.copy()
         result._sort_keys = None
         return result
 
@@ -159,7 +125,7 @@ class MutationMixin:
 
         Args:
             pos: 0-based row index
-            **updates: Keyword arguments mapping column_name → new_value
+            **updates: Keyword arguments mapping column_name -> new_value
 
         Returns:
             New LTSeq with the row modified; the original is unchanged.
@@ -167,8 +133,6 @@ class MutationMixin:
         Example:
             >>> t2 = t.modify(0, status="active", score=100)
         """
-        import pyarrow as pa
-
         from .core import LTSeq
 
         if not self._schema:
@@ -176,20 +140,9 @@ class MutationMixin:
                 "Schema not initialized. Call read_csv() first to populate the schema."
             )
 
-        pa_table = self.to_arrow()
-
-        if 0 <= pos < len(pa_table):
-            for col_name, val in updates.items():
-                idx = pa_table.schema.get_field_index(col_name)
-                if idx >= 0:
-                    col_list = pa_table.column(idx).to_pylist()
-                    col_list[pos] = val
-                    field_type = pa_table.schema.field(col_name).type
-                    pa_table = pa_table.set_column(
-                        idx, col_name, pa.array(col_list, type=field_type)
-                    )
-
-        result = LTSeq.from_arrow(pa_table)
-        result._schema = self._schema
+        result_inner = self._inner.modify_row(pos, updates)
+        result = LTSeq()
+        result._inner = result_inner
+        result._schema = self._schema.copy()
         result._sort_keys = None
         return result

--- a/py-ltseq/ltseq/partitioning.py
+++ b/py-ltseq/ltseq/partitioning.py
@@ -7,7 +7,6 @@ all rows with the same key value regardless of position.
 
 from typing import Any, Callable, Iterator
 
-
 class SQLPartitionedTable:
     """
     SQL-based partitioned table for fast column-based partitioning.
@@ -57,11 +56,12 @@ class SQLPartitionedTable:
         if self._partitions_cache is None:
             self._partitions_cache = {}
 
-        # Normalize key to tuple
-        if len(self._columns) == 1:
-            key_tuple = (key,) if not isinstance(key, tuple) else key
-        else:
-            key_tuple = key if isinstance(key, tuple) else (key,)
+        key_tuple = self._normalize_key(key)
+
+        if self._keys_cache is None:
+            self._compute_keys()
+        if key not in self._keys_cache and key_tuple not in self._keys_cache:
+            raise KeyError(f"Partition key '{key}' not found")
 
         # Check cache first
         if key_tuple in self._partitions_cache:
@@ -93,6 +93,11 @@ class SQLPartitionedTable:
         except Exception as e:
             raise KeyError(f"Failed to access partition for key {key}: {e}")
 
+    def _normalize_key(self, key: Any) -> tuple[Any, ...]:
+        if len(self._columns) == 1:
+            return (key,) if not isinstance(key, tuple) else key
+        return key if isinstance(key, tuple) else (key,)
+
     def keys(self) -> list[Any]:
         """
         Return all partition keys.
@@ -105,18 +110,19 @@ class SQLPartitionedTable:
         return self._keys_cache  # type: ignore[return-value]
 
     def _compute_keys(self) -> None:
-        """Compute distinct keys using SQL."""
-        # Select just the partition columns
+        """Compute distinct keys using Arrow (avoids pandas round-trip)."""
         distinct_ltseq = self._ltseq.select(*self._columns).distinct()
-        df = distinct_ltseq.to_pandas()
+        pa_table = distinct_ltseq.to_arrow()
 
-        # Extract keys from the distinct result
         keys = []
-        for _, row in df.iterrows():
-            if len(self._columns) == 1:
-                keys.append(row[self._columns[0]])
-            else:
-                keys.append(tuple(row[col] for col in self._columns))
+        if len(self._columns) == 1:
+            col_name = self._columns[0]
+            col = pa_table.column(col_name)
+            keys = col.to_pylist()
+        else:
+            columns = [pa_table.column(c).to_pylist() for c in self._columns]
+            for i in range(pa_table.num_rows):
+                keys.append(tuple(columns[j][i] for j in range(len(self._columns))))
 
         self._keys_cache = keys
 
@@ -231,6 +237,29 @@ class PartitionedTable:
         self._ltseq = ltseq_instance
         self._partition_fn = partition_fn
         self._partitions_cache: dict[Any, "LTSeq"] | None = None
+        self._delegate = self._build_delegate()
+
+    def _build_delegate(self) -> SQLPartitionedTable:
+        """Build the SQL-backed delegate for capturable partition expressions."""
+        try:
+            expr_dict = self._ltseq._capture_expr(self._partition_fn)
+        except Exception as e:
+            raise ValueError(
+                "partition(by=callable) only supports simple column expressions such as "
+                "lambda r: r.region. Complex Python logic is no longer supported "
+                "because it forces internal materialization. "
+                f"Capture failed with: {e}"
+            ) from e
+
+        columns = _partition_expr_to_columns(expr_dict)
+        if columns is None:
+            raise ValueError(
+                "partition(by=callable) only supports simple column expressions such as "
+                "lambda r: r.region or lambda r: r.year. Derived Python expressions "
+                "must use explicit column partitioning or another API."
+            )
+
+        return SQLPartitionedTable(self._ltseq, columns)
 
     def __getitem__(self, key: Any) -> "LTSeq":
         """
@@ -248,13 +277,7 @@ class PartitionedTable:
         Example:
             >>> west_sales = partitions["West"]
         """
-        if self._partitions_cache is None:
-            self._materialize_partitions()
-
-        if key not in self._partitions_cache:
-            raise KeyError(f"Partition key '{key}' not found")
-
-        return self._partitions_cache[key]
+        return self._delegate[key]
 
     def keys(self) -> list[Any]:
         """
@@ -267,9 +290,7 @@ class PartitionedTable:
             >>> regions = partitions.keys()
             >>> print(regions)  # ['West', 'East', 'Central']
         """
-        if self._partitions_cache is None:
-            self._materialize_partitions()
-        return list(self._partitions_cache.keys())  # type: ignore[union-attr]
+        return self._delegate.keys()
 
     def values(self) -> list["LTSeq"]:
         """
@@ -278,9 +299,7 @@ class PartitionedTable:
         Returns:
             List of LTSeq objects, one per partition
         """
-        if self._partitions_cache is None:
-            self._materialize_partitions()
-        return list(self._partitions_cache.values())  # type: ignore[union-attr]
+        return self._delegate.values()
 
     def items(self) -> Iterator[tuple[Any, "LTSeq"]]:
         """
@@ -293,9 +312,7 @@ class PartitionedTable:
             >>> for region, data in partitions.items():
             ...     print(f"{region}: {len(data)} rows")
         """
-        if self._partitions_cache is None:
-            self._materialize_partitions()
-        return iter(self._partitions_cache.items())  # type: ignore[union-attr]
+        return self._delegate.items()
 
     def __iter__(self) -> Iterator["LTSeq"]:
         """
@@ -313,9 +330,7 @@ class PartitionedTable:
         Returns:
             Count of distinct partition keys
         """
-        if self._partitions_cache is None:
-            self._materialize_partitions()
-        return len(self._partitions_cache)  # type: ignore[arg-type]
+        return len(self._delegate)
 
     def map(self, fn: Callable[["LTSeq"], "LTSeq"]) -> "PartitionedTable":
         """
@@ -335,12 +350,8 @@ class PartitionedTable:
             >>> for region, total_row in totals.items():
             ...     print(f"{region}: {total_row}")
         """
-        if self._partitions_cache is None:
-            self._materialize_partitions()
-
-        # Apply function to each partition
         transformed_partitions: dict[Any, "LTSeq"] = {}
-        for key, partition_table in self._partitions_cache.items():  # type: ignore[union-attr]
+        for key, partition_table in self._delegate.items():
             try:
                 result = fn(partition_table)
                 transformed_partitions[key] = result
@@ -364,52 +375,28 @@ class PartitionedTable:
         Compute the partitions (triggered on first access).
 
         This method:
-        1. Gets data from the underlying table via pandas
+        1. Gets data from the underlying table via Arrow
         2. Evaluates partition function on each row
         3. Groups rows by partition key
         4. Creates LTSeq for each partition
         5. Caches results
-
-        Note: Requires pandas. If not installed, raises RuntimeError.
         """
-        try:
-            import pandas as pd
-        except ImportError:
-            raise RuntimeError(
-                "partition() requires pandas. Install it with: pip install pandas"
-            )
+        # Retained for backward compatibility with tests/internal calls.
+        # PartitionedTable now delegates to SQLPartitionedTable instead of
+        # materializing Arrow data in Python.
+        self._partitions_cache = {key: table for key, table in self._delegate.items()}
 
-        # Get data as pandas DataFrame
-        df = self._ltseq.to_pandas()
-        rows = df.to_dict("records")
 
-        # Evaluate partition function on each row and group
-        partitions_dict: dict[Any, list[dict]] = {}
+def _partition_expr_to_columns(expr_dict: dict[str, Any]) -> tuple[str, ...] | None:
+    """Convert a captured partition lambda into SQL partition columns.
 
-        for row_idx, row_data in enumerate(rows):
-            try:
-                # Create a proxy-like object to pass to the partition function
-                row_proxy = _RowProxy(row_data)
-                partition_key = self._partition_fn(row_proxy)
-
-                if partition_key not in partitions_dict:
-                    partitions_dict[partition_key] = []
-                partitions_dict[partition_key].append(row_data)
-            except Exception as e:
-                raise RuntimeError(
-                    f"Error evaluating partition function on row {row_idx}: {e}"
-                )
-
-        # Convert grouped rows back to LTSeq tables
-        self._partitions_cache = {}
-        for key, row_list in partitions_dict.items():
-            try:
-                partition_table = self._ltseq.__class__._from_rows(
-                    row_list, self._ltseq._schema
-                )
-                self._partitions_cache[key] = partition_table
-            except Exception as e:
-                raise RuntimeError(f"Error creating LTSeq for partition '{key}': {e}")
+    Strict-mode partitioning accepts only direct column references so the
+    implementation can stay inside Rust/DataFusion without internal Arrow
+    materialization.
+    """
+    if expr_dict.get("type") == "Column":
+        return (expr_dict["name"],)
+    return None
 
 
 class _PrecomputedPartitionedTable(PartitionedTable):
@@ -430,30 +417,25 @@ class _PrecomputedPartitionedTable(PartitionedTable):
         self._ltseq = None
         self._partition_fn = None
         self._partitions_cache = precomputed_partitions
+        self._delegate = None
+
+    def __getitem__(self, key: Any) -> "LTSeq":
+        if key not in self._partitions_cache:
+            raise KeyError(f"Partition key '{key}' not found")
+        return self._partitions_cache[key]
+
+    def keys(self) -> list[Any]:
+        return list(self._partitions_cache.keys())
+
+    def values(self) -> list["LTSeq"]:
+        return list(self._partitions_cache.values())
+
+    def items(self) -> Iterator[tuple[Any, "LTSeq"]]:
+        return iter(self._partitions_cache.items())
+
+    def __len__(self) -> int:
+        return len(self._partitions_cache)
 
     def _materialize_partitions(self) -> None:
         """Override: partitions are already materialized."""
         pass  # No-op since _partitions_cache is already set
-
-
-class _RowProxy:
-    """
-    Proxy object for accessing row data in partition function.
-
-    Allows syntax like: partition_fn(lambda r: r.region)
-    """
-
-    def __init__(self, row_data: dict[str, Any]):
-        """Initialize with row dictionary."""
-        self._data = row_data
-
-    def __getattr__(self, name: str) -> Any:
-        """Get column value by name."""
-        if name.startswith("_"):
-            # Allow access to internal attributes
-            return object.__getattribute__(self, name)
-
-        if name not in self._data:
-            raise AttributeError(f"Column '{name}' not found in row")
-
-        return self._data[name]

--- a/py-ltseq/tests/test_partition_by.py
+++ b/py-ltseq/tests/test_partition_by.py
@@ -143,6 +143,13 @@ class TestPartitionValidation:
         with pytest.raises(TypeError):
             t.partition(123)
 
+    def test_partition_complex_lambda_raises(self, sample_csv):
+        """Callable partitioning should reject non-capturable Python logic."""
+        t = LTSeq.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="only supports simple column expressions"):
+            t.partition(by=lambda r: "low" if r.amount < 200 else "high")
+
 
 class TestPartitionEquivalence:
     """Test that partition(col) produces same results as partition(lambda)."""

--- a/py-ltseq/tests/test_partitioning.py
+++ b/py-ltseq/tests/test_partitioning.py
@@ -153,16 +153,12 @@ class TestPartitionWithDifferentKeys:
         assert "West" in partitions.keys()
         assert "East" in partitions.keys()
 
-    def test_partition_numeric_key(self):
-        """partition() should work with numeric partition keys."""
+    def test_partition_complex_lambda_raises(self):
+        """partition() should reject non-capturable Python logic."""
         t = LTSeq.read_csv("py-ltseq/tests/test_data/test_agg.csv")
 
-        # Partition by amount range
-        partitions = t.partition(by=lambda r: "low" if int(r.amount) < 1000 else "high")
-
-        assert len(partitions) >= 1
-        keys = partitions.keys()
-        assert "low" in keys or "high" in keys
+        with pytest.raises(ValueError, match="only supports simple column expressions"):
+            t.partition(by=lambda r: "low" if int(r.amount) < 1000 else "high")
 
 
 class TestPartitionErrorHandling:
@@ -178,11 +174,9 @@ class TestPartitionErrorHandling:
     def test_partition_with_invalid_column_raises(self):
         """partition() with non-existent column should raise."""
         t = LTSeq.read_csv("py-ltseq/tests/test_data/test_agg.csv")
-        partitions = t.partition(by=lambda r: r.nonexistent_column)
 
-        # Error should occur when we try to access partitions
-        with pytest.raises(RuntimeError):
-            _ = partitions.keys()
+        with pytest.raises(ValueError, match="Capture failed"):
+            t.partition(by=lambda r: r.nonexistent_column)
 
 
 class TestPartitionCaching:

--- a/py-ltseq/tests/test_stateful_scan.py
+++ b/py-ltseq/tests/test_stateful_scan.py
@@ -42,6 +42,17 @@ def prices_csv():
 class TestStatefulScanBasic:
     """Basic functionality tests."""
 
+    def test_stateful_scan_emits_small_table_warning(self, sample_csv):
+        """stateful_scan() should explicitly warn about materialization."""
+        t = LTSeq.read_csv(sample_csv).sort("date")
+
+        with pytest.warns(UserWarning, match="small-table convenience API"):
+            t.stateful_scan(
+                func=lambda s, r: s + r["value"],
+                init=0,
+                output_col="running_total",
+            )
+
     def test_compound_growth(self, sample_csv):
         """Test compound growth calculation (main use case from API spec)."""
         t = LTSeq.read_csv(sample_csv).sort("date")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1126,6 +1126,43 @@ impl LTSeqTable {
     fn step(&self, n: usize) -> PyResult<LTSeqTable> {
         crate::ops::set_ops::step_impl(self, n)
     }
+
+    // ── Mutation operations ─────────────────────────────────────
+
+    /// Insert a row at the given 0-based position (copy-on-write).
+    ///
+    /// The row data is provided as a Python dict mapping column names to values.
+    /// Position is clamped: negative → 0, beyond end → append.
+    fn insert_row(&self, pos: i64, row_dict: &Bound<'_, PyDict>) -> PyResult<LTSeqTable> {
+        crate::ops::mutation::insert_row_impl(self, pos, row_dict)
+    }
+
+    /// Delete the row at the given 0-based position (copy-on-write).
+    ///
+    /// Out-of-range positions are silently ignored (no-op).
+    fn delete_rows(&self, pos: i64) -> PyResult<LTSeqTable> {
+        crate::ops::mutation::delete_rows_impl(self, pos)
+    }
+
+    /// Conditionally update columns where predicate is True (copy-on-write).
+    ///
+    /// The predicate is the same expression format used by filter().
+    /// Updates is a dict mapping column names to new values (literals only).
+    fn conditional_update(
+        &self,
+        expr_dict: &Bound<'_, PyDict>,
+        updates: &Bound<'_, PyDict>,
+    ) -> PyResult<LTSeqTable> {
+        crate::ops::mutation::conditional_update_impl(self, expr_dict, updates)
+    }
+
+    /// Modify specific columns in the row at 0-based position (copy-on-write).
+    ///
+    /// Updates is a dict mapping column names to new values.
+    /// Out-of-range positions are silently ignored (no-op).
+    fn modify_row(&self, pos: i64, updates: &Bound<'_, PyDict>) -> PyResult<LTSeqTable> {
+        crate::ops::mutation::modify_row_impl(self, pos, updates)
+    }
 }
 
 #[pymodule]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -60,5 +60,6 @@ pub(crate) mod asof_join;
 pub(crate) mod derive_sql;
 pub(crate) mod grouping;
 pub(crate) mod join;
+pub(crate) mod mutation;
 pub(crate) mod pivot;
 pub(crate) mod sort;

--- a/src/ops/mutation.rs
+++ b/src/ops/mutation.rs
@@ -1,0 +1,381 @@
+//! Row-level mutation operations: insert_row, delete_rows, conditional_update, modify_row
+
+use crate::engine::RUNTIME;
+use crate::error::LtseqError;
+use crate::LTSeqTable;
+use datafusion::arrow::array::*;
+use datafusion::arrow::datatypes::*;
+use datafusion::common::ScalarValue;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::sync::Arc;
+
+// ============================================================================
+// insert_row: Insert a row at a given position
+// ============================================================================
+
+pub fn insert_row_impl(
+    table: &LTSeqTable,
+    pos: i64,
+    row_dict: &Bound<'_, PyDict>,
+) -> PyResult<LTSeqTable> {
+    let (df, schema) = table.require_df_and_schema()?;
+
+    let batches = RUNTIME
+        .block_on(async { (**df).clone().collect().await })
+        .map_err(|e| LtseqError::with_context("Failed to collect data", e))?;
+
+    let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    let pos = pos.clamp(0, num_rows as i64) as usize;
+
+    let new_batch = row_dict_to_batch(row_dict, schema)?;
+
+    if num_rows == 0 {
+        return LTSeqTable::from_batches(
+            Arc::clone(&table.session),
+            vec![new_batch],
+            table.sort_exprs.clone(),
+            table.source_parquet_path.clone(),
+        );
+    }
+
+    let mut result_batches = Vec::new();
+    let mut row_offset = 0usize;
+    let mut inserted = false;
+
+    for batch in &batches {
+        let batch_len = batch.num_rows();
+        if inserted {
+            result_batches.push(batch.clone());
+            row_offset += batch_len;
+            continue;
+        }
+
+        let insert_pos_in_batch = pos.saturating_sub(row_offset);
+        if insert_pos_in_batch < batch_len {
+            if insert_pos_in_batch > 0 {
+                result_batches.push(batch.slice(0, insert_pos_in_batch));
+            }
+            result_batches.push(new_batch.clone());
+            if insert_pos_in_batch < batch_len {
+                result_batches.push(batch.slice(insert_pos_in_batch, batch_len - insert_pos_in_batch));
+            }
+            inserted = true;
+        } else {
+            result_batches.push(batch.clone());
+        }
+        row_offset += batch_len;
+    }
+
+    if !inserted {
+        result_batches.push(new_batch);
+    }
+
+    LTSeqTable::from_batches(
+        Arc::clone(&table.session),
+        result_batches,
+        table.sort_exprs.clone(),
+        table.source_parquet_path.clone(),
+    )
+}
+
+// ============================================================================
+// delete_rows: Delete row at a given position
+// ============================================================================
+
+pub fn delete_rows_impl(table: &LTSeqTable, pos: i64) -> PyResult<LTSeqTable> {
+    let (df, schema) = table.require_df_and_schema()?;
+
+    let batches = RUNTIME
+        .block_on(async { (**df).clone().collect().await })
+        .map_err(|e| LtseqError::with_context("Failed to collect data", e))?;
+
+    let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+
+    if pos < 0 || pos as usize >= num_rows {
+        return Ok(LTSeqTable::from_df_with_schema(
+            Arc::clone(&table.session),
+            (**df).clone(),
+            Arc::clone(schema),
+            table.sort_exprs.clone(),
+            table.source_parquet_path.clone(),
+        ));
+    }
+
+    let pos = pos as usize;
+    let mut result_batches = Vec::new();
+    let mut row_offset = 0usize;
+
+    for batch in &batches {
+        let batch_len = batch.num_rows();
+        let delete_pos_in_batch = pos.saturating_sub(row_offset);
+
+        if delete_pos_in_batch >= batch_len {
+            result_batches.push(batch.clone());
+        } else {
+            if delete_pos_in_batch > 0 {
+                result_batches.push(batch.slice(0, delete_pos_in_batch));
+            }
+            let after_start = delete_pos_in_batch + 1;
+            if after_start < batch_len {
+                result_batches.push(batch.slice(after_start, batch_len - after_start));
+            }
+        }
+        row_offset += batch_len;
+    }
+
+    LTSeqTable::from_batches(
+        Arc::clone(&table.session),
+        result_batches,
+        table.sort_exprs.clone(),
+        table.source_parquet_path.clone(),
+    )
+}
+
+// ============================================================================
+// conditional_update: Update columns where predicate is True
+// ============================================================================
+
+pub fn conditional_update_impl(
+    table: &LTSeqTable,
+    expr_dict: &Bound<'_, PyDict>,
+    updates: &Bound<'_, PyDict>,
+) -> PyResult<LTSeqTable> {
+    let (df, schema) = table.require_df_and_schema()?;
+
+    if updates.is_empty() {
+        return Ok(LTSeqTable::from_df_with_schema(
+            Arc::clone(&table.session),
+            (**df).clone(),
+            Arc::clone(schema),
+            table.sort_exprs.clone(),
+            table.source_parquet_path.clone(),
+        ));
+    }
+
+    let predicate_expr = crate::transpiler::pyexpr_to_datafusion(
+        crate::types::dict_to_py_expr(expr_dict)?,
+        schema,
+    )
+    .map_err(LtseqError::Validation)?;
+
+    let mut update_map = std::collections::HashMap::<String, ScalarValue>::new();
+    for (key, val) in updates.iter() {
+        let col_name: String = key
+            .extract()
+            .map_err(|e| LtseqError::with_context("Invalid column name", e))?;
+        let field = schema.field_with_name(&col_name).map_err(|e| {
+            LtseqError::Validation(format!("Column '{}' not found: {}", col_name, e))
+        })?;
+        let dt = field.data_type();
+        let scalar = python_value_to_scalar(&val, dt).ok_or_else(|| {
+            LtseqError::Validation(format!("Cannot convert value for column '{}'", col_name))
+        })?;
+        update_map.insert(col_name, scalar);
+    }
+
+    let result_df = RUNTIME
+        .block_on(async {
+            use datafusion::common::Column;
+            use datafusion::logical_expr::case;
+            use datafusion::prelude::lit;
+
+            let mut select_exprs = Vec::new();
+
+            for field in schema.fields() {
+                let col_name = field.name();
+                let col_expr = datafusion::prelude::Expr::Column(Column::new_unqualified(col_name));
+
+                if let Some(scalar) = update_map.get(col_name) {
+                    let updated_expr = case(predicate_expr.clone())
+                        .when(lit(true), lit(scalar.clone()))
+                        .otherwise(col_expr.clone())
+                        .map_err(|e| format!("Failed to build CASE for '{}': {}", col_name, e))?
+                        .alias(col_name);
+                    select_exprs.push(updated_expr);
+                } else {
+                    select_exprs.push(col_expr);
+                }
+            }
+
+            (**df)
+                .clone()
+                .select(select_exprs)
+                .map_err(|e| format!("Conditional update execution failed: {}", e))
+        })
+        .map_err(LtseqError::Runtime)?;
+
+    Ok(LTSeqTable::from_df_with_schema(
+        Arc::clone(&table.session),
+        result_df,
+        Arc::clone(schema),
+        table.sort_exprs.clone(),
+        table.source_parquet_path.clone(),
+    ))
+}
+
+// ============================================================================
+// modify_row: Modify specific columns at a row position
+// ============================================================================
+
+pub fn modify_row_impl(
+    table: &LTSeqTable,
+    pos: i64,
+    updates: &Bound<'_, PyDict>,
+) -> PyResult<LTSeqTable> {
+    let (df, schema) = table.require_df_and_schema()?;
+
+    let batches = RUNTIME
+        .block_on(async { (**df).clone().collect().await })
+        .map_err(|e| LtseqError::with_context("Failed to collect data", e))?;
+
+    let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+
+    if pos < 0 || pos as usize >= num_rows || updates.is_empty() {
+        return Ok(LTSeqTable::from_df_with_schema(
+            Arc::clone(&table.session),
+            (**df).clone(),
+            Arc::clone(schema),
+            table.sort_exprs.clone(),
+            table.source_parquet_path.clone(),
+        ));
+    }
+
+    let pos = pos as usize;
+
+    let update_map: Vec<(String, ScalarValue)> = updates
+        .iter()
+        .filter_map(|(key, val)| {
+            let col_name: String = key.extract().ok()?;
+            let field = schema.field_with_name(&col_name).ok()?;
+            let dt = field.data_type();
+            let scalar = python_value_to_scalar(&val, dt)?;
+            Some((col_name, scalar))
+        })
+        .collect();
+
+    let mut result_batches = Vec::new();
+    let mut row_offset = 0usize;
+
+    for batch in &batches {
+        let batch_len = batch.num_rows();
+        let row_start = row_offset;
+        let row_end = row_offset + batch_len;
+
+        if pos < row_start || pos >= row_end {
+            result_batches.push(batch.clone());
+        } else {
+            let local_pos = pos - row_start;
+
+            let mut new_columns: Vec<ArrayRef> = Vec::new();
+            for (i, field) in schema.fields().iter().enumerate() {
+                let col = batch.column(i).clone();
+                let col_name = field.name().as_str();
+
+                if let Some((_, scalar)) = update_map.iter().find(|(c, _)| c == col_name) {
+                    let new_val: ArrayRef = scalar.to_array_of_size(1)
+                        .map_err(|e| LtseqError::with_context("Failed to create scalar array", e))?;
+                    let updated_col = compute_replace_at(&col, local_pos, &new_val.slice(0, 1))
+                        .map_err(|e| LtseqError::with_context("replace_at failed", e))?;
+                    new_columns.push(updated_col);
+                } else {
+                    new_columns.push(col);
+                }
+            }
+            let new_batch = RecordBatch::try_new(Arc::clone(schema), new_columns)
+                .map_err(|e| LtseqError::with_context("Failed to create batch", e))?;
+            result_batches.push(new_batch);
+        }
+        row_offset += batch_len;
+    }
+
+    LTSeqTable::from_batches(
+        Arc::clone(&table.session),
+        result_batches,
+        table.sort_exprs.clone(),
+        table.source_parquet_path.clone(),
+    )
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn row_dict_to_batch(
+    row_dict: &Bound<'_, PyDict>,
+    schema: &Arc<Schema>,
+) -> PyResult<RecordBatch> {
+    let mut arrays: Vec<ArrayRef> = Vec::new();
+    let mut fields: Vec<Field> = Vec::new();
+
+    for field in schema.fields() {
+        let col_name = field.name().as_str();
+        let dt = field.data_type();
+        let val_opt = row_dict.get_item(col_name)?;
+        let scalar = match val_opt {
+            None => ScalarValue::try_from(dt)
+                .map_err(|e| LtseqError::with_context("Failed to create null scalar", e))?,
+            Some(val) => python_value_to_scalar(&val, dt).ok_or_else(|| LtseqError::Validation(
+                format!("Cannot convert Python value for column '{}'", col_name)
+            ))?,
+        };
+        let arr: ArrayRef = scalar.to_array_of_size(1)
+            .map_err(|e| LtseqError::with_context("Failed to create array from scalar", e))?;
+        arrays.push(arr);
+        fields.push((**field).clone());
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)
+        .map_err(|e| LtseqError::with_context("Failed to create record batch for insert", e).into())
+}
+
+fn python_value_to_scalar(val: &Bound<'_, PyAny>, dt: &DataType) -> Option<ScalarValue> {
+    if val.is_none() {
+        return ScalarValue::try_from(dt).ok();
+    }
+    match dt {
+        DataType::Int64 => val.extract::<i64>().ok().map(|v| ScalarValue::Int64(Some(v))),
+        DataType::Int32 => val.extract::<i32>().ok().map(|v| ScalarValue::Int32(Some(v))),
+        DataType::Int16 => val.extract::<i16>().ok().map(|v| ScalarValue::Int16(Some(v))),
+        DataType::Int8 => val.extract::<i8>().ok().map(|v| ScalarValue::Int8(Some(v))),
+        DataType::Float64 => val.extract::<f64>().ok().map(|v| ScalarValue::Float64(Some(v))),
+        DataType::Float32 => val.extract::<f32>().ok().map(|v| ScalarValue::Float32(Some(v))),
+        DataType::Utf8 | DataType::LargeUtf8 => {
+            val.extract::<String>().ok().map(|v| ScalarValue::Utf8(Some(v)))
+        }
+        DataType::Boolean => val.extract::<bool>().ok().map(|v| ScalarValue::Boolean(Some(v))),
+        DataType::Date32 => val.extract::<i32>().ok().map(|v| ScalarValue::Date32(Some(v))),
+        DataType::Date64 => val.extract::<i64>().ok().map(|v| ScalarValue::Date64(Some(v))),
+        _ => None,
+    }
+}
+
+fn compute_replace_at(
+    col: &ArrayRef,
+    pos: usize,
+    new_val: &ArrayRef,
+) -> Result<ArrayRef, datafusion::arrow::error::ArrowError> {
+    use datafusion::arrow::compute::cast;
+
+    let col_type = col.data_type();
+    let cast_new_val = if new_val.data_type() != col_type {
+        cast(new_val, col_type)?
+    } else {
+        new_val.clone()
+    };
+
+    let len = col.len();
+
+    let mut new_arrays: Vec<ArrayRef> = Vec::new();
+
+    if pos > 0 {
+        new_arrays.push(col.slice(0, pos));
+    }
+    new_arrays.push(cast_new_val.slice(0, 1));
+    if pos + 1 < len {
+        new_arrays.push(col.slice(pos + 1, len - pos - 1));
+    }
+
+    let refs: Vec<&dyn Array> = new_arrays.iter().map(|a| a.as_ref()).collect();
+    datafusion::arrow::compute::concat(&refs)
+}


### PR DESCRIPTION
## Summary
- remove silent pandas/pyarrow fallback paths in nested filtering, joins, partitioning, and mutation APIs so issue #69 stays on explicit Rust/DataFusion or explicit error/warning paths
- add Rust-native row mutation methods and tighten `conditional_update()` to a single DataFusion projection plan instead of filter/collect/rebuild behavior
- document and benchmark the remaining explicit exception path for `stateful_scan()`, and add regression coverage for strict callable partitioning and warning behavior

## Validation
- `.venv/bin/maturin develop`
- `.venv/bin/pytest py-ltseq/tests/ -v`
- `cargo test`

## Notes
- `stateful_scan()` is kept as an explicit small-table convenience API with a runtime warning instead of a silent materialization path
- benchmark artifacts for the issue-69 hotspots are included in `benchmarks/bench_pandas_bypass.py` and `benchmarks/pandas_bypass_results.json`