### PR TITLE
fix: SortSpec 重构——排序方向进入表元数据，修复 DESC 窗口函数与 Parquet 快速路径失效 (#95)

### DIFF
--- a/py-ltseq/ltseq/transforms.py
+++ b/py-ltseq/ltseq/transforms.py
@@ -578,7 +578,7 @@ class TransformMixin(LookupMixin, LTSeqLike):
             raise TypeError(f"desc must be bool or list, got {type(desc).__name__}")
 
         key_exprs = _collect_key_exprs(keys, self._schema, self._capture_expr)
-        result_inner = self._inner.assume_sorted(key_exprs)
+        result_inner = self._inner.assume_sorted(key_exprs, desc_list)
 
         result = LTSeq._from_inner(result_inner)
         result._schema = self._schema.copy()

--- a/py-ltseq/tests/test_parquet_fast_path_metadata.py
+++ b/py-ltseq/tests/test_parquet_fast_path_metadata.py
@@ -1,0 +1,38 @@
+"""Regression tests for issue #95 (Bug 2): metadata invalidation of the
+Parquet fast path.
+
+filter() used to keep source_parquet_path while returning a lazy filtered
+DataFrame; downstream Parquet fast paths (group_ordered count) re-read the
+raw file directly, silently ignoring the filter.
+"""
+
+import os
+import tempfile
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from ltseq import LTSeq
+
+
+@pytest.fixture
+def presorted_parquet():
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        path = f.name
+    t = pa.table({"ts": [1, 2, 3, 4, 5], "val": [10, 20, 30, 40, 50]})
+    pq.write_table(t, path)
+    yield path
+    os.unlink(path)
+
+
+class TestFilterBeforeGroupOrderedCount:
+    def test_filter_invalidates_parquet_fast_path(self, presorted_parquet):
+        """filter → group_ordered → count must NOT use raw Parquet fast path."""
+        t = LTSeq.read_parquet(presorted_parquet).assume_sorted("ts")
+        filtered = t.filter(lambda r: r.val >= 30)
+        # All values are distinct, so every row starts a new group: the group
+        # count equals the row count. Filtered: 3. Raw (unfiltered) file: 5.
+        grouped = filtered.group_ordered(lambda r: r.val != r.val.shift(1))
+        count = grouped.first().count()
+        assert count == 3

--- a/py-ltseq/tests/test_sort_spec_desc_windows.py
+++ b/py-ltseq/tests/test_sort_spec_desc_windows.py
@@ -1,0 +1,111 @@
+"""Regression tests for issue #95: window functions on DESC-sorted tables.
+
+sort_exprs used to store bare column names, losing direction; window ORDER BY
+was rebuilt with hardcoded asc=true, so shift/diff/cum_sum/rolling computed
+ASC semantics on DESC-sorted tables.
+"""
+
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+
+from ltseq import LTSeq
+
+
+@pytest.fixture
+def desc_table():
+    df = pd.DataFrame({"k": [1, 2, 3, 4, 5], "v": [10.0, 20.0, 30.0, 40.0, 50.0]})
+    return LTSeq.from_pandas(df).sort("k", desc=True)
+
+
+@pytest.fixture
+def mixed_table():
+    """Multi-column sort: grp ASC, k DESC. Rows: (A,5),(A,3),(A,1),(B,4),(B,2)"""
+    df = pd.DataFrame({
+        "grp": ["A", "A", "A", "B", "B"],
+        "k":   [5, 3, 1, 4, 2],
+        "v":   [50.0, 30.0, 10.0, 40.0, 20.0],
+    })
+    return LTSeq.from_pandas(df).sort("grp", "k", desc=[False, True])
+
+
+class TestDescShift:
+    def test_desc_shift_1(self, desc_table):
+        """shift(1) on DESC-sorted table: k=4→prev=50, k=3→prev=40"""
+        result = desc_table.derive(lambda r: {"prev": r.v.shift(1)})
+        df = result.to_pandas().sort_values("k", ascending=False).reset_index(drop=True)
+        expected_prev = [None, 50.0, 40.0, 30.0, 20.0]
+        assert df["v"].tolist() == [50.0, 40.0, 30.0, 20.0, 10.0]
+        for i, (actual, expected) in enumerate(zip(df["prev"].tolist(), expected_prev)):
+            if expected is None:
+                assert pd.isna(actual), f"index {i}: expected NaN, got {actual}"
+            else:
+                assert actual == expected, f"index {i}: expected {expected}, got {actual}"
+
+    def test_desc_diff_1(self, desc_table):
+        """diff(1) on DESC: each step = -10"""
+        result = desc_table.derive(lambda r: {"d": r.v.diff(1)})
+        df = result.to_pandas().sort_values("k", ascending=False).reset_index(drop=True)
+        expected_diff = [None, -10.0, -10.0, -10.0, -10.0]
+        for i, (actual, expected) in enumerate(zip(df["d"].tolist(), expected_diff)):
+            if expected is None:
+                assert pd.isna(actual), f"index {i}: expected NaN, got {actual}"
+            else:
+                assert actual == expected, f"index {i}: expected {expected}, got {actual}"
+
+    def test_desc_cum_sum(self, desc_table):
+        """cum_sum on DESC: 50, 90, 120, 140, 150"""
+        result = desc_table.cum_sum("v")
+        df = result.to_pandas().sort_values("k", ascending=False).reset_index(drop=True)
+        expected_v_cumsum = [50.0, 90.0, 120.0, 140.0, 150.0]
+        assert df["v_cumsum"].tolist() == expected_v_cumsum
+
+    def test_desc_rolling_sum(self, desc_table):
+        """rolling(2).sum() on DESC: 50, 90, 70, 50, 30"""
+        result = desc_table.derive(lambda r: {"rsum": r.v.rolling(2).sum()})
+        df = result.to_pandas().sort_values("k", ascending=False).reset_index(drop=True)
+        expected = [50.0, 90.0, 70.0, 50.0, 30.0]
+        assert df["rsum"].tolist() == expected
+
+
+class TestMultiColumnMixedDirection:
+    def test_shift_on_mixed_direction(self, mixed_table):
+        """shift(1) respects multi-col order: grp ASC, k DESC"""
+        result = mixed_table.derive(lambda r: {"prev": r.v.shift(1)})
+        df = result.to_pandas()
+        # Sort to match table order: grp=A,k=5 first; then A,3; A,1; B,4; B,2
+        df_sorted = df.sort_values(["grp", "k"], ascending=[True, False]).reset_index(drop=True)
+        # Expected prev over the whole sequence (no partitioning): the row
+        # before B,4 in table order is A,1 (v=10).
+        expected_prev = [None, 50.0, 30.0, 10.0, 40.0]
+        for i, (actual, expected) in enumerate(zip(df_sorted["prev"].tolist(), expected_prev)):
+            if expected is None:
+                assert pd.isna(actual), f"index {i}: expected NaN, got {actual}"
+            else:
+                assert actual == expected, f"index {i}: expected {expected}, got {actual}"
+
+
+class TestAssumeSortedDesc:
+    def test_assume_sorted_desc_shift(self):
+        """assume_sorted('k', desc=True) followed by shift(1) works correctly"""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            path = f.name
+        t = pa.table({"k": [5, 4, 3, 2, 1], "v": [50.0, 40.0, 30.0, 20.0, 10.0]})
+        pq.write_table(t, path)
+        try:
+            table = LTSeq.read_parquet(path).assume_sorted("k", desc=True)
+            result = table.derive(lambda r: {"prev": r.v.shift(1)})
+            df = result.to_pandas().sort_values("k", ascending=False).reset_index(drop=True)
+            expected_prev = [None, 50.0, 40.0, 30.0, 20.0]
+            for i, (actual, expected) in enumerate(zip(df["prev"].tolist(), expected_prev)):
+                if expected is None:
+                    assert pd.isna(actual), f"index {i}: expected NaN, got {actual}"
+                else:
+                    assert actual == expected, f"index {i}: expected {expected}, got {actual}"
+        finally:
+            os.unlink(path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod cursor;
 pub(crate) mod engine; // DataFusion session and LTSeqTable struct
 mod error;
 pub(crate) mod format; // Formatting and display functions
+pub(crate) mod metadata; // SortSpec and sort-metadata helpers
 pub(crate) mod ops; // Table operations grouped by category
 pub(crate) mod transpiler; // PyExpr to DataFusion transpilation
 mod types; // Streaming cursor for lazy iteration
@@ -22,6 +23,7 @@ mod types; // Streaming cursor for lazy iteration
 // Re-exports for internal use
 pub(crate) use error::LtseqError;
 pub(crate) use format::format_table;
+pub(crate) use metadata::SortSpec;
 use crate::engine::{create_session_context, RUNTIME};
 
 /// LTSeqTable: Holds DataFusion SessionContext and loaded data
@@ -31,7 +33,7 @@ pub struct LTSeqTable {
     session: Arc<SessionContext>,
     dataframe: Option<Arc<DataFrame>>,
     schema: Option<Arc<ArrowSchema>>,
-    sort_exprs: Vec<String>, // Column names used for sorting, for Phase 6 window functions
+    sort_specs: Vec<SortSpec>, // Declared row order (column + direction), drives window ORDER BY
     source_parquet_path: Option<String>, // Parquet file path for assume_sorted optimization
 }
 
@@ -50,7 +52,7 @@ impl LTSeqTable {
     pub(crate) fn from_df(
         session: Arc<SessionContext>,
         df: DataFrame,
-        sort_exprs: Vec<String>,
+        sort_specs: Vec<SortSpec>,
         source_parquet_path: Option<String>,
     ) -> Self {
         let schema = Self::schema_from_df(df.schema());
@@ -58,7 +60,7 @@ impl LTSeqTable {
             session,
             dataframe: Some(Arc::new(df)),
             schema: Some(schema),
-            sort_exprs,
+            sort_specs,
             source_parquet_path,
         }
     }
@@ -69,14 +71,14 @@ impl LTSeqTable {
         session: Arc<SessionContext>,
         df: DataFrame,
         schema: Arc<ArrowSchema>,
-        sort_exprs: Vec<String>,
+        sort_specs: Vec<SortSpec>,
         source_parquet_path: Option<String>,
     ) -> Self {
         LTSeqTable {
             session,
             dataframe: Some(Arc::new(df)),
             schema: Some(schema),
-            sort_exprs,
+            sort_specs,
             source_parquet_path,
         }
     }
@@ -86,7 +88,7 @@ impl LTSeqTable {
     pub(crate) fn from_batches(
         session: Arc<SessionContext>,
         batches: Vec<RecordBatch>,
-        sort_exprs: Vec<String>,
+        sort_specs: Vec<SortSpec>,
         source_parquet_path: Option<String>,
     ) -> PyResult<Self> {
         if batches.is_empty() {
@@ -94,7 +96,7 @@ impl LTSeqTable {
                 session,
                 dataframe: None,
                 schema: None,
-                sort_exprs,
+                sort_specs,
                 source_parquet_path,
             });
         }
@@ -112,7 +114,7 @@ impl LTSeqTable {
             session,
             dataframe: Some(Arc::new(result_df)),
             schema: Some(result_schema),
-            sort_exprs,
+            sort_specs,
             source_parquet_path,
         })
     }
@@ -122,7 +124,7 @@ impl LTSeqTable {
         session: Arc<SessionContext>,
         batches: Vec<RecordBatch>,
         empty_schema: Arc<ArrowSchema>,
-        sort_exprs: Vec<String>,
+        sort_specs: Vec<SortSpec>,
         source_parquet_path: Option<String>,
     ) -> PyResult<Self> {
         if batches.is_empty() {
@@ -130,7 +132,7 @@ impl LTSeqTable {
                 session,
                 dataframe: None,
                 schema: Some(empty_schema),
-                sort_exprs,
+                sort_specs,
                 source_parquet_path,
             });
         }
@@ -148,7 +150,7 @@ impl LTSeqTable {
             session,
             dataframe: Some(Arc::new(result_df)),
             schema: Some(result_schema),
-            sort_exprs,
+            sort_specs,
             source_parquet_path,
         })
     }
