### PR TITLE
perf: aggregation 迁移到纯 native DataFusion 计划 + SQL 往返静态守卫 (#91 PR 1+2)

### DIFF
--- a/py-ltseq/tests/test_no_materialization_rule.py
+++ b/py-ltseq/tests/test_no_materialization_rule.py
@@ -88,3 +88,104 @@ def test_table_returning_query_apis_do_not_materialize() -> None:
                     )
 
     assert not violations, "\n".join(violations)
+
+
+# =============================================================================
+# Rust-side guard (issue #91): table-returning ops must not round-trip through
+# "collect → MemTable → session.sql() → collect".
+#
+# Function-level allowlist per the issue's matrix. Modules still on the SQL
+# path are strict-xfail: when a migration PR lands, its xpass forces the
+# marker's removal, turning the guard into the module's acceptance lock.
+# =============================================================================
+
+import re
+
+import pytest
+
+# Tokens that indicate a SQL round-trip / temp-table materialization.
+RUST_ROUNDTRIP_TOKENS = (
+    "session.sql",
+    ".sql(&",
+    "execute_sql_query(",
+    "MemTable::try_new",
+    "register_table(",
+)
+
+_RUST_FN_RE = re.compile(r"^(?:pub(?:\(crate\))? )?(?:async )?fn (\w+)", re.M)
+
+
+def _rust_functions(source: str) -> list[tuple[str, str]]:
+    """Split a Rust source file into (fn_name, body_text) at top-level fns."""
+    matches = list(_RUST_FN_RE.finditer(source))
+    out = []
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(source)
+        out.append((m.group(1), source[m.start():end]))
+    return out
+
+
+def _scan_rust_file(rel_path: str, allowed_fns: set) -> list[str]:
+    source = (REPO_ROOT / rel_path).read_text()
+    violations = []
+    for fn_name, body in _rust_functions(source):
+        if fn_name in allowed_fns:
+            continue
+        for token in RUST_ROUNDTRIP_TOKENS:
+            if token in body:
+                violations.append(f"{rel_path}: fn {fn_name} uses {token}")
+    return violations
+
+
+RUST_GUARD_PARAMS = [
+    # (file, allowlisted fns, xfail reason or None)
+    pytest.param(
+        "src/ops/aggregation.rs",
+        # filter_where uses session.sql as a parser-as-library (empty table,
+        # no data round-trip) — explicitly allowlisted by issue #91.
+        {"filter_where_impl"},
+        id="aggregation",
+    ),
+    pytest.param(
+        "src/ops/window.rs",
+        set(),
+        marks=pytest.mark.xfail(reason="pending PR 3 of #91 (window SQL fallback)", strict=True),
+        id="window",
+    ),
+    pytest.param(
+        "src/ops/grouping.rs",
+        set(),
+        marks=pytest.mark.xfail(reason="pending PR 4 of #91 (group window)", strict=True),
+        id="grouping",
+    ),
+    pytest.param(
+        "src/ops/derive_sql.rs",
+        set(),
+        marks=pytest.mark.xfail(reason="pending PR 4 of #91 (group window)", strict=True),
+        id="derive_sql",
+    ),
+    pytest.param(
+        "src/ops/align.rs",
+        set(),
+        marks=pytest.mark.xfail(reason="pending PR 5 of #91 (native align join)", strict=True),
+        id="align",
+    ),
+    pytest.param(
+        "src/ops/set_ops.rs",
+        set(),
+        marks=pytest.mark.xfail(reason="pending PR 6 of #91 (native set ops)", strict=True),
+        id="set_ops",
+    ),
+    pytest.param(
+        "src/ops/common.rs",
+        set(),
+        marks=pytest.mark.xfail(reason="pending PR 6/7 of #91 (SQL helper removal)", strict=True),
+        id="common",
+    ),
+]
+
+
+@pytest.mark.parametrize("rel_path,allowed_fns", RUST_GUARD_PARAMS)
+def test_rust_table_ops_do_not_sql_roundtrip(rel_path: str, allowed_fns: set) -> None:
+    violations = _scan_rust_file(rel_path, allowed_fns)
+    assert not violations, "\n".join(violations)

--- a/py-ltseq/tests/test_no_materialization_rule.py
+++ b/py-ltseq/tests/test_no_materialization_rule.py
@@ -112,21 +112,37 @@ RUST_ROUNDTRIP_TOKENS = (
     "register_table(",
 )
 
+# Matches only column-0 `fn` declarations. Assumption (holds for all scanned
+# ops modules): helpers are top-level fns, not methods in `impl` blocks.
+# Anything between two top-level fns — including an indented `impl` block —
+# is attributed to the PRECEDING fn's segment, so its tokens are still
+# scanned (just reported under that fn's name); text before the first fn is
+# scanned as "<module-prelude>". A token can therefore never hide entirely,
+# but if an impl block ever follows an allowlisted fn, move it or split the
+# allowlist entry.
 _RUST_FN_RE = re.compile(r"^(?:pub(?:\(crate\))? )?(?:async )?fn (\w+)", re.M)
 
 
 def _rust_functions(source: str) -> list[tuple[str, str]]:
-    """Split a Rust source file into (fn_name, body_text) at top-level fns."""
+    """Split a Rust source file into (name, segment) chunks covering the file."""
     matches = list(_RUST_FN_RE.finditer(source))
     out = []
