### PR TITLE
feat: native staged select 支持两层嵌套窗口 (#101)

### DIFF
--- a/py-ltseq/tests/test_sequence_ops_advanced.py
+++ b/py-ltseq/tests/test_sequence_ops_advanced.py
@@ -73,6 +73,9 @@ class TestSequenceChaining:
         assert one_step["prev_ma"].tolist() == pytest.approx(
             two_step["prev_ma"].tolist(), nan_ok=True
         )
+        # Direct row-order assertion on a stable key: derived values could
+        # coincide across rows, but the date sequence cannot.
+        assert one_step["date"].tolist() == two_step["date"].tolist()
         assert not any(c.startswith("__ltseq_stage_") for c in one_step.columns)
 
     def test_shift_then_rolling_sum_matches_two_step_derive(self, sample_csv):
@@ -92,6 +95,7 @@ class TestSequenceChaining:
         assert one_step["sum_prev"].tolist() == pytest.approx(
             two_step["sum_prev"].tolist(), nan_ok=True
         )
+        assert one_step["date"].tolist() == two_step["date"].tolist()
 
     def test_nested_window_mixed_with_plain_window_and_plain_expr(self, sample_csv):
         """Nested window, plain window and plain expression coexist in one
@@ -153,6 +157,34 @@ class TestSequenceChaining:
                     "x": r.price.rolling(3).mean().shift(1).rolling(2).sum(),
                 }
             )
+
+    def test_ranking_over_window_still_hints(self, sample_csv):
+        """Scope lock (issue #101 design review revision 2): the staged
+        planner deliberately does not enter PyExpr::Window (ranking) nodes.
+        A ranking ordered by a window result degrades to the actionable
+        hint — never to a silently wrong result."""
+        from ltseq import rank
+
+        t = LTSeq.read_csv(sample_csv).sort("date")
+
+        with pytest.raises(Exception, match="split it into two steps"):
+            t.derive(
+                lambda r: {"rk": rank().over(order_by=r.price.rolling(3).mean())}
+            )
+
+    def test_ranking_over_window_two_step_workaround(self, sample_csv):
+        """The documented workaround for ranking-over-window: stage the
+        window column first, then rank over it."""
+        from ltseq import rank
+
+        t = LTSeq.read_csv(sample_csv).sort("date")
+        df = (
+            t.derive(lambda r: {"ma_3": r.price.rolling(3).mean()})
+            .derive(lambda r: {"rk": rank().over(order_by=r.ma_3)})
+            .to_pandas()
+        )
+        assert "rk" in df.columns
+        assert len(df) == 5
 
     def test_hidden_stage_name_collision_avoided(self):
         """A user column literally named __ltseq_stage_0 must not collide

--- a/py-ltseq/tests/test_sequence_ops_advanced.py
+++ b/py-ltseq/tests/test_sequence_ops_advanced.py
@@ -53,18 +53,132 @@ class TestSequenceChaining:
         except Exception as e:
             pytest.skip(f"Combining shift() and diff() not yet implemented: {e}")
 
-    def test_rolling_and_shift_together_rejected_with_hint(self, sample_csv):
-        """Window-on-window in one derive raises a clear error (issue #91:
-        the SQL fallback is gone; native staged select is a tracked
-        follow-up). The error must point at the two-step workaround."""
+    def test_rolling_and_shift_together_matches_two_step_derive(self, sample_csv):
+        """Two-level nested windows plan natively via the staged select
+        (issue #101). The staged plan is LogicalPlan-isomorphic to the
+        manual two-step derive, so VALUES AND ROW ORDER must both match —
+        compared unsorted on purpose."""
+        t = LTSeq.read_csv(sample_csv).sort("date")
+
+        one_step = t.derive(
+            lambda r: {"prev_ma": r.price.rolling(3).mean().shift(1)}
+        ).to_pandas()
+
+        two_step = (
+            t.derive(lambda r: {"ma_3": r.price.rolling(3).mean()})
+            .derive(lambda r: {"prev_ma": r.ma_3.shift(1)})
+            .to_pandas()
+        )
+
+        assert one_step["prev_ma"].tolist() == pytest.approx(
+            two_step["prev_ma"].tolist(), nan_ok=True
+        )
+        assert not any(c.startswith("__ltseq_stage_") for c in one_step.columns)
+
+    def test_shift_then_rolling_sum_matches_two_step_derive(self, sample_csv):
+        """The reverse nesting direction: shift feeding a rolling sum."""
+        t = LTSeq.read_csv(sample_csv).sort("date")
+
+        one_step = t.derive(
+            lambda r: {"sum_prev": r.price.shift(1).rolling(3).sum()}
+        ).to_pandas()
+
+        two_step = (
+            t.derive(lambda r: {"prev": r.price.shift(1)})
+            .derive(lambda r: {"sum_prev": r.prev.rolling(3).sum()})
+            .to_pandas()
+        )
+
+        assert one_step["sum_prev"].tolist() == pytest.approx(
+            two_step["sum_prev"].tolist(), nan_ok=True
+        )
+
+    def test_nested_window_mixed_with_plain_window_and_plain_expr(self, sample_csv):
+        """Nested window, plain window and plain expression coexist in one
+        derive; hidden stage columns never reach the result."""
+        t = LTSeq.read_csv(sample_csv).sort("date")
+
+        df = t.derive(
+            lambda r: {
+                "prev_ma": r.price.rolling(3).mean().shift(1),
+                "prev_price": r.price.shift(1),
+                "double_volume": r.volume * 2,
+            }
+        ).to_pandas()
+
+        expected = (
+            t.derive(lambda r: {"ma_3": r.price.rolling(3).mean()})
+            .derive(lambda r: {"prev_ma": r.ma_3.shift(1)})
+            .to_pandas()
+        )
+
+        assert df["prev_ma"].tolist() == pytest.approx(
+            expected["prev_ma"].tolist(), nan_ok=True
+        )
+        assert df["prev_price"].tolist()[1:] == pytest.approx(
+            df["price"].tolist()[:-1]
+        )
+        assert df["double_volume"].tolist() == pytest.approx(
+            [v * 2 for v in df["volume"].tolist()]
+        )
+        assert not any(c.startswith("__ltseq_stage_") for c in df.columns)
+
+    def test_nested_window_in_arithmetic(self, sample_csv):
+        """A nested window inside arithmetic with plain windows."""
+        t = LTSeq.read_csv(sample_csv).sort("date")
+
+        df = t.derive(
+            lambda r: {
+                "momentum": r.price.rolling(3).mean().shift(1) - r.price.shift(1),
+            }
+        ).to_pandas()
+
+        expected = (
+            t.derive(lambda r: {"ma_3": r.price.rolling(3).mean()})
+            .derive(lambda r: {"momentum": r.ma_3.shift(1) - r.price.shift(1)})
+            .to_pandas()
+        )
+        assert df["momentum"].tolist() == pytest.approx(
+            expected["momentum"].tolist(), nan_ok=True
+        )
+
+    def test_three_level_nesting_still_hints(self, sample_csv):
+        """Scope lock (issue #101): the staged planner covers exactly two
+        levels; three and deeper keep the actionable error."""
         t = LTSeq.read_csv(sample_csv).sort("date")
 
         with pytest.raises(Exception, match="split it into two steps"):
             t.derive(
                 lambda r: {
-                    "prev_ma": r.price.rolling(3).mean().shift(1),
+                    "x": r.price.rolling(3).mean().shift(1).rolling(2).sum(),
                 }
             )
+
+    def test_hidden_stage_name_collision_avoided(self):
+        """A user column literally named __ltseq_stage_0 must not collide
+        with the planner's hidden columns."""
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "k": [1, 2, 3, 4],
+                "price": [10.0, 20.0, 30.0, 40.0],
+                "__ltseq_stage_0": [7.0, 7.0, 7.0, 7.0],
+            }
+        )
+        t = LTSeq.from_pandas(df).sort("k")
+        out = t.derive(
+            lambda r: {"prev_ma": r.price.rolling(2).mean().shift(1)}
+        ).to_pandas()
+        assert out["__ltseq_stage_0"].tolist() == [7.0] * 4
+        expected = (
+            t.derive(lambda r: {"ma": r.price.rolling(2).mean()})
+            .derive(lambda r: {"prev_ma": r.ma.shift(1)})
+            .to_pandas()
+        )
+        assert out["prev_ma"].tolist() == pytest.approx(
+            expected["prev_ma"].tolist(), nan_ok=True
+        )
 
     def test_rolling_and_shift_via_two_step_derive(self, sample_csv):
         """The documented workaround: stage the inner window as a column,

--- a/py-ltseq/tests/test_window_partition_by.py
+++ b/py-ltseq/tests/test_window_partition_by.py
@@ -211,3 +211,35 @@ class TestCumSumPartitionBy:
         assert df["cs"].iloc[3] == 160
         assert df["cs"].iloc[4] == 360
         assert df["cs"].iloc[5] == 660
+
+
+class TestPartitionedNestedWindows:
+    """Nested windows with partition_by through the staged planner (#101)."""
+
+    def test_partitioned_rolling_then_shift_matches_two_step(self, grouped_table):
+        """One-step nested must equal the manual two-step. Rows are sorted
+        before comparison, following this module's documented convention
+        (partition_by may cause DataFusion to reorder rows by partition)."""
+        one_step = grouped_table.derive(
+            lambda r: {
+                "prev_rsum": r.value.rolling(2, partition_by="grp")
+                .sum()
+                .shift(1, partition_by="grp")
+            }
+        ).to_pandas()
+
+        two_step = (
+            grouped_table.derive(
+                lambda r: {"rsum": r.value.rolling(2, partition_by="grp").sum()}
+            )
+            .derive(lambda r: {"prev_rsum": r.rsum.shift(1, partition_by="grp")})
+            .to_pandas()
+        )
+
+        one_step = one_step.sort_values(["grp", "value"]).reset_index(drop=True)
+        two_step = two_step.sort_values(["grp", "value"]).reset_index(drop=True)
+
+        assert one_step["prev_rsum"].tolist() == pytest.approx(
+            two_step["prev_rsum"].tolist(), nan_ok=True
+        )
+        assert not any(c.startswith("__ltseq_stage_") for c in one_step.columns)

--- a/src/ops/window.rs
+++ b/src/ops/window.rs
@@ -8,10 +8,12 @@
 //!
 //! Window functions are converted directly to DataFusion's native
 //! `Expr::WindowFunction` via the `window_native` transpiler (issue #91):
-//! the plan stays lazy and there is no SQL fallback. Expression shapes the
-//! native transpiler cannot plan (currently: a window function applied to
-//! another window function's result) surface as errors that suggest the
-//! two-step derive workaround.
+//! the plan stays lazy and there is no SQL fallback. Two-level nested
+//! windows (a window applied to another window's result, e.g.
+//! `rolling(3).mean().shift(1)`) are planned as a staged pair of lazy
+//! projections (issue #101) — plan-isomorphic to the manual two-step
+//! derive. Deeper nesting and ranking-over-window shapes surface as errors
+//! that suggest the two-step derive workaround.
 
 use crate::error::LtseqError;
 use crate::transpiler::pyexpr_to_window_expr;
@@ -67,7 +69,9 @@ pub(crate) fn derive_with_window_functions_from_parsed(
 }
 
 /// Enrich native-transpile errors about window-on-window shapes with the
-/// two-step derive workaround (tracked follow-up: native staged select, issue #101).
+/// two-step derive workaround. Two-level nesting is planned natively by the
+/// staged planner (issue #101); this hint now covers what remains — three
+/// and deeper levels, and ranking-over-window shapes.
 fn nested_window_hint(err: PyErr) -> PyErr {
     let msg = err.to_string();
     if msg.contains("requires DataFrame context") {
@@ -101,6 +105,133 @@ pub(crate) fn parse_derived_cols(derived_cols: &Bound<'_, PyDict>) -> PyResult<V
 }
 
 
+/// A derive request split into two lazy projections (issue #101).
+///
+/// `stage_cols` are hidden intermediate window columns (the INPUT of an
+/// outer window that itself contains a window); `final_cols` are the user's
+/// requested columns with those inputs rewritten to hidden-column
+/// references. Empty `stage_cols` means no nesting — single-select path.
+struct StagedWindowPlan {
+    stage_cols: Vec<(String, PyExpr)>,
+    final_cols: Vec<(String, PyExpr)>,
+}
+
+/// Split two-level nested windows into a staged plan.
+///
+/// Whenever a window call's input subtree contains another window function
+/// (`contains_window_function`), the WHOLE input expression is hoisted into
+/// a hidden stage column (stage-1 can plan arbitrary window-bearing
+/// expressions) and replaced by a column reference. `PyExpr::Window`
+/// (ranking) nodes are deliberately left untouched: nesting inside them
+/// still falls through to the nested_window_hint error.
+fn build_staged_plan(
+    schema: &ArrowSchema,
+    parsed_cols: &[(String, PyExpr)],
+) -> StagedWindowPlan {
+    let mut used_names: std::collections::HashSet<String> = schema
+        .fields()
+        .iter()
+        .map(|f| f.name().clone())
+        .collect();
+    for (name, _) in parsed_cols {
+        used_names.insert(name.clone());
+    }
+
+    let mut stage_cols: Vec<(String, PyExpr)> = Vec::new();
+    let mut counter = 0usize;
+
+    let mut hoist = |input: PyExpr| -> PyExpr {
+        // Reuse an existing stage column for an identical input expression.
+        for (name, expr) in stage_cols.iter() {
+            if *expr == input {
+                return PyExpr::Column(name.clone());
+            }
+        }
+        let mut name = format!("__ltseq_stage_{}", counter);
+        while used_names.contains(&name) {
+            counter += 1;
+            name = format!("__ltseq_stage_{}", counter);
+        }
+        counter += 1;
+        used_names.insert(name.clone());
+        stage_cols.push((name.clone(), input));
+        PyExpr::Column(name)
+    };
+
+    fn rewrite(
+        expr: PyExpr,
+        hoist: &mut dyn FnMut(PyExpr) -> PyExpr,
+    ) -> PyExpr {
+        match expr {
+            PyExpr::Call { func, on, args, kwargs } => {
+                if crate::transpiler::is_window_call(&func, &on) {
+                    // The window's input: for rolling aggregates the input
+                    // lives one level down (agg → rolling → input).
+                    if func != "rolling" && matches!(&*on, PyExpr::Call { func: f, .. } if f == "rolling") {
+                        // agg over rolling: dig into the rolling call's input
+                        if let PyExpr::Call { func: rfunc, on: rin, args: rargs, kwargs: rkwargs } = *on {
+                            let new_rin = if crate::transpiler::contains_window_function(&rin) {
+                                hoist(*rin)
+                            } else {
+                                rewrite(*rin, hoist)
+                            };
+                            return PyExpr::Call {
+                                func,
+                                on: Box::new(PyExpr::Call {
+                                    func: rfunc,
+                                    on: Box::new(new_rin),
+                                    args: rargs,
+                                    kwargs: rkwargs,
+                                }),
+                                args,
+                                kwargs,
+                            };
+                        }
+                        unreachable!("matched rolling above");
+                    }
+                    // shift/diff/cum_sum/rolling: input is `on`
+                    let new_on = if crate::transpiler::contains_window_function(&on) {
+                        hoist(*on)
+                    } else {
+                        rewrite(*on, hoist)
+                    };
+                    return PyExpr::Call { func, on: Box::new(new_on), args, kwargs };
+                }
+                // Plain call: recurse into on and args
+                PyExpr::Call {
+                    func,
+                    on: Box::new(rewrite(*on, hoist)),
+                    args: args.into_iter().map(|a| rewrite(a, hoist)).collect(),
+                    kwargs,
+                }
+            }
+            PyExpr::BinOp { op, left, right } => PyExpr::BinOp {
+                op,
+                left: Box::new(rewrite(*left, hoist)),
+                right: Box::new(rewrite(*right, hoist)),
+            },
+            PyExpr::UnaryOp { op, operand } => PyExpr::UnaryOp {
+                op,
+                operand: Box::new(rewrite(*operand, hoist)),
+            },
+            PyExpr::Alias { expr, alias } => PyExpr::Alias {
+                expr: Box::new(rewrite(*expr, hoist)),
+                alias,
+            },
+            // Ranking windows: leave untouched — nesting inside them is out
+            // of scope and falls through to nested_window_hint.
+            other => other,
+        }
+    }
+
+    let final_cols = parsed_cols
+        .iter()
+        .map(|(name, expr)| (name.clone(), rewrite(expr.clone(), &mut hoist)))
+        .collect();
+
+    StagedWindowPlan { stage_cols, final_cols }
+}
+
 /// Native window derive: convert PyExpr window calls to DataFusion Expr and use df.select()
 fn native_window_derive(
     table: &LTSeqTable,
@@ -108,30 +239,59 @@ fn native_window_derive(
     df: &Arc<DataFrame>,
     parsed_cols: &[(String, PyExpr)],
 ) -> PyResult<LTSeqTable> {
-    // Build the list of select expressions: all existing columns + derived window columns
-    let mut all_exprs: Vec<Expr> = Vec::new();
+    let plan = build_staged_plan(schema, parsed_cols);
 
-    // Add all existing columns
-    for field in schema.fields() {
-        all_exprs.push(Expr::Column(Column::new_unqualified(field.name())));
+    // Fast path: no nested windows — the existing single lazy projection.
+    if plan.stage_cols.is_empty() {
+        let mut all_exprs: Vec<Expr> = original_columns(schema);
+        for (col_name_str, py_expr) in parsed_cols.iter() {
+            let window_expr = pyexpr_to_window_expr(py_expr.clone(), schema, &table.sort_specs)
+                .map_err(LtseqError::Transpile)?;
+            all_exprs.push(window_expr.alias(col_name_str));
+        }
+        let result_df = (**df)
+            .clone()
+            .select(all_exprs)
+            .map_err(|e| {
+                LtseqError::Runtime(format!("Native window derive failed: {}", e))
+            })?;
+        return Ok(LTSeqTable::from_df(
+            Arc::clone(&table.session),
+            result_df,
+            table.sort_specs.clone(),
+            None, // column set changed relative to the raw file: drop fast-path token
+        ));
     }
 
-    // Convert each derived column's PyExpr to a native DataFusion window Expr
-    for (col_name_str, py_expr) in parsed_cols.iter() {
-        // Convert to native DataFusion window expression
+    // Staged path (issue #101): two lazy projections, plan-isomorphic to the
+    // manual two-step derive.
+    //
+    // Stage 1: original columns + hidden inner-window columns.
+    let mut stage1: Vec<Expr> = original_columns(schema);
+    for (hidden_name, py_expr) in plan.stage_cols.iter() {
         let window_expr = pyexpr_to_window_expr(py_expr.clone(), schema, &table.sort_specs)
             .map_err(LtseqError::Transpile)?;
-
-        all_exprs.push(window_expr.alias(col_name_str));
+        stage1.push(window_expr.alias(hidden_name));
     }
-
-    // Apply via df.select() — stays lazy, no materialization!
-    let result_df = (**df)
+    let stage_df = (**df)
         .clone()
-        .select(all_exprs)
-        .map_err(|e| {
-            LtseqError::Runtime(format!("Native window derive failed: {}", e))
-        })?;
+        .select(stage1)
+        .map_err(|e| LtseqError::Runtime(format!("Nested window stage failed: {}", e)))?;
+
+    // Stage 2: original columns + the rewritten user expressions (hidden
+    // columns are consumed here and NOT selected — they never reach the
+    // result schema).
+    let stage_schema = LTSeqTable::schema_from_df(stage_df.schema());
+    let mut stage2: Vec<Expr> = original_columns(schema);
+    for (col_name_str, py_expr) in plan.final_cols.iter() {
+        let window_expr =
+            pyexpr_to_window_expr(py_expr.clone(), &stage_schema, &table.sort_specs)
+                .map_err(LtseqError::Transpile)?;
+        stage2.push(window_expr.alias(col_name_str));
+    }
+    let result_df = stage_df
+        .select(stage2)
+        .map_err(|e| LtseqError::Runtime(format!("Native window derive failed: {}", e)))?;
 
     Ok(LTSeqTable::from_df(
         Arc::clone(&table.session),
@@ -139,6 +299,15 @@ fn native_window_derive(
         table.sort_specs.clone(),
         None, // column set changed relative to the raw file: drop fast-path token
     ))
+}
+
+/// All schema fields as unqualified column expressions.
+fn original_columns(schema: &ArrowSchema) -> Vec<Expr> {
+    schema
+        .fields()
+        .iter()
+        .map(|f| Expr::Column(Column::new_unqualified(f.name())))
+        .collect()
 }
 
 /// Add cumulative sum columns with proper window functions (fully native).

--- a/src/ops/window.rs
+++ b/src/ops/window.rs
@@ -116,6 +116,76 @@ struct StagedWindowPlan {
     final_cols: Vec<(String, PyExpr)>,
 }
 
+/// Recursive rewrite for `build_staged_plan`: hoists any window call's
+/// window-bearing input via `hoist`, recursing through plain combinators.
+/// Ranking (`PyExpr::Window`) nodes are deliberately not entered — nesting
+/// inside them stays out of scope and falls to `nested_window_hint`.
+fn rewrite_nested(
+    expr: PyExpr,
+    hoist: &mut dyn FnMut(PyExpr) -> PyExpr,
+) -> PyExpr {
+    match expr {
+        PyExpr::Call { func, on, args, kwargs } => {
+            if crate::transpiler::is_window_call(&func, &on) {
+                // The window's input: for rolling aggregates the input
+                // lives one level down (agg → rolling → input).
+                if func != "rolling" && matches!(&*on, PyExpr::Call { func: f, .. } if f == "rolling") {
+                    // agg over rolling: dig into the rolling call's input
+                    if let PyExpr::Call { func: rfunc, on: rin, args: rargs, kwargs: rkwargs } = *on {
+                        let new_rin = if crate::transpiler::contains_window_function(&rin) {
+                            hoist(*rin)
+                        } else {
+                            rewrite_nested(*rin, hoist)
+                        };
+                        return PyExpr::Call {
+                            func,
+                            on: Box::new(PyExpr::Call {
+                                func: rfunc,
+                                on: Box::new(new_rin),
+                                args: rargs,
+                                kwargs: rkwargs,
+                            }),
+                            args,
+                            kwargs,
+                        };
+                    }
+                    unreachable!("matched rolling above");
+                }
+                // shift/diff/cum_sum/rolling: input is `on`
+                let new_on = if crate::transpiler::contains_window_function(&on) {
+                    hoist(*on)
+                } else {
+                    rewrite_nested(*on, hoist)
+                };
+                return PyExpr::Call { func, on: Box::new(new_on), args, kwargs };
+            }
+            // Plain call: recurse into on and args
+            PyExpr::Call {
+                func,
+                on: Box::new(rewrite_nested(*on, hoist)),
+                args: args.into_iter().map(|a| rewrite_nested(a, hoist)).collect(),
+                kwargs,
+            }
+        }
+        PyExpr::BinOp { op, left, right } => PyExpr::BinOp {
+            op,
+            left: Box::new(rewrite_nested(*left, hoist)),
+            right: Box::new(rewrite_nested(*right, hoist)),
+        },
+        PyExpr::UnaryOp { op, operand } => PyExpr::UnaryOp {
+            op,
+            operand: Box::new(rewrite_nested(*operand, hoist)),
+        },
+        PyExpr::Alias { expr, alias } => PyExpr::Alias {
+            expr: Box::new(rewrite_nested(*expr, hoist)),
+            alias,
+        },
+        // Ranking windows: leave untouched — nesting inside them is out
+        // of scope and falls through to nested_window_hint.
+        other => other,
+    }
+}
+
 /// Split two-level nested windows into a staged plan.
 ///
 /// Whenever a window call's input subtree contains another window function
@@ -158,75 +228,9 @@ fn build_staged_plan(
         PyExpr::Column(name)
     };
 
-    fn rewrite(
-        expr: PyExpr,
-        hoist: &mut dyn FnMut(PyExpr) -> PyExpr,
-    ) -> PyExpr {
-        match expr {
-            PyExpr::Call { func, on, args, kwargs } => {
-                if crate::transpiler::is_window_call(&func, &on) {
-                    // The window's input: for rolling aggregates the input
-                    // lives one level down (agg → rolling → input).
-                    if func != "rolling" && matches!(&*on, PyExpr::Call { func: f, .. } if f == "rolling") {
-                        // agg over rolling: dig into the rolling call's input
-                        if let PyExpr::Call { func: rfunc, on: rin, args: rargs, kwargs: rkwargs } = *on {
-                            let new_rin = if crate::transpiler::contains_window_function(&rin) {
-                                hoist(*rin)
-                            } else {
-                                rewrite(*rin, hoist)
-                            };
-                            return PyExpr::Call {
-                                func,
-                                on: Box::new(PyExpr::Call {
-                                    func: rfunc,
-                                    on: Box::new(new_rin),
-                                    args: rargs,
-                                    kwargs: rkwargs,
-                                }),
-                                args,
-                                kwargs,
-                            };
-                        }
-                        unreachable!("matched rolling above");
-                    }
-                    // shift/diff/cum_sum/rolling: input is `on`
-                    let new_on = if crate::transpiler::contains_window_function(&on) {
-                        hoist(*on)
-                    } else {
-                        rewrite(*on, hoist)
-                    };
-                    return PyExpr::Call { func, on: Box::new(new_on), args, kwargs };
-                }
-                // Plain call: recurse into on and args
-                PyExpr::Call {
-                    func,
-                    on: Box::new(rewrite(*on, hoist)),
-                    args: args.into_iter().map(|a| rewrite(a, hoist)).collect(),
-                    kwargs,
-                }
-            }
-            PyExpr::BinOp { op, left, right } => PyExpr::BinOp {
-                op,
-                left: Box::new(rewrite(*left, hoist)),
-                right: Box::new(rewrite(*right, hoist)),
-            },
-            PyExpr::UnaryOp { op, operand } => PyExpr::UnaryOp {
-                op,
-                operand: Box::new(rewrite(*operand, hoist)),
-            },
-            PyExpr::Alias { expr, alias } => PyExpr::Alias {
-                expr: Box::new(rewrite(*expr, hoist)),
-                alias,
-            },
-            // Ranking windows: leave untouched — nesting inside them is out
-            // of scope and falls through to nested_window_hint.
-            other => other,
-        }
-    }
-
     let final_cols = parsed_cols
         .iter()
-        .map(|(name, expr)| (name.clone(), rewrite(expr.clone(), &mut hoist)))
+        .map(|(name, expr)| (name.clone(), rewrite_nested(expr.clone(), &mut hoist)))
         .collect();
 
     StagedWindowPlan { stage_cols, final_cols }

--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -998,30 +998,35 @@ fn pyexpr_to_datafusion_inner(py_expr: PyExpr, schema: &ArrowSchema) -> Result<E
 }
 
 /// Helper function to detect if a PyExpr contains a window function call
+/// Is this Call node itself a window-function invocation?
+///
+/// The single source of truth for "what counts as a window call" — shared by
+/// `contains_window_function` and the staged nested-window rewriter in
+/// window.rs (issue #101). Do not duplicate this match.
+pub(crate) fn is_window_call(func: &str, on: &PyExpr) -> bool {
+    // Direct window functions
+    if matches!(func, "shift" | "rolling" | "diff" | "cum_sum") {
+        return true;
+    }
+    // Aggregation functions applied to rolling windows
+    if matches!(func, "mean" | "sum" | "min" | "max" | "count" | "std") {
+        if let PyExpr::Call { func: inner_func, .. } = on {
+            if inner_func == "rolling" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 pub fn contains_window_function(py_expr: &PyExpr) -> bool {
     match py_expr {
         // Window expressions always require window function handling
         PyExpr::Window { .. } => true,
 
         PyExpr::Call { func, on, args, .. } => {
-            // Direct window functions
-            if matches!(func.as_str(), "shift" | "rolling" | "diff" | "cum_sum") {
+            if is_window_call(func, on) {
                 return true;
-            }
-            // Aggregation functions applied to rolling windows
-            if matches!(
-                func.as_str(),
-                "mean" | "sum" | "min" | "max" | "count" | "std"
-            ) {
-                // Check if this is applied to a rolling() call
-                if let PyExpr::Call {
-                    func: inner_func, ..
-                } = &**on
-                {
-                    if matches!(inner_func.as_str(), "rolling") {
-                        return true;
-                    }
-                }
             }
             // Check recursively in the `on` field
             if contains_window_function(on) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use pyo3::types::PyDict;
 use std::collections::HashMap;
 
 /// Represents a serialized Python expression for transpilation to DataFusion
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PyExpr {
     /// Column reference: {"type": "Column", "name": "age"}
     Column(String),


### PR DESCRIPTION
实现 issue #101（按 issue 中已修订的方案 v2——设计 review 的 4 项修订全部落地）。

## 核心机制

在 transpile 之前对 PyExpr 做重写 pass：当某个窗口调用的输入子树含窗口函数（判定直接用 `contains_window_function`）时，把**整个输入表达式** hoist 成隐藏列 `__ltseq_stage_<n>`，两层 lazy select 完成计划。

**等价性是结构性的**：staged 计划（select → select）与用户手工两步 derive 的 LogicalPlan **同构**，数值与输出行序自动跟随——等价性测试特意不排序对比来锁定这一点。

```python
# 现在一步可用：
t.derive(lambda r: {"prev_ma": r.price.rolling(3).mean().shift(1)})
t.derive(lambda r: {"sum_prev": r.price.shift(1).rolling(3).sum()})
# 混合嵌套/普通窗口/普通表达式、嵌套进算术、partition_by 嵌套均支持
```

## Review 修订的落地

1. **不新写平行 match**：从 `contains_window_function` 抽出共享谓词 `is_window_call()`，两处调用（防第六套解释器漂移）
2. **`PyExpr::Window`（ranking）显式不覆盖**：重写器不进入其内嵌表达式，含嵌套的 ranking 与三层以上嵌套仍落 `nested_window_hint`——两者均有测试锁定
3. **行序断言约定**：主等价测试不排序对比（docstring 点明计划同构）；partition_by 变体先排序，注释引用该模块既有的宽松顺序约定
4. **边界测试**：三层嵌套报错保留、隐藏列名冲突避让（源表含 `__ltseq_stage_0` 列时避让生效且原列无损）

## 实现细节

- 无 staging 时保留现有单 select 快速路径（零成本）
- 相同的 hoist 输入去重共享一个 stage 列
- 隐藏列在 stage-2 投影中被消费且不选出，永不进入结果 schema
- `PyExpr` 增加 `PartialEq`（用于 stage 列去重）
- `nested_window_hint` 保留为兜底，注释更新为覆盖剩余形状

## 验证

- 全量 pytest **1349 passed, 0 xfailed**；cargo test 通过；pyright 45 持平；crate 零警告
- 新增 7 项测试（双向嵌套等价、混合、算术内嵌套、partition_by 嵌套、三层 hint、名字冲突）
- bench：首轮干净对撞上了并行 rustc 编译（数据双向失真已弃用），已布置监控待机器空闲后重跑追加评论。机制预期：无 staging 的既有 workload 走原路径零变化（bench 无嵌套窗口 workload）

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)