@@ -158,7 +160,7 @@ impl LTSeqTable {
     pub(crate) fn empty(
         session: Arc<SessionContext>,
         schema: Option<Arc<ArrowSchema>>,
-        sort_exprs: Vec<String>,
+        sort_specs: Vec<SortSpec>,
         source_parquet_path: Option<String>,
     ) -> Self {
         // Explicit field initialization for clarity and future-proofing
@@ -166,7 +168,7 @@ impl LTSeqTable {
             session,
             dataframe: None,
             schema,
-            sort_exprs,
+            sort_specs,
             source_parquet_path,
         }
     }
@@ -203,7 +205,7 @@ impl LTSeqTable {
             session,
             dataframe: None,
             schema: None,
-            sort_exprs: Vec::with_capacity(0),
+            sort_specs: Vec::with_capacity(0),
             source_parquet_path: None,
         }
     }
@@ -305,7 +307,7 @@ impl LTSeqTable {
             session,
             dataframe: None,
             schema: None,
-            sort_exprs: Vec::new(),
+            sort_specs: Vec::new(),
             source_parquet_path: None,
         };
         table.read_csv(path, has_header)?;
@@ -330,7 +332,7 @@ impl LTSeqTable {
             session,
             dataframe: None,
             schema: None,
-            sort_exprs: Vec::new(),
+            sort_specs: Vec::new(),
             source_parquet_path: None,
         };
         table.read_parquet(path)?;
@@ -617,8 +619,9 @@ impl LTSeqTable {
     fn assume_sorted(
         &self,
         sort_exprs: Vec<Bound<'_, PyDict>>,
+        desc_flags: Vec<bool>,
     ) -> PyResult<LTSeqTable> {
-        crate::ops::sort::assume_sorted_impl(self, sort_exprs)
+        crate::ops::sort::assume_sorted_impl(self, sort_exprs, desc_flags)
     }
 
     /// Add __group_id__ column for consecutive identical grouping values
@@ -680,8 +683,8 @@ impl LTSeqTable {
             return Ok(LTSeqTable::empty(
                 Arc::clone(&self.session),
                 self.schema.as_ref().map(Arc::clone),
-                self.sort_exprs.clone(),
-                self.source_parquet_path.clone(),
+                self.sort_specs.clone(),
+                None,
             ));
         }
 
@@ -702,14 +705,16 @@ impl LTSeqTable {
             })
             .map_err(LtseqError::Runtime)?;
 