+    if matches and matches[0].start() > 0:
+        out.append(("<module-prelude>", source[: matches[0].start()]))
+    elif not matches:
+        out.append(("<module-prelude>", source))
     for i, m in enumerate(matches):
         end = matches[i + 1].start() if i + 1 < len(matches) else len(source)
         out.append((m.group(1), source[m.start():end]))
     return out
 
 
+_RUST_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
 def _scan_rust_file(rel_path: str, allowed_fns: set) -> list[str]:
-    source = (REPO_ROOT / rel_path).read_text()
+    # Strip line comments so documentation may mention the forbidden tokens.
+    source = _RUST_LINE_COMMENT_RE.sub("", (REPO_ROOT / rel_path).read_text())
     violations = []
     for fn_name, body in _rust_functions(source):
         if fn_name in allowed_fns:

--- a/py-ltseq/tests/test_statistical_aggs.py
+++ b/py-ltseq/tests/test_statistical_aggs.py
@@ -284,3 +284,60 @@ class TestStatisticalEdgeCases:
 
         a_row = df[df["group"] == "A"].iloc[0]
         assert a_row["p50"] == 100.0
+
+
+class TestSkew:
+    """Numeric tests for skew() (added with the native migration, #91 PR 2).
+
+    Expected values follow the population-moment formula the implementation
+    (and the legacy SQL before it) uses:
+        (E[x**3] - 3*E[x**2]*E[x] + 2*E[x]**3) / stddev_pop(x)**3
+    """
+
+    @pytest.fixture
+    def grouped_table(self):
+        csv = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        csv.write("g,x\n")
+        for row in ["a,1", "a,2", "a,9", "b,1", "b,2", "b,3"]:
+            csv.write(row + "\n")
+        csv.close()
+        yield LTSeq.read_csv(csv.name)
+        os.unlink(csv.name)
+
+    @staticmethod
+    def _expected_skew(values):
+        n = len(values)
+        m1 = sum(values) / n
+        m2 = sum(v * v for v in values) / n
+        m3 = sum(v * v * v for v in values) / n
+        sd = (m2 - m1 * m1) ** 0.5
+        return (m3 - 3 * m2 * m1 + 2 * m1**3) / sd**3
+
+    def test_skew_method_form(self, grouped_table):
+        """g.x.skew(): symmetric group -> 0, right-skewed group -> positive."""
+        df = (
+            grouped_table.agg(by=lambda r: r.g, s=lambda g: g.x.skew())
+            .to_pandas()
+            .sort_values("g")
+            .reset_index(drop=True)
+        )
+        assert df["s"][0] == pytest.approx(self._expected_skew([1, 2, 9]))
+        assert df["s"][0] > 0  # right-skewed
+        assert df["s"][1] == pytest.approx(0.0)  # symmetric
+
+    def test_skew_free_function_form(self, grouped_table):
+        """skew(g.x): the exported free function must match the method form.
+
+        (Previously broken on both the SQL and native paths: the free
+        function carries the column in args[0], not `on`.)
+        """
+        from ltseq import skew
+
+        df = (
+            grouped_table.agg(by=lambda r: r.g, s=lambda g: skew(g.x))
+            .to_pandas()
+            .sort_values("g")
+            .reset_index(drop=True)
+        )
+        assert df["s"][0] == pytest.approx(self._expected_skew([1, 2, 9]))
+        assert df["s"][1] == pytest.approx(0.0)

--- a/py-ltseq/tests/test_top_k.py
+++ b/py-ltseq/tests/test_top_k.py
@@ -210,3 +210,24 @@ class TestTopKWithOtherAggregates:
         for _, row in df.iterrows():
             top_values = parse_top_k(row["top_quarters"])
             assert len(top_values) == 2
+
+
+class TestTopKNulls:
+    """Locks the legacy null semantics through the native migration (#91):
+    ORDER BY col DESC places nulls first (DataFusion SQL default), so nulls
+    consume top-k slots and are then dropped by array_to_string."""
+
+    def test_top_k_nulls_consume_slots(self):
+        csv = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        csv.write("g,v\n")
+        for row in ["a,10", "a,", "a,30", "a,20"]:
+            csv.write(row + "\n")
+        csv.close()
+        try:
+            t = LTSeq.read_csv(csv.name)
+            top_fn = lambda g: g.v.top_k(2)  # noqa: E731
+            df = t.agg(by=lambda r: r.g, top=top_fn).to_pandas()
+            # [null, 30, 20, 10] sliced to [null, 30]; null dropped in join.
+            assert df["top"][0] == "30"
+        finally:
+            os.unlink(csv.name)

