### PR TITLE
fix: remove noisy join warnings and autoloop xfails

### DIFF
--- a/benchmarks/autoresearch/pilot/scripts/autoloop.sh
+++ b/benchmarks/autoresearch/pilot/scripts/autoloop.sh
@@ -699,11 +699,15 @@ get_field() {
   local file="$1"
   local key="$2"
   local line
-  line="$(rg "^${key}=" "$file" | head -1 || true)"
-  if [[ -z "$line" ]]; then
-    return 0
-  fi
-  printf '%s' "${line#*=}" | tr -d '\r'
+
+  [[ -r "$file" ]] || return 0
+
+  while IFS= read -r line; do
+    if [[ "$line" == "$key="* ]]; then
+      printf '%s' "${line#*=}" | tr -d '\r'
+      return 0
+    fi
+  done < "$file"
 }
 
 next_issue_id() {

--- a/py-ltseq/ltseq/joins.py
+++ b/py-ltseq/ltseq/joins.py
@@ -340,19 +340,6 @@ class JoinMixin(LTSeqLike):
         except Exception as e:
             raise TypeError(f"Invalid join condition: {e}")
 
-        # Warn if no schema overlap (likely user error)
-        left_cols = set(self._schema.keys())
-        right_cols = set(other._schema.keys())
-        if not left_cols & right_cols:
-            import warnings
-
-            warnings.warn(
-                "No overlapping column names between tables. "
-                "This may indicate an error in join condition. "
-                "Use lambda a, b: a.left_key == b.right_key syntax.",
-                UserWarning,
-            )
-
         from .helpers import _extract_join_keys
 
         left_key_expr, right_key_expr, _ = _extract_join_keys(

--- a/py-ltseq/tests/test_benchmark_autoresearch_controller.py
+++ b/py-ltseq/tests/test_benchmark_autoresearch_controller.py
@@ -31,6 +31,23 @@ def write_summary(path: Path, data_file: str) -> None:
     path.write_text(json.dumps({"data_file": data_file}), encoding="utf-8")
 
 
+def test_get_field_returns_empty_for_missing_file(tmp_path):
+    missing_file = tmp_path / "missing.txt"
+
+    script = textwrap.dedent(
+        f"""
+        source {autoloop_path()!s}
+        value="$(get_field {missing_file!s} status)"
+        printf 'value=%s' "$value"
+        """
+    )
+
+    result = run_autoloop_shell(script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "value="
+
+
 def test_baseline_matches_requested_data_rejects_dataset_mismatch(tmp_path):
     baseline_summary = tmp_path / "benchmark-summary.json"
     write_summary(baseline_summary, "benchmarks/data/hits_sample.parquet")
@@ -141,7 +158,6 @@ def test_validate_candidate_scope_distinguishes_empty_from_out_of_scope(tmp_path
     assert out_of_scope_result.stdout.endswith("src/lib.rs")
 
 
-@pytest.mark.xfail(reason="Shell integration: get_field/rg parsing differs in CI environment")
 def test_run_iteration_clears_root_candidate_and_diff_on_gate_failure(tmp_path):
     worktree = tmp_path / "worktree"
     report_dir = tmp_path / "reports"
@@ -175,7 +191,7 @@ def test_run_iteration_clears_root_candidate_and_diff_on_gate_failure(tmp_path):
         "if [[ \"$1\" == \"benchmarks/autoresearch/pilot/scripts/benchmark_gate.py\" ]]; then\n"
         "  exit 1\n"
         "fi\n"
-        "exec /usr/bin/python \"$@\"\n",
+        "exec python3 \"$@\"\n",
         encoding="utf-8",
     )
     (fake_bin_dir / "python").chmod(0o755)
@@ -271,7 +287,6 @@ def test_run_baseline_if_needed_logs_reuse_for_matching_dataset(tmp_path):
     )
 
 
-@pytest.mark.xfail(reason="Shell integration: artifact paths differ in CI environment")
 def test_run_iteration_archives_artifacts_and_records_result(tmp_path):
     worktree = tmp_path / "worktree"
     report_dir = tmp_path / "reports"
@@ -325,7 +340,7 @@ def test_run_iteration_archives_artifacts_and_records_result(tmp_path):
         "JSON\n"
         "  exit 0\n"
         "fi\n"
-        "exec /usr/bin/python3 \"$@\"\n",
+        "exec python3 \"$@\"\n",
         encoding="utf-8",
     )
     (fake_bin_dir / "python").chmod(0o755)

--- a/py-ltseq/tests/test_semi_anti_joins.py
+++ b/py-ltseq/tests/test_semi_anti_joins.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import warnings
 
 import pytest
 
@@ -334,17 +335,29 @@ class TestValidationErrors:
 
 
 class TestSchemaOverlapWarning:
-    """Tests for schema overlap warning."""
+    """Tests for avoiding noisy schema overlap warnings."""
 
-    def test_no_overlap_warning(self, users_csv, products_csv):
-        """Warning is raised when tables have no overlapping columns."""
+    def test_no_warning_for_valid_different_column_names(self, users_csv, orders_csv):
+        """Valid foreign-key style joins should not warn just because names differ."""
+        users = LTSeq.read_csv(users_csv)
+        orders = LTSeq.read_csv(orders_csv)
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            users.semi_join(orders, on=lambda u, o: u.id == o.user_id)
+
+        assert len(record) == 0
+
+    def test_no_warning_for_explicit_non_overlapping_join(self, users_csv, products_csv):
+        """Explicit join conditions should not warn just because schemas differ."""
         users = LTSeq.read_csv(users_csv)
         products = LTSeq.read_csv(products_csv)
 
-        # Users and products have no overlapping columns
-        with pytest.warns(UserWarning, match="No overlapping column names"):
-            # This will still work but warn
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
             users.semi_join(products, on=lambda u, p: u.id == p.product_id)
+
+        assert len(record) == 0
 
 
 class TestCompositeKeys:


### PR DESCRIPTION
## Summary
- remove noisy semi/anti-join warnings for explicit join conditions
- make autoloop decision field parsing shell-native and resilient to missing files
- unskip benchmark controller tests now that the shell integration bug is fixed

## Test Plan
- [x] pytest py-ltseq/tests/test_benchmark_autoresearch_controller.py -q
- [x] pytest py-ltseq/tests/test_semi_anti_joins.py -q
- [x] pytest py-ltseq/tests/ -q