-        // Return new LTSeqTable with sliced data (schema unchanged)
+        // Return new LTSeqTable with sliced data (schema unchanged).
+        // Row subset preserves order → keep sort_specs; the raw file no
+        // longer matches the row set → drop the Parquet fast-path token.
         let schema = self.require_schema()?;
         Ok(LTSeqTable::from_df_with_schema(
             Arc::clone(&self.session),
             sliced_df,
             Arc::clone(schema),
-            self.sort_exprs.clone(),
-            self.source_parquet_path.clone(),
+            self.sort_specs.clone(),
+            None,
         ))
     }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -9,7 +9,8 @@
 //! Propagation rules (issue #95): ops that preserve row order (filter,
 //! select, slice, derive, head/tail) clone `sort_specs`; ops that destroy
 //! or redefine order (sort output = new specs; distinct/join/agg/set ops/
-//! insert/rvs = empty). `source_parquet_path` survives only `assume_sorted`:
+//! insert/delete/update/modify = empty). `source_parquet_path` survives
+//! only `assume_sorted`:
 //! any op that changes the row set must clear it so Parquet fast paths
 //! cannot scan stale raw data.
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,85 @@
+//! Table-level sort metadata: the `SortSpec` type and conversion helpers.
+//!
+//! `LTSeqTable.sort_specs` records the declared row order (column, direction,
+//! nulls placement). Every downstream consumer that rebuilds an ORDER BY —
+//! window functions, group boundary detection, linear scans, Parquet
+//! file_sort_order declarations, SQL fallbacks — must derive it from
+//! `SortSpec` via the helpers below instead of assuming ascending order.
+//!
+//! Propagation rules (issue #95): ops that preserve row order (filter,
+//! select, slice, derive, head/tail) clone `sort_specs`; ops that destroy
+//! or redefine order (sort output = new specs; distinct/join/agg/set ops/
+//! insert/rvs = empty). `source_parquet_path` survives only `assume_sorted`:
+//! any op that changes the row set must clear it so Parquet fast paths
+//! cannot scan stale raw data.
+
+use datafusion::common::Column;
+use datafusion::logical_expr::expr::Sort;
+use datafusion::logical_expr::{Expr, SortExpr};
+
+/// One sort key: column name + direction + nulls placement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SortSpec {
+    pub column: String,
+    pub descending: bool,
+    pub nulls_first: bool,
+}
+
+impl SortSpec {
+    /// `nulls_first = descending` matches the historical `sort_impl` behavior
+    /// (DESC sorts put nulls first, ASC sorts put nulls last).
+    pub fn new(column: String, descending: bool) -> Self {
+        SortSpec {
+            column,
+            descending,
+            nulls_first: descending,
+        }
+    }
+
+    pub fn to_df_sort_expr(&self) -> SortExpr {
+        SortExpr {
+            expr: Expr::Column(Column::new_unqualified(&self.column)),
+            asc: !self.descending,
+            nulls_first: self.nulls_first,
+        }
+    }
+
+    pub fn to_window_sort(&self) -> Sort {
+        Sort {
+            expr: Expr::Column(Column::new_unqualified(&self.column)),
+            asc: !self.descending,
+            nulls_first: self.nulls_first,
+        }
+    }
+}
+
+pub(crate) fn sort_specs_to_df_sort_exprs(specs: &[SortSpec]) -> Vec<SortExpr> {
+    specs.iter().map(|s| s.to_df_sort_expr()).collect()
+}
+
+pub(crate) fn sort_specs_to_window_sorts(specs: &[SortSpec]) -> Vec<Sort> {
+    specs.iter().map(|s| s.to_window_sort()).collect()
+}
+
+/// The `Vec<Vec<SortExpr>>` shape expected by `file_sort_order` /
+/// `MemTable::with_sort_order`.
+pub(crate) fn sort_specs_to_file_sort_order(specs: &[SortSpec]) -> Vec<Vec<SortExpr>> {
+    vec![sort_specs_to_df_sort_exprs(specs)]
+}
+
+/// Render an ORDER BY column list (without the `ORDER BY` keyword) for the
+/// SQL fallback paths. Empty string when there are no sort specs.
+pub(crate) fn sort_specs_to_sql_order_by(specs: &[SortSpec]) -> String {
+    if specs.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = specs
+        .iter()
+        .map(|s| {
+            let dir = if s.descending { "DESC" } else { "ASC" };
+            let nulls = if s.nulls_first { "NULLS FIRST" } else { "NULLS LAST" };
+            format!("\"{}\" {} {}", s.column, dir, nulls)
+        })
+        .collect();
+    parts.join(", ")
+}

--- a/src/ops/aggregation.rs
+++ b/src/ops/aggregation.rs
@@ -803,7 +803,7 @@ pub fn filter_where_impl(table: &LTSeqTable, where_clause: &str) -> PyResult<LTS
         Arc::clone(&table.session),
         filtered_df,
         Arc::clone(schema),
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     ))
 }

--- a/src/ops/align.rs
+++ b/src/ops/align.rs
@@ -164,6 +164,6 @@ pub fn align_impl(
         result_batches,
         Arc::clone(&batch_schema),
         Vec::new(),
-        table.source_parquet_path.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     )
 }

--- a/src/ops/asof_join.rs
+++ b/src/ops/asof_join.rs
@@ -250,7 +250,7 @@ pub fn asof_join_impl(
         Arc::clone(&table.session),
         vec![result_batch],
         Vec::new(),
-        table.source_parquet_path.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     )
 }
 

--- a/src/ops/basic.rs
+++ b/src/ops/basic.rs
@@ -40,8 +40,8 @@ pub fn filter_impl(table: &LTSeqTable, expr_dict: &Bound<'_, PyDict>) -> PyResul
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -69,8 +69,8 @@ pub fn filter_impl(table: &LTSeqTable, expr_dict: &Bound<'_, PyDict>) -> PyResul
         Arc::clone(&table.session),
         filtered_df,
         Arc::clone(schema),
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     ))
 }
 
@@ -85,8 +85,8 @@ pub fn select_impl(table: &LTSeqTable, exprs: Vec<Bound<'_, PyDict>>) -> PyResul
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -119,12 +119,25 @@ pub fn select_impl(table: &LTSeqTable, exprs: Vec<Bound<'_, PyDict>>) -> PyResul
         })
         .map_err(LtseqError::Runtime)?;
 
-    // 5. Return new LTSeqTable with recomputed schema
+    // 5. Keep sort metadata only if every sort column survived the projection;
+    // otherwise downstream ORDER BY would reference a nonexistent column.
+    let result_schema = LTSeqTable::schema_from_df(selected_df.schema());
+    let all_sort_cols_present = table
+        .sort_specs
+        .iter()
+        .all(|spec| result_schema.fields().iter().any(|f| f.name() == &spec.column));
+    let sort_specs = if all_sort_cols_present {
+        table.sort_specs.clone()
+    } else {
+        Vec::new()
+    };
+
+    // 6. Return new LTSeqTable with recomputed schema
     Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
         selected_df,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        sort_specs,