--- a/src/ops/aggregation.rs
+++ b/src/ops/aggregation.rs
@@ -257,11 +257,18 @@ fn pyexpr_to_agg_plan(
         // hidden aliases: (E[x³] - 3·E[x²]·E[x] + 2·E[x]³) / stddev_pop(x)³.
         // Values are cast to Float64 up front to avoid integer overflow.
         "skew" => {
-            let PyExpr::Column(col_name) = on.as_ref() else {
-                return Err("skew requires a column reference".to_string());
+            // Method form g.col.skew() carries the column in `on`; the
+            // exported free function skew(g.col) leaves `on` as the empty
+            // placeholder and passes the column in args[0].
+            let col_name = match on.as_ref() {
+                PyExpr::Column(name) if !name.is_empty() => name.clone(),
+                _ => match args.first() {
+                    Some(PyExpr::Column(name)) if !name.is_empty() => name.clone(),
+                    _ => return Err("skew requires a column reference".to_string()),
+                },
             };
             let x = cast(
-                Expr::Column(Column::new_unqualified(col_name)),
+                Expr::Column(Column::new_unqualified(&col_name)),
                 DataType::Float64,
             );
 
@@ -277,13 +284,14 @@ fn pyexpr_to_agg_plan(
                 (sd_name.clone(), agg_fn::stddev_pop(x)),
             ];
 
-            let m1 = || Expr::Column(Column::new_unqualified(&m1_name));
+            let m1 = Expr::Column(Column::new_unqualified(&m1_name));
             let m2 = Expr::Column(Column::new_unqualified(&m2_name));
             let m3 = Expr::Column(Column::new_unqualified(&m3_name));
             let sd = Expr::Column(Column::new_unqualified(&sd_name));
 
             use datafusion::functions::expr_fn::{nullif, power};
-            let numerator = m3 - lit(3.0) * m2 * m1() + lit(2.0) * power(m1(), lit(3.0));
+            let numerator =
+                m3 - lit(3.0) * m2 * m1.clone() + lit(2.0) * power(m1, lit(3.0));
             let post = numerator / nullif(power(sd, lit(3.0)), lit(0.0));
             Ok(AggPlan::Staged { parts, post })
         }

--- a/src/ops/aggregation.rs
+++ b/src/ops/aggregation.rs
@@ -1,31 +1,47 @@
 //! Aggregation operations for LTSeqTable
 //!
-//! Provides SQL GROUP BY aggregation and raw SQL WHERE filtering.
-//! Uses DataFusion's native df.aggregate() API for performance (no materialization).
+//! Fully native DataFusion `df.aggregate()` path (issue #91): the plan stays
+//! lazy — no collect, no MemTable, no SQL string round-trip. Aggregates that
+//! SQL would express as scalar-over-aggregate (top_k, skew) are planned in
+//! two stages: hidden aggregate parts in the Aggregate node, combined by a
+//! post-aggregation projection.
+//!
+//! `filter_where_impl` keeps its `session.sql()` call by design: it uses the
+//! SQL engine as a WHERE-clause parser against an empty table (allowlisted in
+//! issue #91 — no data ever round-trips).
 
 use crate::engine::RUNTIME;
 use crate::error::LtseqError;
-use crate::transpiler::pyexpr_to_sql;
 use crate::types::{dict_to_py_expr, PyExpr};
 use crate::LTSeqTable;
-use datafusion::arrow::datatypes::Schema as ArrowSchema;
+use datafusion::arrow::datatypes::{DataType, Schema as ArrowSchema};
 use datafusion::common::Column;
-use datafusion::datasource::MemTable;
 use datafusion::functions_aggregate::expr_fn as agg_fn;
-use datafusion::logical_expr::{case, Expr};
+use datafusion::logical_expr::{case, Expr, ExprFunctionExt, SortExpr};
 use datafusion::prelude::*;
 use datafusion::scalar::ScalarValue;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::sync::Arc;
 
-/// Convert a PyExpr aggregate call to a native DataFusion Expr.
-/// Returns Ok(Some(expr)) for supported aggregates, Ok(None) for unsupported ones
-/// that need the SQL fallback path (top_k, mode).
-fn pyexpr_to_agg_expr(
+/// How one requested aggregate is planned.
+enum AggPlan {
+    /// A single aggregate expression (aliased with the output key by the caller).
+    Plain(Expr),
+    /// Aggregate parts computed under hidden aliases in the Aggregate node,
+    /// combined into the final value by a post-aggregation projection.
+    Staged {
+        parts: Vec<(String, Expr)>,
+        post: Expr,
+    },
+}
+
+/// Every supported aggregate maps to a native plan — there is no fallback.
+fn pyexpr_to_agg_plan(
     py_expr: &PyExpr,
     schema: &ArrowSchema,
-) -> Result<Option<Expr>, String> {
+    out_key: &str,
+) -> Result<AggPlan, String> {
     let PyExpr::Call { func, on, args, .. } = py_expr else {
         return Err("Expected aggregate function call".to_string());
     };
@@ -56,7 +72,7 @@ fn pyexpr_to_agg_expr(
                 "stddev" | "std" => agg_fn::stddev(col_expr),
                 _ => unreachable!(),
             };
-            Ok(Some(agg_expr))
+            Ok(AggPlan::Plain(agg_expr))
         }
         "percentile" => {
             let col_expr = match on.as_ref() {
@@ -73,7 +89,7 @@ fn pyexpr_to_agg_expr(
                 }
             }).unwrap_or(0.5);
             let sort = datafusion::logical_expr::SortExpr::new(col_expr, true, false);
-            Ok(Some(agg_fn::approx_percentile_cont(sort, lit(p), None)))
+            Ok(AggPlan::Plain(agg_fn::approx_percentile_cont(sort, lit(p), None)))
         }
         // Conditional aggregations
         "count_if" => {
@@ -84,7 +100,7 @@ fn pyexpr_to_agg_expr(
                 .when(lit(true), lit(1i64))
                 .otherwise(lit(0i64))
                 .map_err(|e| format!("Failed to create CASE: {}", e))?;
-            Ok(Some(agg_fn::sum(case_expr)))
+            Ok(AggPlan::Plain(agg_fn::sum(case_expr)))
         }
         "sum_if" | "avg_if" | "min_if" | "max_if" => {
             if args.len() < 2 {
@@ -110,7 +126,7 @@ fn pyexpr_to_agg_expr(
                 "max_if" => agg_fn::max(case_expr),
                 _ => unreachable!(),
             };
-            Ok(Some(agg_expr))
+            Ok(AggPlan::Plain(agg_expr))
         }
         // Statistical aggregates — native DataFusion path
         "corr" => {
@@ -132,7 +148,7 @@ fn pyexpr_to_agg_expr(
                     crate::transpiler::pyexpr_to_datafusion(args[0].clone(), schema)?,
                 )
             };
-            Ok(Some(agg_fn::corr(col_a, col_b)))
+            Ok(AggPlan::Plain(agg_fn::corr(col_a, col_b)))
         }
         "covar" => {
             let (col_a, col_b) = if matches!(on.as_ref(), PyExpr::Column(name) if name.is_empty()) {
@@ -152,7 +168,7 @@ fn pyexpr_to_agg_expr(
                     crate::transpiler::pyexpr_to_datafusion(args[0].clone(), schema)?,
                 )
             };
-            Ok(Some(agg_fn::covar_samp(col_a, col_b)))
+            Ok(AggPlan::Plain(agg_fn::covar_samp(col_a, col_b)))
         }
         "concat_agg" => {
             // concat_agg(col, delimiter) — uses native string_agg UDAF
@@ -177,11 +193,100 @@ fn pyexpr_to_agg_expr(
                 (col, delim)
             };
             use datafusion::functions_aggregate::string_agg::string_agg;
-            Ok(Some(string_agg(col_expr, delim_expr)))
+            Ok(AggPlan::Plain(string_agg(col_expr, delim_expr)))
         }
-        // Complex aggregates that need SQL path
-        // skew → SQL fallback using moment formula
-        "top_k" | "mode" | "skew" => Ok(None),
+        // top_k(col, k) → ordered array_agg under a hidden alias, then
+        // array_slice + array_to_string in the post-aggregation projection.
+        // Output format (semicolon-joined doubles, descending) matches the
+        // legacy SQL expression exactly.
+        "top_k" => {
+            let PyExpr::Column(col_name) = on.as_ref() else {
+                return Err("top_k requires a column reference".to_string());
+            };
+            let k = args
+                .first()
+                .and_then(|arg| {
+                    if let PyExpr::Literal { value, .. } = arg {
+                        value.parse::<i64>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(10);
+
+            let col_f64 = cast(
+                Expr::Column(Column::new_unqualified(col_name)),
+                DataType::Float64,
+            );
+            // ORDER BY col DESC (SQL default for DESC: nulls first)
+            let sort = SortExpr::new(col_f64.clone(), false, true);
+            let agg = agg_fn::array_agg(col_f64)
+                .order_by(vec![sort])
+                .build()
+                .map_err(|e| format!("Failed to build top_k array_agg: {}", e))?;
+
+            let hidden = format!("__{}_topk_arr", out_key);
+            use datafusion::functions_nested::expr_fn::{array_slice, array_to_string};
+            let post = array_to_string(
+                array_slice(
+                    Expr::Column(Column::new_unqualified(&hidden)),
+                    lit(1i64),
+                    lit(k),
+                    None,
+                ),
+                lit(";"),
+            );
+            Ok(AggPlan::Staged {
+                parts: vec![(hidden, agg)],
+                post,
+            })
+        }
+        // mode keeps the legacy behavior (FIRST_VALUE ordered ascending —
+        // i.e. min, not a true statistical mode). Real mode semantics are
+        // deferred per issue #91 risk 3.
+        "mode" => {
+            let PyExpr::Column(col_name) = on.as_ref() else {
+                return Err("mode requires a column reference".to_string());
+            };
+            let col_expr = Expr::Column(Column::new_unqualified(col_name));
+            let sort = SortExpr::new(col_expr.clone(), true, false);
+            let agg = agg_fn::first_value(col_expr, vec![sort]);
+            Ok(AggPlan::Plain(agg))
+        }
+        // skew via the moment formula, composed from native aggregates over
+        // hidden aliases: (E[x³] - 3·E[x²]·E[x] + 2·E[x]³) / stddev_pop(x)³.
+        // Values are cast to Float64 up front to avoid integer overflow.
+        "skew" => {
+            let PyExpr::Column(col_name) = on.as_ref() else {
+                return Err("skew requires a column reference".to_string());
+            };
+            let x = cast(
+                Expr::Column(Column::new_unqualified(col_name)),
+                DataType::Float64,
+            );
+
+            let m1_name = format!("__{}_skew_m1", out_key);
+            let m2_name = format!("__{}_skew_m2", out_key);
+            let m3_name = format!("__{}_skew_m3", out_key);
+            let sd_name = format!("__{}_skew_sd", out_key);
+
+            let parts = vec![
+                (m1_name.clone(), agg_fn::avg(x.clone())),
+                (m2_name.clone(), agg_fn::avg(x.clone() * x.clone())),
+                (m3_name.clone(), agg_fn::avg(x.clone() * x.clone() * x.clone())),
+                (sd_name.clone(), agg_fn::stddev_pop(x)),
+            ];
+
+            let m1 = || Expr::Column(Column::new_unqualified(&m1_name));
+            let m2 = Expr::Column(Column::new_unqualified(&m2_name));
+            let m3 = Expr::Column(Column::new_unqualified(&m3_name));
+            let sd = Expr::Column(Column::new_unqualified(&sd_name));
+
+            use datafusion::functions::expr_fn::{nullif, power};
+            let numerator = m3 - lit(3.0) * m2 * m1() + lit(2.0) * power(m1(), lit(3.0));
+            let post = numerator / nullif(power(sd, lit(3.0)), lit(0.0));
+            Ok(AggPlan::Staged { parts, post })
+        }
         _ => Err(format!("Unknown aggregate function: {}", func)),
     }
 }
@@ -205,7 +310,8 @@ fn parse_group_exprs(
 }
 
 /// Aggregate rows into a summary table with one row per group.
-/// Uses native DataFusion df.aggregate() API — no materialization needed.
+/// Fully lazy: builds an Aggregate (plus, when needed, a post-aggregation
+/// projection) on the logical plan and returns without collecting.
 pub fn agg_impl(
     table: &LTSeqTable,
     group_expr: Option<Bound<'_, PyDict>>,
@@ -213,9 +319,12 @@ pub fn agg_impl(
 ) -> PyResult<LTSeqTable> {
     let (df, schema) = table.require_df_and_schema()?;
 
-    // Try the native DataFusion path first: build aggregate Exprs directly
+    // Plan each requested aggregate.
     let mut agg_exprs: Vec<Expr> = Vec::new();
-    let mut needs_sql_fallback = false;
+    // (output key, final expression over hidden columns) — empty when no
+    // aggregate needs a post-aggregation projection.
+    let mut staged_posts: Vec<(String, Option<Expr>)> = Vec::new();
+    let mut any_staged = false;
 
     for (key, value) in agg_dict.iter() {
         let key_str = key
@@ -229,369 +338,66 @@ pub fn agg_impl(
         let py_expr = dict_to_py_expr(val_dict)
             .map_err(|e| LtseqError::Validation(format!("Failed to parse: {}", e)))?;
 
-        match pyexpr_to_agg_expr(&py_expr, schema) {
-            Ok(Some(expr)) => {
+        match pyexpr_to_agg_plan(&py_expr, schema, &key_str)
+            .map_err(LtseqError::Validation)?
+        {
+            AggPlan::Plain(expr) => {
                 agg_exprs.push(expr.alias(&key_str));
+                staged_posts.push((key_str, None));
             }
-            Ok(None) => {
-                // top_k or mode — need SQL fallback
-                needs_sql_fallback = true;
-                break;
-            }
-            Err(e) => {
-                return Err(LtseqError::Validation(e).into());
+            AggPlan::Staged { parts, post } => {
+                any_staged = true;
+                for (hidden_name, part_expr) in parts {
+                    agg_exprs.push(part_expr.alias(hidden_name));
+                }
+                staged_posts.push((key_str, Some(post)));
             }
         }
-    }
-
-    if needs_sql_fallback {
-        return agg_impl_sql_fallback(table, group_expr, agg_dict);
     }
 
     // Parse group expressions
     let group_exprs = parse_group_exprs(group_expr, schema)?;
+    let n_group = group_exprs.len();
 
-    // Execute native aggregate — stays lazy until collect!
-    let result_df = RUNTIME.block_on(async {
-        let cloned_df = (**df).clone();
-        let agg_df = cloned_df
-            .aggregate(group_exprs, agg_exprs)
-            .map_err(|e| format!("Aggregate failed: {}", e))?;
-        // Collect to get result schema
-        let batches = agg_df
-            .collect()
-            .await
-            .map_err(|e| format!("Collect failed: {}", e))?;
-        Ok::<_, String>(batches)
-    })
-    .map_err(LtseqError::Runtime)?;
+    // Build the lazy plan: Aggregate, then (only if needed) a projection that
+    // combines hidden aggregate parts into the requested outputs.
+    let agg_df = (**df)
+        .clone()
+        .aggregate(group_exprs, agg_exprs)
+        .map_err(|e| LtseqError::Runtime(format!("Aggregate failed: {}", e)))?;
 
-    create_result_table(table, result_df)
-}
+    let result_df = if any_staged {
+        // Group columns come first in the Aggregate output schema.
+        let group_cols: Vec<Expr> = agg_df
+            .schema()
+            .fields()
+            .iter()
+            .take(n_group)
+            .map(|f| Expr::Column(Column::new_unqualified(f.name())))
+            .collect();
 
-/// SQL-based fallback for complex aggregates (top_k, mode)
-fn agg_impl_sql_fallback(
-    table: &LTSeqTable,
-    group_expr: Option<Bound<'_, PyDict>>,
-    agg_dict: &Bound<'_, PyDict>,
-) -> PyResult<LTSeqTable> {
-    let (df, schema) = table.require_df_and_schema()?;
-
-    let mut agg_select_parts: Vec<String> = Vec::new();
-
-    for (key, value) in agg_dict.iter() {
-        let key_str = key
-            .extract::<String>()
-            .map_err(|_| LtseqError::TypeMismatch("Agg key must be string".into()))?;
-
-        let val_dict = value
-            .cast::<PyDict>()
-            .map_err(|_| LtseqError::TypeMismatch("Agg value must be dict".into()))?;
-
-        let py_expr = dict_to_py_expr(val_dict)
-            .map_err(|e| LtseqError::Validation(format!("Failed to parse: {}", e)))?;
-
-        let agg_result = extract_agg_function(&py_expr, schema).ok_or_else(|| {
-            LtseqError::Validation(
-                "Invalid aggregate expression - must be g.column.agg_func() or g.count()"
-                    .into(),
-            )
-        })?;
-
-        let sql_expr =
-            agg_result_to_sql(agg_result).map_err(LtseqError::Validation)?;
-
-        agg_select_parts.push(format!("{} as {}", sql_expr, key_str));
-    }
-
-    let group_cols = parse_group_expr_sql(group_expr, schema)?;
-
-    // Register temp table (must materialize for SQL path)
-    let temp_table_name = "__ltseq_agg_temp";
-    let current_batches = collect_dataframe(df)?;
-    let arrow_schema = Arc::new((**schema).clone());
-
-    let temp_table = MemTable::try_new(arrow_schema, vec![current_batches])
-        .map_err(|e| LtseqError::Runtime(format!("Failed to create table: {}", e)))?;
-
-    table
-        .session
-        .register_table(temp_table_name, Arc::new(temp_table))
-        .map_err(|e| LtseqError::Runtime(format!("Register failed: {}", e)))?;
-
-    let sql_query = build_agg_sql(&group_cols, &agg_select_parts, temp_table_name);
-    let result_batches =
-        execute_sql_query(table, &sql_query).map_err(LtseqError::Runtime)?;
-
-    let _ = table.session.deregister_table(temp_table_name);
-
-    create_result_table(table, result_batches)
-}
-
-// ============================================================================
-// SQL-path helpers (kept for fallback and filter_where_impl)
-// ============================================================================
-
-/// Result type for aggregate function extraction (SQL path)
-enum AggResult {
-    Simple(String, String, Option<String>),
-    Conditional(String, String, Option<String>),
-}
-
-fn extract_agg_function(py_expr: &PyExpr, schema: &ArrowSchema) -> Option<AggResult> {
-    let PyExpr::Call { func, on, args, .. } = py_expr else {
-        return None;
-    };
-
-    match func.as_str() {
-        "sum" | "count" | "min" | "max" | "avg" | "median" | "variance" | "var" | "stddev"
-        | "std" | "mode" | "skew" => extract_simple_agg(func, on, args),
-        "top_k" | "percentile" => extract_agg_with_arg(func, on, args),
-        "concat_agg" => extract_concat_agg(on, args),
-        "count_if" => extract_count_if(args, schema),
-        "sum_if" | "avg_if" | "min_if" | "max_if" => extract_conditional_agg(func, args, schema),
-        _ => None,
-    }
-}
-
-fn extract_concat_agg(on: &PyExpr, args: &[PyExpr]) -> Option<AggResult> {
-    let col_name = if let PyExpr::Column(name) = on {
-        if !name.is_empty() {
-            name.clone()
-        } else if let Some(PyExpr::Column(arg_name)) = args.first() {
-            arg_name.clone()
-        } else {
-            return None;
-        }
-    } else if let Some(PyExpr::Column(name)) = args.first() {
-        name.clone()
-    } else {
-        return None;
-    };
-
-    // Extract optional delimiter from args
-    let delim = if let PyExpr::Column(name) = on {
-        if name.is_empty() {
-            // standalone: args[0]=col, args[1]=delim
-            args.get(1).and_then(|a| {
-                if let PyExpr::Literal { value, .. } = a { Some(value.clone()) } else { None }
-            }).unwrap_or_else(|| ",".to_string())
-        } else {
-            // method: on=col, args[0]=delim
-            args.first().and_then(|a| {
-                if let PyExpr::Literal { value, .. } = a { Some(value.clone()) } else { None }
-            }).unwrap_or_else(|| ",".to_string())
-        }
-    } else {
-        ",".to_string()
-    };
-
-    Some(AggResult::Simple("concat_agg".to_string(), col_name, Some(delim)))
-}
-
-fn extract_simple_agg(func: &str, on: &PyExpr, _args: &[PyExpr]) -> Option<AggResult> {
-    if let PyExpr::Column(col_name) = on {
-        return Some(AggResult::Simple(func.to_string(), col_name.clone(), None));
-    }
-    if func == "count" {
-        return Some(AggResult::Simple(func.to_string(), "*".to_string(), None));
-    }
-    None
-}
-
-fn extract_agg_with_arg(func: &str, on: &PyExpr, args: &[PyExpr]) -> Option<AggResult> {
-    if let PyExpr::Column(col_name) = on {
-        let arg = args.first().and_then(|arg| {
-            if let PyExpr::Literal { value, .. } = arg {
-                Some(value.clone())
-            } else {
-                None
-            }
-        });
-        return Some(AggResult::Simple(func.to_string(), col_name.clone(), arg));
-    }
-    None
-}
-
-fn extract_count_if(args: &[PyExpr], schema: &ArrowSchema) -> Option<AggResult> {
-    let predicate = args.first()?;
-    let pred_sql = pyexpr_to_sql(predicate, schema).ok()?;
-    Some(AggResult::Conditional(
-        "count_if".to_string(),
-        pred_sql,
-        None,
-    ))
-}
-
-fn extract_conditional_agg(func: &str, args: &[PyExpr], schema: &ArrowSchema) -> Option<AggResult> {
-    if args.len() < 2 {
-        return None;
-    }
-    let pred_sql = pyexpr_to_sql(&args[0], schema).ok()?;
-    let col_sql = pyexpr_to_sql(&args[1], schema).ok()?;
-    Some(AggResult::Conditional(
-        func.to_string(),
-        pred_sql,
-        Some(col_sql),
-    ))
-}
-
-fn agg_result_to_sql(agg_result: AggResult) -> Result<String, String> {
-    match agg_result {
-        AggResult::Simple(agg_func, col_name, arg_opt) => {
-            simple_agg_to_sql(&agg_func, &col_name, arg_opt)
-        }
-        AggResult::Conditional(agg_func, pred_sql, col_opt) => {
-            conditional_agg_to_sql(&agg_func, &pred_sql, col_opt)
-        }
-    }
-}
-
-fn simple_agg_to_sql(func: &str, col: &str, arg: Option<String>) -> Result<String, String> {
-    Ok(match func {
-        "sum" => format!("SUM({})", col),
-        "count" => {
-            if col == "*" {
-                "COUNT(*)".to_string()
-            } else {
-                format!("COUNT({})", col)
+        let mut select_exprs = group_cols;
+        for (key, post) in staged_posts {
+            match post {
+                Some(post_expr) => select_exprs.push(post_expr.alias(&key)),
+                None => select_exprs.push(Expr::Column(Column::new_unqualified(&key))),
             }
         }
-        "min" => format!("MIN({})", col),
-        "max" => format!("MAX({})", col),
-        "avg" => format!("AVG({})", col),
-        "median" => format!("MEDIAN({})", col),
-        "variance" | "var" => format!("VAR_SAMP({})", col),
-        "stddev" | "std" => format!("STDDEV_SAMP({})", col),
-        "percentile" => {
-            let p = arg
-                .as_ref()
-                .and_then(|s| s.parse::<f64>().ok())
-                .unwrap_or(0.5);
-            format!("APPROX_PERCENTILE_CONT({}, {})", col, p)
-        }
-        "mode" => format!("FIRST_VALUE({} ORDER BY {} ASC)", col, col),
-        "top_k" => {
-            let k = arg
-                .as_ref()
-                .and_then(|s| s.parse::<i64>().ok())
-                .unwrap_or(10);
-            format!(
-                "ARRAY_TO_STRING(ARRAY_SLICE(ARRAY_AGG(CAST({} AS DOUBLE) ORDER BY CAST({} AS DOUBLE) DESC), 1, {}), ';')",
-                col, col, k
-            )
-        }
-        "skew" => format!(
-            "(AVG({col}*{col}*{col}) - 3*AVG({col}*{col})*AVG({col}) + 2*POWER(AVG({col}),3)) \
-             / NULLIF(POWER(STDDEV_POP({col}),3), 0)"
-        ),
-        "concat_agg" => {
-            let delim = arg.as_deref().unwrap_or(",");
-            let delim_escaped = delim.replace('\'', "''");
-            format!("STRING_AGG({}, '{}')", col, delim_escaped)
-        }
-        _ => return Err(format!("Unknown aggregate function: {}", func)),
-    })
-}
 
-fn conditional_agg_to_sql(func: &str, pred: &str, col: Option<String>) -> Result<String, String> {
-    let col_sql = col.unwrap_or_else(|| "1".to_string());
-    Ok(match func {
-        "count_if" => format!("SUM(CASE WHEN {} THEN 1 ELSE 0 END)", pred),
-        "sum_if" => format!("SUM(CASE WHEN {} THEN {} ELSE 0 END)", pred, col_sql),
-        "avg_if" => format!("AVG(CASE WHEN {} THEN {} ELSE NULL END)", pred, col_sql),
-        "min_if" => format!("MIN(CASE WHEN {} THEN {} ELSE NULL END)", pred, col_sql),
-        "max_if" => format!("MAX(CASE WHEN {} THEN {} ELSE NULL END)", pred, col_sql),
-        _ => return Err(format!("Unknown conditional aggregate: {}", func)),
-    })
-}
+        agg_df
+            .select(select_exprs)
+            .map_err(|e| LtseqError::Runtime(format!("Post-aggregation projection failed: {}", e)))?
+    } else {
+        agg_df
+    };
 
-fn execute_sql_query(
-    table: &LTSeqTable,
-    sql_query: &str,
-) -> Result<Vec<datafusion::arrow::array::RecordBatch>, String> {
-    RUNTIME.block_on(async {
-        let result_df = table
-            .session
-            .sql(sql_query)
-            .await
-            .map_err(|e| format!("Failed to execute query: {}", e))?;
-
-        result_df
-            .collect()
-            .await
-            .map_err(|e| format!("Failed to collect results: {}", e))
-    })
-}
-
-/// Create a result LTSeqTable from record batches
-fn create_result_table(
-    table: &LTSeqTable,
-    batches: Vec<datafusion::arrow::array::RecordBatch>,
-) -> PyResult<LTSeqTable> {
-    LTSeqTable::from_batches(
+    // Aggregation redefines row identity: no sort metadata, no fast-path token.
+    Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
-        batches,
+        result_df,
         Vec::new(),
         None,
-    )
-}
-
-/// Parse group expression into column names (SQL path)
-fn parse_group_expr_sql(
-    group_expr: Option<Bound<'_, PyDict>>,
-    schema: &Arc<ArrowSchema>,
-) -> PyResult<Option<Vec<String>>> {
-    let Some(group_expr_dict) = group_expr else {
-        return Ok(None);
-    };
-
-    let py_expr = dict_to_py_expr(&group_expr_dict)
-        .map_err(|e| LtseqError::Validation(format!("Failed to parse group: {}", e)))?;
-
-    match py_expr {
-        PyExpr::Column(col_name) => Ok(Some(vec![col_name])),
-        _ => {
-            let sql_expr =
-                crate::transpiler::pyexpr_to_datafusion(py_expr, schema).map_err(|e| {
-                    LtseqError::Validation(format!("Transpile failed: {}", e))
-                })?;
-            Ok(Some(vec![format!("{}", sql_expr)]))
-        }
-    }
-}
-
-/// Collect dataframe into record batches
-fn collect_dataframe(
-    df: &Arc<datafusion::dataframe::DataFrame>,
-) -> PyResult<Vec<datafusion::arrow::array::RecordBatch>> {
-    Ok(RUNTIME
-        .block_on(async {
-            (**df)
-                .clone()
-                .collect()
-                .await
-                .map_err(|e| format!("Failed to collect: {}", e))
-        })
-        .map_err(LtseqError::Runtime)?)
-}
-
-fn build_agg_sql(
-    group_cols: &Option<Vec<String>>,
-    agg_parts: &[String],
-    table_name: &str,
-) -> String {
-    if let Some(cols) = group_cols {
-        let group_str = cols.join(", ");
-        let agg_str = agg_parts.join(", ");
-        format!(
-            "SELECT {}, {} FROM {} GROUP BY {}",
-            group_str, agg_str, table_name, group_str
-        )
-    } else {
-        let agg_str = agg_parts.join(", ");
-        format!("SELECT {} FROM {}", agg_str, table_name)
-    }
+    ))
 }
 
 /// Filter rows using a raw SQL WHERE clause


### PR DESCRIPTION
issue #91 迁移系列的第一发：按推荐执行顺序交付 **PR 1（静态守卫）+ PR 2（aggregation native 迁移）**。

## Gate 0（已确认）

- SortSpec 已完成（#95/PR #98 合并）：`grep 'asc: true\|nulls_first: true' src/transpiler/window_native.rs` 与 `grep 'sort_exprs: Vec<String>' src/lib.rs` 均无结果 → PR 3/4 阻塞解除
- DataFusion 53（window frame / `ExprFunctionExt` / `functions_nested` API 可用）

## PR 1：函数级静态守卫

`test_no_materialization_rule.py` 新增 Rust 源码扫描：对 issue 矩阵中 6 个模块（+common.rs）按**函数级 allowlist** 检查 SQL 往返 token（`session.sql` / `execute_sql_query(` / `MemTable::try_new` / `register_table(`）：

- `aggregation.rs`：**本 PR 内红→绿**（allowlist 仅 `filter_where_impl`——parser-as-library 用法，空表解析 WHERE AST，无数据往返）
- window / grouping / derive_sql / align / set_ops / common：**strict xfail**，注明 pending PR 3-6——后续迁移 PR 落地时 xpass 强制摘除标记，守卫即验收锁

## PR 2：aggregation.rs 全 native + 全 lazy

**双物化消除**：此前即使 native 路径也 `collect()` 全量数据只为推导结果 schema，再经 `from_batches` 重建 MemTable；SQL fallback 路径（top_k/mode/skew 触发）更是完整的 collect→register→SQL→collect。现在 `agg_impl` 纯 LogicalPlan 构建，`from_df` 直接返回，**零 collect**。

**三个 SQL-only 聚合的 native 化**（两阶段方案：Aggregate 节点产出隐藏中间列 → 后置 projection 组合，因 DataFusion 的 Aggregate 节点不接受标量包裹聚合的表达式）：

- `top_k`：有序 `array_agg`（隐藏列）+ `array_slice`/`array_to_string` projection——输出格式与旧 SQL 表达式逐字节一致（分号连接、双精度、降序），现有测试无改动全过
- `skew`：矩公式由 native 聚合组合（avg x/x²/x³ + stddev_pop，输入先 cast Float64 防溢出）
- `mode`：native `first_value` 升序——**保留旧语义**（实为 min 而非真 mode），真 mode 语义按 issue 风险 3 defer

**删除 ~330 行 SQL 字符串拼装**：`agg_impl_sql_fallback`、`execute_sql_query`、`collect_dataframe`、`build_agg_sql`、`parse_group_expr_sql`、`AggResult` 及 `extract_*`/`*_to_sql` 全家。aggregation.rs 809→615 行。

## 验证

- 全量 pytest **1300 passed, 6 xfailed**（xfail 即待迁移模块的守卫）；cargo test 通过；pyright 45 与 main 持平
- targeted：test_agg / test_top_k / test_statistical_aggs / test_conditional_aggs 全过，**零测试改动**（输出格式兼容性验证）
- 守卫：`test_rust_table_ops_do_not_sql_roundtrip[aggregation]` 红→绿
- bench（release, M1 Pro）：见下方评论。R1 ClickBench gate 所需的 `hits_sorted.parquet` 本机不存在，本地代理为 bench_core 的 `group_agg_*` workload；建议合并后在有数据的环境跑一次 `benchmark_gate.py clickbench_top_urls` 确认 R1 改善

## 系列进度

- [x] Gate 0 / PR 1（守卫）/ PR 2（aggregation）← 本 PR
- [ ] PR 3（window 字符串手术）→ PR 4（grouping/derive_sql）→ PR 5（align）→ PR 6（set_ops）→ PR 7（清尾 sql_gen）

Refs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