+        None, // row set / columns diverge from the raw file: drop fast-path token
     ))
 }
 
@@ -165,7 +178,7 @@ pub fn search_first_impl(
     Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
         result_df,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     ))
 }

--- a/src/ops/derive.rs
+++ b/src/ops/derive.rs
@@ -106,8 +106,8 @@ pub fn derive_impl(table: &LTSeqTable, derived_cols: &Bound<'_, PyDict>) -> PyRe
     Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
         result_df,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     ))
 }
 

--- a/src/ops/derive_sql.rs
+++ b/src/ops/derive_sql.rs
@@ -133,7 +133,7 @@ pub fn derive_window_sql_impl(
             Arc::clone(&table.session),
             Some(empty_schema),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -141,6 +141,6 @@ pub fn derive_window_sql_impl(
         Arc::clone(&table.session),
         result_batches,
         Vec::new(),
-        table.source_parquet_path.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     )
 }

--- a/src/ops/derive_sql.rs
+++ b/src/ops/derive_sql.rs
@@ -133,14 +133,14 @@ pub fn derive_window_sql_impl(
             Arc::clone(&table.session),
             Some(empty_schema),
             Vec::new(),
-            None, // row set / columns diverge from the raw file: drop fast-path token
+            None, // SQL-reconstructed result: no known sort or raw-file source
         ));
     }
 
     LTSeqTable::from_batches(
         Arc::clone(&table.session),
         result_batches,
-        Vec::new(),
-        None, // row set / columns diverge from the raw file: drop fast-path token
+        Vec::new(), // SQL window queries define their own ORDER BY; source sort is obsolete
+        None,       // SQL-reconstructed result: no known raw-file source
     )
 }

--- a/src/ops/grouping.rs
+++ b/src/ops/grouping.rs
@@ -54,7 +54,7 @@ fn get_df_and_schema_or_empty(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
     // SAFETY: dataframe.is_none() is checked above
@@ -64,7 +64,7 @@ fn get_df_and_schema_or_empty(
             Arc::clone(&table.session),
             None,
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         )
     })?;
     Ok((df, schema))
@@ -205,7 +205,7 @@ pub fn group_ordered_count_impl(
 
     // Try Parquet fast paths (bypass DataFusion entirely).
     if let Some(ref parquet_path) = table.source_parquet_path {
-        if !table.sort_exprs.is_empty() {
+        if !table.sort_specs.is_empty() {
             // Preferred: parallel per-RG counting with seam stitching.
             match crate::ops::parallel_scan::parallel_streaming_group_count(
                 table,
@@ -293,23 +293,15 @@ pub fn group_id_impl(table: &LTSeqTable, grouping_expr: Bound<'_, PyDict>) -> Py
 
     let has_window = contains_window_function(&py_expr);
 
-    // Build ORDER BY from table's sort_exprs
-    let order_by: Vec<Sort> = table
-        .sort_exprs
-        .iter()
-        .map(|col_name| Sort {
-            expr: Expr::Column(datafusion::common::Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
-        .collect();
+    // Build ORDER BY from table's sort specs (direction-aware)
+    let order_by: Vec<Sort> = crate::metadata::sort_specs_to_window_sorts(&table.sort_specs);
 
     // ── Step 1: Build the boundary boolean expression ──────────────────
     let boundary_expr = if has_window {
         // The expression itself IS the boundary condition (contains shift/diff/etc.)
         // e.g., (r.userid != r.userid.shift(1)) | (r.eventtime - r.eventtime.shift(1) > 1800)
         // Convert using the window-aware transpiler → native DataFusion Expr with LAG/LEAD
-        pyexpr_to_window_expr(py_expr, schema, &table.sort_exprs)
+        pyexpr_to_window_expr(py_expr, schema, &table.sort_specs)
             .map_err(LtseqError::Validation)?
     } else {
         // Simple expression (e.g., column reference) — build:
@@ -491,8 +483,8 @@ pub fn group_id_impl(table: &LTSeqTable, grouping_expr: Bound<'_, PyDict>) -> Py
         Arc::clone(&table.session),
         result_df,
         result_schema,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     ))
 }
 
@@ -563,7 +555,7 @@ fn first_or_last_row_impl(table: &LTSeqTable, is_first: bool) -> PyResult<LTSeqT
                 Arc::clone(&table.session),
                 filtered,
                 Vec::new(),
-                table.source_parquet_path.clone(),
+                None, // row set / columns diverge from the raw file: drop fast-path token
             ));
         }
 
@@ -575,7 +567,7 @@ fn first_or_last_row_impl(table: &LTSeqTable, is_first: bool) -> PyResult<LTSeqT
             Arc::clone(&table.session),
             projected,
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -610,7 +602,7 @@ fn first_or_last_row_impl(table: &LTSeqTable, is_first: bool) -> PyResult<LTSeqT
                 Arc::clone(&table.session),
                 filtered,
                 Vec::new(),
-                table.source_parquet_path.clone(),
+                None, // row set / columns diverge from the raw file: drop fast-path token
             ));
         }
 
@@ -622,7 +614,7 @@ fn first_or_last_row_impl(table: &LTSeqTable, is_first: bool) -> PyResult<LTSeqT
             Arc::clone(&table.session),
             projected,
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 

--- a/src/ops/join.rs
+++ b/src/ops/join.rs
@@ -195,18 +195,20 @@ fn rename_right_df_for_join(
     Ok((renamed_df, new_key_cols))
 }
 
-/// Build result LTSeqTable from a DataFrame
+/// Build result LTSeqTable from a DataFrame.
+///
+/// Joins merge rows from two sources, so neither input's sort metadata
+/// describes the result: always empty.
 fn build_result_table_from_df(
     session: &Arc<SessionContext>,
     result_df: DataFrame,
     expected_schema: Arc<ArrowSchema>,
-    sort_exprs: &[String],
 ) -> PyResult<LTSeqTable> {
     Ok(LTSeqTable::from_df_with_schema(
         Arc::clone(session),
         result_df,
         expected_schema,
-        sort_exprs.to_vec(),
+        Vec::new(),
         None,
     ))
 }
@@ -275,7 +277,7 @@ pub fn join_impl(
     // Build expected schema for the result
     let expected_schema = build_aliased_join_schema(stored_schema_left, stored_schema_right, alias);
 
-    build_result_table_from_df(&table.session, result_df, expected_schema, &[])
+    build_result_table_from_df(&table.session, result_df, expected_schema)
 }
 
 /// Semi-join: Return rows from left table where keys exist in right table
@@ -344,6 +346,5 @@ fn semi_anti_join_impl(
         &table.session,
         result_df,
         Arc::clone(stored_schema_left),
-        &table.sort_exprs,
     )
 }

--- a/src/ops/linear_scan.rs
+++ b/src/ops/linear_scan.rs
@@ -1010,16 +1010,9 @@ fn vectorized_binop(op: &str, left: &ArrayRef, right: &ArrayRef) -> Result<Array
 // Main entry point
 // ============================================================================
 
-/// Build DataFusion sort expressions from the table's `sort_exprs` column names.
-pub(crate) fn build_sort_exprs(sort_keys: &[String]) -> Vec<SortExpr> {
-    sort_keys
-        .iter()
-        .map(|col_name| SortExpr {
-            expr: Expr::Column(Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
-        .collect()
+/// Build DataFusion sort expressions from the table's `sort_specs`.
+pub(crate) fn build_sort_exprs(sort_specs: &[crate::SortSpec]) -> Vec<SortExpr> {
+    crate::metadata::sort_specs_to_df_sort_exprs(sort_specs)
 }
 
 /// Single-pass group ID assignment with `__group_count__` and `__rn__`.
@@ -1052,7 +1045,7 @@ pub fn linear_scan_group_id(table: &LTSeqTable, predicate: &PyExpr) -> PyResult<
     //   - execute_stream(): batch-by-batch processing, no concat_batches
     //   - Skip .sort() node: single partition + file_sort_order is sufficient
     if let Some(ref parquet_path) = table.source_parquet_path {
-        if !table.sort_exprs.is_empty() {
+        if !table.sort_specs.is_empty() {
             // Direct Parquet streaming — bypasses DataFusion for lower overhead
             match crate::ops::parallel_scan::direct_streaming_group_ordered(
                 table,
@@ -1093,14 +1086,10 @@ pub fn linear_scan_group_id(table: &LTSeqTable, predicate: &PyExpr) -> PyResult<
     // Non-referenced sort keys don't affect boundary detection and reading
     // them from Parquet is wasteful (e.g., watchid adds ~30% I/O overhead).
     let relevant_sort_exprs: Vec<SortExpr> = table
-        .sort_exprs
+        .sort_specs
         .iter()
-        .filter(|key| needed_cols.contains(key.as_str()))
-        .map(|col_name| SortExpr {
-            expr: Expr::Column(Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
+        .filter(|spec| needed_cols.contains(spec.column.as_str()))
+        .map(|spec| spec.to_df_sort_expr())
         .collect();
 
     // Step 2: Project to only needed columns + sort
@@ -1146,7 +1135,7 @@ pub fn linear_scan_group_id(table: &LTSeqTable, predicate: &PyExpr) -> PyResult<
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -1157,7 +1146,7 @@ pub fn linear_scan_group_id(table: &LTSeqTable, predicate: &PyExpr) -> PyResult<
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -1204,16 +1193,9 @@ fn streaming_linear_scan_group_id(
     // Step 2: Create single-partition session and read Parquet with declared sort order
     let seq_session = create_sequential_session();
 
-    // Build file_sort_order from sort_exprs (same as assume_sorted_impl)
-    let sort_order: Vec<Vec<SortExpr>> = vec![table
-        .sort_exprs
-        .iter()
-        .map(|col_name| SortExpr {
-            expr: Expr::Column(Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
-        .collect()];
+    // Build file_sort_order from sort_specs (same as assume_sorted_impl)
+    let sort_order: Vec<Vec<SortExpr>> =
+        crate::metadata::sort_specs_to_file_sort_order(&table.sort_specs);
 
     let col_names: Vec<String> = needed_cols.into_iter().collect();
 
@@ -1315,7 +1297,7 @@ fn streaming_linear_scan_group_id(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -1356,14 +1338,10 @@ fn general_linear_scan_group_id(
     extract_referenced_columns(predicate, &mut needed_cols);
 
     let relevant_sort_exprs: Vec<SortExpr> = table
-        .sort_exprs
+        .sort_specs
         .iter()
-        .filter(|key| needed_cols.contains(key.as_str()))
-        .map(|col_name| SortExpr {
-            expr: Expr::Column(Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
+        .filter(|spec| needed_cols.contains(spec.column.as_str()))
+        .map(|spec| spec.to_df_sort_expr())
         .collect();
 
     let col_exprs: Vec<Expr> = needed_cols
@@ -1407,7 +1385,7 @@ fn general_linear_scan_group_id(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -1418,7 +1396,7 @@ fn general_linear_scan_group_id(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -1523,6 +1501,6 @@ pub(crate) fn build_metadata_table(
         Arc::clone(&table.session),
         vec![meta_batch],
         Vec::new(),
-        table.source_parquet_path.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     )
 }

--- a/src/ops/mutation.rs
+++ b/src/ops/mutation.rs
@@ -34,8 +34,8 @@ pub fn insert_row_impl(
         return LTSeqTable::from_batches(
             Arc::clone(&table.session),
             vec![new_batch],
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            Vec::new(),
+            None,
         );
     }
 
@@ -74,8 +74,8 @@ pub fn insert_row_impl(
     LTSeqTable::from_batches(
         Arc::clone(&table.session),
         result_batches,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        Vec::new(), // mutations invalidate declared order (mirrors Python _sort_keys = None)
+        None,
     )
 }
 
@@ -97,8 +97,8 @@ pub fn delete_rows_impl(table: &LTSeqTable, pos: i64) -> PyResult<LTSeqTable> {
             Arc::clone(&table.session),
             (**df).clone(),
             Arc::clone(schema),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            Vec::new(),
+            None,
         ));
     }
 
@@ -127,8 +127,8 @@ pub fn delete_rows_impl(table: &LTSeqTable, pos: i64) -> PyResult<LTSeqTable> {
     LTSeqTable::from_batches(
         Arc::clone(&table.session),
         result_batches,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        Vec::new(), // mutations invalidate declared order (mirrors Python _sort_keys = None)
+        None,
     )
 }
 
@@ -148,8 +148,8 @@ pub fn conditional_update_impl(
             Arc::clone(&table.session),
             (**df).clone(),
             Arc::clone(schema),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            Vec::new(),
+            None,
         ));
     }
 
@@ -209,8 +209,8 @@ pub fn conditional_update_impl(
         Arc::clone(&table.session),
         result_df,
         Arc::clone(schema),
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        Vec::new(), // mutations invalidate declared order (mirrors Python _sort_keys = None)
+        None,
     ))
 }
 
@@ -236,8 +236,8 @@ pub fn modify_row_impl(
             Arc::clone(&table.session),
             (**df).clone(),
             Arc::clone(schema),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            Vec::new(),
+            None,
         ));
     }
 
@@ -292,8 +292,8 @@ pub fn modify_row_impl(
     LTSeqTable::from_batches(
         Arc::clone(&table.session),
         result_batches,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        Vec::new(), // mutations invalidate declared order (mirrors Python _sort_keys = None)
+        None,
     )
 }
 

--- a/src/ops/parallel_scan.rs
+++ b/src/ops/parallel_scan.rs
@@ -181,7 +181,7 @@ pub fn direct_streaming_group_ordered(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 

--- a/src/ops/pattern_match.rs
+++ b/src/ops/pattern_match.rs
@@ -532,10 +532,10 @@ pub fn search_pattern_impl(
     }
 
     // 3. Project only needed columns, add sort, collect
-    let sort_keys = &table.sort_exprs;
+    let sort_keys = &table.sort_specs;
     // Also ensure sort key columns are included
-    for sk in sort_keys {
-        referenced_cols.insert(sk.clone());
+    for sk in sort_keys.iter() {
+        referenced_cols.insert(sk.column.clone());
     }
 
     let projected_df = {
@@ -584,8 +584,8 @@ pub fn search_pattern_impl(
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             Some(Arc::clone(schema)),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -599,8 +599,8 @@ pub fn search_pattern_impl(
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             Some(Arc::clone(schema)),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -686,8 +686,8 @@ pub fn search_pattern_impl(
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             Some(Arc::clone(schema)),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -723,8 +723,8 @@ pub fn search_pattern_impl(
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             Some(Arc::clone(schema)),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
@@ -752,8 +752,8 @@ pub fn search_pattern_impl(
     LTSeqTable::from_batches(
         Arc::clone(&table.session),
         vec![result_batch],
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // row set / columns diverge from the raw file: drop fast-path token
     )
 }
 
@@ -784,7 +784,7 @@ pub fn search_pattern_count_impl(
     if let (Some(ref parquet_path), Some(ref part_col)) =
         (&table.source_parquet_path, &partition_by)
     {
-        if !table.sort_exprs.is_empty() {
+        if !table.sort_specs.is_empty() {
             match crate::ops::parallel_scan::parallel_pattern_match_count(
                 table,
                 &py_exprs,
@@ -818,7 +818,7 @@ pub fn search_pattern_count_impl(
     }
 
     // 3. Project only needed columns, add sort, collect
-    let sort_keys = &table.sort_exprs;
+    let sort_keys = &table.sort_specs;
 
     let batches = collect_projected_sorted(df, &referenced_cols, schema, sort_keys)?;
 
@@ -1005,7 +1005,7 @@ fn collect_projected_sorted(
     df: &Arc<datafusion::dataframe::DataFrame>,
     referenced_cols: &HashSet<String>,
     schema: &Arc<datafusion::arrow::datatypes::Schema>,
-    sort_keys: &[String],
+    sort_keys: &[crate::SortSpec],
 ) -> PyResult<Vec<RecordBatch>> {
     let select_exprs: Vec<Expr> = referenced_cols
         .iter()

--- a/src/ops/set_ops.rs
+++ b/src/ops/set_ops.rs
@@ -74,16 +74,18 @@ async fn collect_batches(
         .map_err(|e| format!("Failed to collect {}: {}", table_name, e))
 }
 
-/// Create result LTSeqTable from DataFrame
+/// Create result LTSeqTable from DataFrame.
+///
+/// Set operations (union/intersect/diff) and rvs merge or reorder rows, so
+/// the input sort metadata no longer describes the result: always empty.
 fn create_result_table(
     session: &Arc<SessionContext>,
     result_df: datafusion::dataframe::DataFrame,
-    sort_exprs: &[String],
 ) -> LTSeqTable {
     LTSeqTable::from_df(
         Arc::clone(session),
         result_df,
-        sort_exprs.to_vec(),
+        Vec::new(),
         None,
     )
 }
@@ -106,8 +108,8 @@ pub fn distinct_impl(
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            Vec::new(),
+            None,
         ));
     }
 
@@ -144,8 +146,8 @@ fn distinct_all_columns(
         distinct_df,
         // SAFETY: schema validated by require_df_and_schema() before this function
         Arc::clone(table.schema.as_ref().expect("schema validated by caller")),
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        Vec::new(), // distinct reorders rows: sort metadata no longer holds
+        None,
     ))
 }
 
@@ -227,8 +229,8 @@ fn distinct_with_keys(
         distinct_df,
         // SAFETY: schema validated by require_df_and_schema() before this function
         Arc::clone(table.schema.as_ref().expect("schema validated by caller")),
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        Vec::new(), // distinct reorders rows: sort metadata no longer holds
+        None,
     ))
 }
 
@@ -261,11 +263,7 @@ pub fn union_impl(table1: &LTSeqTable, table2: &LTSeqTable) -> PyResult<LTSeqTab
         })
         .map_err(LtseqError::Runtime)?;
 
-    Ok(create_result_table(
-        &table1.session,
-        union_df,
-        &table1.sort_exprs,
-    ))
+    Ok(create_result_table(&table1.session, union_df))
 }
 
 /// Intersect: Return rows present in both tables
@@ -420,11 +418,7 @@ fn set_operation_impl(
         })
         .map_err(LtseqError::Runtime)?;
 
-    Ok(create_result_table(
-        &table1.session,
-        result_df,
-        &table1.sort_exprs,
-    ))
+    Ok(create_result_table(&table1.session, result_df))
 }
 
 /// Reverse: Return rows in reversed order

--- a/src/ops/sort.rs
+++ b/src/ops/sort.rs
@@ -4,13 +4,13 @@
 
 use crate::engine::RUNTIME;
 use crate::error::LtseqError;
+use crate::metadata::{sort_specs_to_file_sort_order, SortSpec};
 use crate::transpiler::pyexpr_to_datafusion;
 use crate::types::{dict_to_py_expr, PyExpr};
 use crate::LTSeqTable;
-use datafusion::common::Column;
 use datafusion::datasource::file_format::options::ParquetReadOptions;
 use datafusion::datasource::MemTable;
-use datafusion::logical_expr::{Expr, SortExpr};
+use datafusion::logical_expr::SortExpr;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::sync::Arc;
@@ -30,30 +30,30 @@ pub fn sort_impl(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
             Vec::new(),
-            table.source_parquet_path.clone(),
+            None, // row set / columns diverge from the raw file: drop fast-path token
         ));
     }
 
     let (df, schema) = table.require_df_and_schema()?;
 
-    // Capture sort column names for Phase 6 window functions
-    let mut captured_sort_keys = Vec::new();
+    // Capture full sort specs (column + direction) for downstream window ops
+    let mut captured_specs = Vec::new();
 
     // Deserialize and transpile each sort expression
     let mut df_sort_exprs = Vec::new();
     for (i, expr_dict) in sort_exprs.iter().enumerate() {
         let py_expr = dict_to_py_expr(expr_dict)?;
 
+        // Get desc flag for this sort key
+        let is_desc = desc_flags.get(i).copied().unwrap_or(false);
+
         // Capture column name if this is a simple column reference
         if let PyExpr::Column(ref col_name) = py_expr {
-            captured_sort_keys.push(col_name.clone());
+            captured_specs.push(SortSpec::new(col_name.clone(), is_desc));
         }
 
         let df_expr = pyexpr_to_datafusion(py_expr, schema)
             .map_err(LtseqError::Validation)?;
-
-        // Get desc flag for this sort key
-        let is_desc = desc_flags.get(i).copied().unwrap_or(false);
 
         // Create SortExpr with asc = !is_desc
         // For descending, nulls_first = true by default
@@ -74,30 +74,18 @@ pub fn sort_impl(
         })
         .map_err(LtseqError::Runtime)?;
 
-    // Return new LTSeqTable with sorted data and captured sort keys (schema unchanged)
+    // Return new LTSeqTable with sorted data and captured sort specs
+    // (schema unchanged). The physical sort defines a new row order, so the
+    // raw-file fast-path token must not survive: the Parquet file's physical
+    // order no longer matches the table's logical order.
     Ok(LTSeqTable::from_df_with_schema(
         Arc::clone(&table.session),
         sorted_df,
-        // SAFETY: require_df_and_schema() validated schema on line 37
+        // SAFETY: require_df_and_schema() validated schema above
         Arc::clone(table.schema.as_ref().expect("schema validated by require_df_and_schema")),
-        captured_sort_keys,
-        table.source_parquet_path.clone(),
+        captured_specs,
+        None,
     ))
-}
-
-/// Build DataFusion `Vec<Vec<SortExpr>>` from column name strings.
-///
-/// Each column is assumed ascending with nulls_first = true, matching
-/// `build_sort_exprs` in linear_scan.rs.
-fn build_df_sort_order(sort_keys: &[String]) -> Vec<Vec<SortExpr>> {
-    vec![sort_keys
-        .iter()
-        .map(|col_name| SortExpr {
-            expr: Expr::Column(Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
-        .collect()]
 }
 
 /// Declare sort order metadata without physically sorting the data.
@@ -123,6 +111,7 @@ fn build_df_sort_order(sort_keys: &[String]) -> Vec<Vec<SortExpr>> {
 pub fn assume_sorted_impl(
     table: &LTSeqTable,
     sort_exprs: Vec<Bound<'_, PyDict>>,
+    desc_flags: Vec<bool>,
 ) -> PyResult<LTSeqTable> {
     // If no dataframe, return empty result
     if table.dataframe.is_none() {
@@ -136,18 +125,19 @@ pub fn assume_sorted_impl(
 
     let (df, _schema) = table.require_df_and_schema()?;
 
-    // Capture sort column names (same logic as sort_impl, but skip the actual sort)
-    let mut captured_sort_keys = Vec::new();
-    for expr_dict in sort_exprs.iter() {
+    // Capture sort specs (same logic as sort_impl, but skip the actual sort)
+    let mut captured_specs = Vec::new();
+    for (i, expr_dict) in sort_exprs.iter().enumerate() {
         let py_expr = dict_to_py_expr(expr_dict)?;
 
         if let PyExpr::Column(ref col_name) = py_expr {
-            captured_sort_keys.push(col_name.clone());
+            let is_desc = desc_flags.get(i).copied().unwrap_or(false);
+            captured_specs.push(SortSpec::new(col_name.clone(), is_desc));
         }
     }
 
     // Build DataFusion sort order for the optimizer
-    let sort_order = build_df_sort_order(&captured_sort_keys);
+    let sort_order = sort_specs_to_file_sort_order(&captured_specs);
 
     // Try Parquet re-read path first (fully lazy, no materialization)
     if let Some(ref path) = table.source_parquet_path {
@@ -170,7 +160,7 @@ pub fn assume_sorted_impl(
             Arc::clone(&table.session),
             result_df,
             result_schema,
-            captured_sort_keys,
+            captured_specs,
             table.source_parquet_path.clone(),
         ));
     }
@@ -190,7 +180,7 @@ pub fn assume_sorted_impl(
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
-            captured_sort_keys,
+            captured_specs,
             None,
         ));
     }
@@ -220,7 +210,7 @@ pub fn assume_sorted_impl(
         Arc::clone(&table.session),
         result_df,
         batch_schema,
-        captured_sort_keys,
+        captured_specs,
         None,
     ))
 }

--- a/src/ops/window.rs
+++ b/src/ops/window.rs
@@ -183,17 +183,8 @@ async fn build_derived_select_parts(
         let is_rolling_agg = expr_sql.contains("__ROLLING_");
         let is_diff = expr_sql.contains("__DIFF_");
 
-        // Build ORDER BY clause from sort expressions
-        let order_by = if !table.sort_exprs.is_empty() {
-            table
-                .sort_exprs
-                .iter()
-                .map(|col| format!("\"{}\"", col))
-                .collect::<Vec<_>>()
-                .join(", ")
-        } else {
-            "".to_string()
-        };
+        // Build ORDER BY clause from sort specs (direction-aware)
+        let order_by = crate::metadata::sort_specs_to_sql_order_by(&table.sort_specs);
 
         // Apply window frame transformation
         let full_expr = apply_window_frame(&expr_sql, &order_by, is_rolling_agg, is_diff);
@@ -285,7 +276,7 @@ fn try_native_window_derive(
     // Convert each derived column's PyExpr to a native DataFusion window Expr
     for (col_name_str, py_expr) in parsed_cols.iter() {
         // Convert to native DataFusion window expression
-        let window_expr = pyexpr_to_window_expr(py_expr.clone(), schema, &table.sort_exprs)
+        let window_expr = pyexpr_to_window_expr(py_expr.clone(), schema, &table.sort_specs)
             .map_err(LtseqError::Transpile)?;
 
         all_exprs.push(window_expr.alias(col_name_str));
@@ -302,8 +293,8 @@ fn try_native_window_derive(
     Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
         result_df,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // column set changed relative to the raw file: drop fast-path token
     ))
 }
 
@@ -361,8 +352,8 @@ fn derive_with_window_functions_sql_fallback(
         Ok(LTSeqTable::from_df(
             Arc::clone(&table.session),
             new_df,
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // column set changed relative to the raw file: drop fast-path token
         ))
     })
 }
@@ -412,14 +403,9 @@ async fn build_cumsum_select_parts(
             }
         }
 
-        // Build ORDER BY clause from sort expressions
-        let order_by = if !table.sort_exprs.is_empty() {
-            let order_cols = table
-                .sort_exprs
-                .iter()
-                .map(|col| format!("\"{}\"", col))
-                .collect::<Vec<_>>()
-                .join(", ");
+        // Build ORDER BY clause from sort specs (direction-aware)
+        let order_cols = crate::metadata::sort_specs_to_sql_order_by(&table.sort_specs);
+        let order_by = if !order_cols.is_empty() {
             format!(" ORDER BY {}", order_cols)
         } else {
             "".to_string()
@@ -454,8 +440,8 @@ pub fn cum_sum_impl(table: &LTSeqTable, cum_exprs: Vec<Bound<'_, PyDict>>) -> Py
         return Ok(LTSeqTable::empty(
             Arc::clone(&table.session),
             table.schema.as_ref().map(Arc::clone),
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // column set changed relative to the raw file: drop fast-path token
         ));
     }
 
@@ -491,16 +477,8 @@ fn try_native_cum_sum(
         all_exprs.push(Expr::Column(Column::new_unqualified(field.name())));
     }
 
-    // Build sort expressions
-    let order_by: Vec<Sort> = table
-        .sort_exprs
-        .iter()
-        .map(|col_name| Sort {
-            expr: Expr::Column(Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
-        .collect();
+    // Build sort expressions from sort specs (direction-aware)
+    let order_by: Vec<Sort> = crate::metadata::sort_specs_to_window_sorts(&table.sort_specs);
 
     // Add cumulative sum columns for each input column
     for (idx, expr_item) in cum_exprs.iter().enumerate() {
@@ -580,8 +558,8 @@ fn try_native_cum_sum(
     Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
         result_df,
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // column set changed relative to the raw file: drop fast-path token
     ))
 }
 
@@ -641,8 +619,8 @@ fn cum_sum_sql_fallback(
         Ok(LTSeqTable::from_df(
             Arc::clone(&table.session),
             new_df,
-            table.sort_exprs.clone(),
-            table.source_parquet_path.clone(),
+            table.sort_specs.clone(),
+            None, // column set changed relative to the raw file: drop fast-path token
         ))
     })
 }
@@ -683,7 +661,7 @@ async fn handle_empty_cum_sum(
     Ok(LTSeqTable::empty(
         Arc::clone(&table.session),
         Some(Arc::new(new_arrow_schema)),
-        table.sort_exprs.clone(),
-        table.source_parquet_path.clone(),
+        table.sort_specs.clone(),
+        None, // column set changed relative to the raw file: drop fast-path token
     ))
 }

--- a/src/transpiler/window_native.rs
+++ b/src/transpiler/window_native.rs
@@ -166,21 +166,17 @@ pub(crate) fn finalize_window_expr(
 pub fn pyexpr_to_window_expr(
     py_expr: PyExpr,
     schema: &ArrowSchema,
-    sort_exprs: &[String],
+    sort_specs: &[crate::SortSpec],
 ) -> Result<Expr, String> {
     // Filter out sort expressions that duplicate partition_by columns.
     // Within a partition, all rows share the same partition key values,
     // so ordering by a partition key is redundant and wastes sort effort.
     let partition_cols = peek_partition_by_cols(&py_expr);
 
-    let order_by: Vec<Sort> = sort_exprs
+    let order_by: Vec<Sort> = sort_specs
         .iter()
-        .filter(|col_name| !partition_cols.contains(col_name))
-        .map(|col_name| Sort {
-            expr: Expr::Column(datafusion::common::Column::new_unqualified(col_name)),
-            asc: true,
-            nulls_first: true,
-        })
+        .filter(|spec| !partition_cols.contains(&spec.column))
+        .map(|spec| spec.to_window_sort())
         .collect();
 
     pyexpr_to_window_inner(py_expr, schema, &order_by)


### PR DESCRIPTION
按 #95 的 v2 执行方案（含 design review 修订）实施。

## 改动

### 新增 `src/metadata.rs`
`SortSpec { column, descending, nulls_first }` + 4 个转换 helper（`to_df_sort_expr` / `to_window_sort` / `file_sort_order` / `sql_order_by`）。`nulls_first = descending` 与 `sort_impl` 既有行为一致。传播规则文档化在模块头注释。

### Bug 1 修复：DESC 表窗口函数
- `LTSeqTable.sort_exprs: Vec<String>` → `sort_specs: Vec<SortSpec>`，全部构造器签名随之改变（编译器驱动迁移，65+ 调用点）
- **13 处硬编码 `asc: true, nulls_first: true` 的重建点全部改为从 SortSpec 派生**：window_native.rs、window.rs（native + SQL fallback ×2）、grouping.rs、linear_scan.rs（×4）、pattern_match.rs（经 `build_sort_exprs`）、sort.rs（assume_sorted file_sort_order）
- `assume_sorted` 新增 `desc_flags` FFI 参数，Python 端 `desc=True` 现在真正传到 Rust（此前收下即丢）

### Bug 2 修复：filter 后 Parquet 快速路径扫原始文件
按传播规则表收敛 `source_parquet_path`：**只有 `assume_sorted` 保留**。`sort`（物理排序后文件序失效）、`filter`/`select`/`slice`/`derive`/窗口派生/group_id/pattern 结果、distinct/join/agg/mutation 全部清空。红灯测试从 `assert 5 == 3`（快速路径扫了未过滤文件）转绿。

### sort_specs 传播规则（收敛自 ~140 处手抄）
- 保序 op（filter/search_first/select†/slice/derive/窗口/first_row/last_row/group_id/pattern 结果）：克隆
- 破坏序 op（distinct/union/intersect/diff/join/agg/insert/delete/update/modify/rvs）：清空——mutation 与 Python 端 `_sort_keys = None` 行为对齐
- † select 新增 Rust 端校验：排序列被投影掉时清空（此前盲传，下游会引用不存在的列）
- `set_ops::create_result_table` / `join::build_result_table_from_df` 按 review 意见去掉 sort 参数

## 测试

新增两个回归文件（先红后绿，红灯输出见 #95）：
- `test_sort_spec_desc_windows.py`：DESC shift/diff/cum_sum/rolling、多列混合方向 shift、`assume_sorted(desc=True)` shift —— 7 项中 6 项在 main 上红
- `test_parquet_fast_path_metadata.py`：`read_parquet → assume_sorted → filter → group_ordered → first().count()`，main 上返回 5（原始文件行数）而非 3

**对 issue 规格的两处修正**（发现于写红灯测试时）：
1. 混合方向测试的期望值：`shift(1)` 无 `partition_by` 不在组边界重置，B,4 行的 prev 应为表序上一行 A,1 的 10.0（issue 里写的 NaN 是按分区语义算的）
2. 快速路径测试谓词：issue 里的 `(r.val - r.val.shift(1)).is_null()` 过滤前后都只有 1 个组，无法区分两条路径；改为 `r.val != r.val.shift(1)`（值互异 → 每行一组 → 3 vs 5），这才让 assert==3 成立并实锤了 Bug 2

## 验证

- `cargo check` 0 错误（5 个警告为 main 已有）；`cargo test` 通过
- pytest：**1295 passed**；3 个失败均为 `test_benchmark_autoresearch_controller` 的 macOS bash 3.2 环境问题（`local: -n`），已验证 main 上同样失败
- 验收 grep：`sort_exprs: Vec<String>`、`sort_exprs: &[String]`、`sort_keys: &[String]` 在 src/ 中零残留
- pyright 45 errors，与 main 持平

### 性能（bench_core，release，M1 Pro；main ×2 轮 vs branch ×3 轮）

- **规模档（100k/1M，真实 per-row 成本会显形的档位）全部通过**：`group_ordered_100000` +0.9%、`window_lag_100000` +4.5%、`window_cumsum_100000` +3.1%、`filter_1M` **-7.8%**、`derive_1M` +0.0%、`join` -0.4%~+1.0%、`group_agg_100000` +2.5% —— issue 的保护 workload gate（<5% 回退）通过
- 10k 微基准档（1.5~3ms，固定开销主导）中位数普遍 +5~16%，**但完全未触碰的对照路径同幅波动**（`read_csv_10000` +14.8%、`write_parquet_10000` +13.3%、亚毫秒的 `read_parquet` ±19~18% 双向摆动），且 >5% 集合在三轮间不稳定（如 `derive_multi` +15.2% → +0.6%）——判定为共享笔记本的运行间噪声，非代码回退
- 说明：`bench_vs.py --sample` 所需 `hits_sample.parquet` 本机不存在，未跑 ClickBench 对比（R2 sessionization 的代理是 `group_ordered`，+0.9%）；mutation benchmark 因 main 已有的 `Cannot convert Python value for column 'amount'` 崩溃而排除（两侧一致）

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
