### PR TITLE
docs: API 文档与实现全量对齐（api.md / api.cn.md）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ t.filter(lambda r: r.age > 18)
 col("age").gt(lit(18))
 ```
 
-Window functions require explicit `.sort()` before use. The sort order is tracked in `_sort_keys` and `sort_exprs`.
+Window functions require a prior `.sort()` — or `.assume_sorted()` for data that is already physically sorted — before use. The sort order is tracked in `_sort_keys` and `sort_exprs`.
 
 ## Testing
 

--- a/docs/api.cn.md
+++ b/docs/api.cn.md
@@ -781,7 +781,7 @@ last_rows = groups.last()
 
 #### `NestedTable.flatten`
 - **签名**: `nested.flatten() -> LTSeq`
-- **行为**: 返回带 `__group_id__` 列的底层行，该列标识每个连续分组
+- **行为**: 返回带 `__group_id__` 列的底层行，该列标识每个连续分组（另含内部辅助列 `__group_count__` 与 `__rn__`）
 - **返回**: 展平后的 `LTSeq`
 - **示例**:
 ```python
@@ -817,10 +817,11 @@ enriched = groups.derive(lambda g: {
 
 #### `len(nested)` / `NestedTable.to_pandas`
 - **签名**: `NestedTable.__len__() -> int`；`NestedTable.to_pandas()`
-- **行为**: `len()` 返回组数；`to_pandas()` 物化展平后的行
+- **行为**: `len()` 返回底层表的**行数**（不是组数）；`to_pandas()` 原样物化底层行，**不含** `__group_id__` 列（需要该列请用 `flatten().to_pandas()`）
 - **示例**:
 ```python
-n_groups = len(groups)
+n_rows = len(groups)                  # 行数，不是组数
+df = groups.flatten().to_pandas()     # 带 __group_id__ 的行
 ```
 
 ### 组代理（NestedTable filter/derive 中的 `g`）
@@ -1114,10 +1115,10 @@ result = t.group_by("region").agg(
 
 ### `LTSeq.partition`
 - **签名**: `LTSeq.partition(*cols: str) -> PartitionedTable` 或 `LTSeq.partition(by: Callable) -> PartitionedTable`
-- **行为**: 按键拆分为子表（不聚合）。字符串列走快速 SQL 路径；callable 走灵活的 Python 路径
+- **行为**: 按键拆分为子表（不聚合）。callable 键必须是**简单列表达式**（如 `lambda r: r.region`）；派生表达式（如 `lambda r: r.price + 1`）会抛 `ValueError`（会迫使内部物化，已不支持）
 - **参数**: 列名、单个 callable，或 `by=` callable
 - **返回**: `PartitionedTable`（字典式：键 → LTSeq）
-- **异常**: `TypeError`（参数无效），`AttributeError`（列不存在），`ValueError`（schema 未初始化）
+- **异常**: `TypeError`（参数无效），`AttributeError`（列不存在），`ValueError`（schema 未初始化，或 callable 不是简单列表达式）
 - **示例**:
 ```python
 parts = t.partition("region")

--- a/docs/api.cn.md
+++ b/docs/api.cn.md
@@ -9,18 +9,30 @@
 - `docs/DESIGN_SUMMARY.cn.md`：中文设计摘要与设计归档
 - `docs/LINKING_GUIDE.cn.md`：中文 Linking 专题文档
 
-LTSeq 是面向有序序列的 Python 数据处理库，底层由 Rust/DataFusion 执行。与传统 DataFrame 不同，LTSeq 强调"顺序"语义，支持窗口、连续分组、游标式处理等 SPL 风格能力。
+LTSeq 是面向有序序列的 Python 数据处理库，底层由 Rust/DataFusion 执行。与传统 DataFrame 不同，LTSeq 强调"顺序"语义，支持窗口、连续分组、游标式流处理等 SPL 风格能力。
+
+本文档描述的是**当前已实现**的 API，所有签名均与 `py-ltseq/ltseq/` 源码逐一核对。
+
+## 0. 基本约定与术语
+
+- t: 当前 LTSeq 实例（不可变，所有操作返回新实例）
+- r: 行代理（lambda 内部用于构造表达式，不在 Python 侧执行）
+- g: 组代理（NestedTable 的 filter/derive 中使用）；组聚合以字符串列名调用（`g.sum("amount")`），`g.first()`/`g.last()` 返回可属性访问的行代理（`g.first().date`）
+- 绝大多数操作返回新的 LTSeq；`LTSeq.scan()`/`scan_parquet()` 返回流式 `Cursor`；`is_subset`/`contain` 返回布尔值
+- 窗口/有序相关能力依赖已有排序（`sort` 或 `assume_sorted`），未排序使用会导致运行期错误或不正确结果；`shift`/`rolling`/`diff` 还支持 `partition_by=` 参数做分组窗口
+- 表达式在 Python 侧被捕获为 AST 并在 Rust/DataFusion 层执行
 
 ## 常见错误与解决方案
 
 | 错误 | 原因 | 解决方法 |
 |------|------|---------|
-| `RuntimeError: window function used without sort` | 未排序直接调用 `shift`/`rolling`/`diff` | 在窗口函数前添加 `.sort(order_column)` |
+| `RuntimeError: window function used without sort` | 未排序直接调用 `shift`/`rolling`/`diff` | 在窗口函数前添加 `.sort(order_column)`（或 `.assume_sorted(...)`）|
 | `AttributeError: column 'xxx' not found` | 列名拼写错误或列不存在 | 通过 `t.columns` 查看可用列名 |
 | `ValueError: schema mismatch` | union/intersect 的表 schema 不匹配 | 确保两表列名和类型相同 |
 | `ValueError: merge strategy requires sorted tables` | 对未排序的表调用 `join(..., strategy="merge")` | 先对双方调用 `.sort(join_key)` |
 | `TypeError: predicate not boolean Expr` | filter lambda 返回非布尔值 | 确保谓词使用比较运算符（`>`、`==` 等）|
 | `ValueError: desc length mismatch` | `desc` 列表长度与排序键数量不匹配 | 为每个排序键提供一个布尔值，或使用单个布尔值 |
+| `ValueError: Schema not initialized` | 对空的 `LTSeq()` 调用操作 | 先加载数据（`read_csv`、`from_pandas` 等）|
 
 ## 快速参考
 
@@ -28,31 +40,38 @@ LTSeq 是面向有序序列的 Python 数据处理库，底层由 Rust/DataFusio
 | 操作 | 方法 | 示例 |
 |------|------|------|
 | 加载 CSV | `LTSeq.read_csv()` | `t = LTSeq.read_csv("data.csv")` |
-| 查看列名 | `.columns` | `print(t.columns)` |
-| 流式输出 | `.to_cursor()` | `for batch in t.to_cursor(): ...` |
-| 物化所有行 | `.collect()` | `rows = t.collect()` |
+| 加载 Parquet | `LTSeq.read_parquet()` | `t = LTSeq.read_parquet("data.parquet")` |
+| 流式读取大文件 | `LTSeq.scan()` | `for batch in LTSeq.scan("big.csv"): ...` |
+| 从 Python 数据构造 | `LTSeq.from_dict()` | `t = LTSeq.from_dict({"id": [1, 2]})` |
+| 查看 schema | `.columns` / `.schema` | `print(t.columns)` |
+| 物化行字典 | `.collect()` | `rows = t.collect()` |
 | 转 pandas | `.to_pandas()` | `df = t.to_pandas()` |
-| 行数统计 | `.count()` | `n = t.count()` |
+| 写文件 | `.write_csv()` / `.write_parquet()` | `t.write_csv("out.csv")` |
+| 行数统计 | `.count()` / `len(t)` | `n = t.count()` |
+| 表格打印 | `.show()` | `t.show(20)` |
 
 ### 基础操作
 | 操作 | 方法 | 示例 |
 |------|------|------|
 | 过滤行 | `.filter()` | `t.filter(lambda r: r.age > 18)` |
 | 投影列 | `.select()` | `t.select("id", "name")` |
-| 新增列 | `.derive()` | `t.derive(total=lambda r: r.a + r.b)` |
+| 新增列 | `.derive()`（别名 `.with_columns()`）| `t.derive(total=lambda r: r.a + r.b)` |
+| 重命名列 | `.rename()` | `t.rename(old="new")` |
+| 删除列 | `.drop()` | `t.drop("tmp")` |
 | 排序 | `.sort()` | `t.sort("date", desc=True)` |
 | 去重 | `.distinct()` | `t.distinct("id")` |
 | 截取行 | `.slice()` | `t.slice(offset=10, length=5)` |
 | 取前 N 行 | `.head()` | `t.head(10)` |
 | 取后 N 行 | `.tail()` | `t.tail(10)` |
 
-### 窗口操作（需先调用 `.sort()`）
+### 窗口操作（需先 `.sort()`；`partition_by=` 支持分组窗口）
 | 操作 | 方法 | 示例 |
 |------|------|------|
 | 前一行 | `.shift(n)` | `r.price.shift(1)` |
 | 滑动聚合 | `.rolling(n).agg()` | `r.price.rolling(5).mean()` |
 | 行差分 | `.diff(n)` | `r.price.diff(1)` |
-| 累计求和 | `.cum_sum()` | `t.cum_sum("volume")` |
+| 环比变化率 | `.pct_change()` | `r.close.pct_change()` |
+| 累计求和 | `.cum_sum()` | `t.cum_sum("volume")` 或 `r.volume.cum_sum()` |
 
 ### 排名（使用 `.over()`）
 | 操作 | 方法 | 示例 |
@@ -65,7 +84,8 @@ LTSeq 是面向有序序列的 Python 数据处理库，底层由 Rust/DataFusio
 ### 聚合
 | 操作 | 方法 | 示例 |
 |------|------|------|
-| 分组聚合 | `.agg()` | `t.agg(by=lambda r: r.region, total=lambda r: r.sales.sum())` |
+| 分组聚合（链式）| `.group_by().agg()` | `t.group_by("region").agg(total=lambda g: g.sales.sum())` |
+| 分组聚合 | `.agg()` | `t.agg(by=lambda r: r.region, total=lambda g: g.sales.sum())` |
 | 分区 | `.partition()` | `parts = t.partition("region")` |
 | 透视 | `.pivot()` | `t.pivot(index="date", columns="region", values="amount")` |
 
@@ -74,82 +94,180 @@ LTSeq 是面向有序序列的 Python 数据处理库，底层由 Rust/DataFusio
 |------|------|------|
 | 哈希连接 | `.join()` | `a.join(b, on=lambda a, b: a.id == b.id)` |
 | 归并连接 | `.join(..., strategy="merge")` | `a.sort("id").join(b.sort("id"), on=lambda a, b: a.id == b.id, strategy="merge")` |
+| 时序就近连接 | `.asof_join()` | `trades.asof_join(quotes, on=lambda t, q: t.time >= q.time)` |
 | 半连接 | `.semi_join()` | `a.semi_join(b, on=lambda a, b: a.id == b.id)` |
 | 反连接 | `.anti_join()` | `a.anti_join(b, on=lambda a, b: a.id == b.id)` |
+| 指针关联 | `.link()` | `orders.link(products, on=lambda o, p: o.product_id == p.id, as_="prod")` |
 
 ### 集合操作
 | 操作 | 方法 | 示例 |
 |------|------|------|
-| 纵向合并 | `.union()` | `t1.union(t2)` |
+| 纵向合并（保留重复）| `.union()` | `t1.union(t2)` |
 | 交集 | `.intersect()` | `t1.intersect(t2)` |
 | 差集 | `.except_()` | `t1.except_(t2)` |
+| 对称差 | `.xunion()` | `t1.xunion(t2)` |
 
-## 0. 基本约定与术语
-
-- t: 当前 LTSeq 实例（不可变，所有操作返回新实例）
-- r: 行代理（lambda 内部用于构造表达式，不在 Python 侧执行）
-- g: 组代理（NestedTable 的 filter/derive 中使用）
-- 绝大多数操作返回新的 LTSeq；`to_cursor` 返回迭代器；`is_subset` 返回布尔值
-- 窗口/有序相关能力依赖已有排序（`sort`），未排序使用会导致运行期错误或不正确结果
-- 表达式在 Python 侧被捕获为 AST 并在 Rust/DataFusion 层执行
+### 行变更（写时复制）
+| 操作 | 方法 | 示例 |
+|------|------|------|
+| 插入行 | `.insert()` | `t.insert(0, {"id": 99})` |
+| 删除行 | `.delete()` | `t.delete(lambda r: r.expired)` |
+| 条件更新 | `.update()` | `t.update(lambda r: r.age > 65, discount=0.2)` |
+| 修改单行 | `.modify()` | `t.modify(0, status="active")` |
 
 ## 1. 输入 / 输出
 
 ### `LTSeq.read_csv`
 - **签名**: `LTSeq.read_csv(path: str, has_header: bool = True) -> LTSeq`
-- **行为**: 从 CSV 加载数据并推断 schema，返回可链式计算的 LTSeq
+- **行为**: 从 CSV 加载数据并推断 schema，返回可链式计算的 LTSeq。`has_header=False` 时列名为 `column_0`、`column_1`、...
 - **参数**: `path` CSV 路径；`has_header` 是否把首行作为列名
 - **返回**: `LTSeq`，包含加载后的数据与 schema
-- **异常**: `FileNotFoundError`/`IOError`（路径无效或不可读），`ValueError`（解析失败或 schema 推断失败）
+- **异常**: `FileNotFoundError`（路径无效），`ValueError`（解析失败或 schema 推断失败）
 - **示例**:
 ```python
 from ltseq import LTSeq
 
 t = LTSeq.read_csv("data.csv")
+t2 = LTSeq.read_csv("raw.csv", has_header=False)
+```
+
+### `LTSeq.read_parquet`
+- **签名**: `LTSeq.read_parquet(path: str) -> LTSeq`
+- **行为**: 加载 Parquet 文件并返回 LTSeq 表
+- **参数**: `path` Parquet 路径
+- **返回**: `LTSeq`，包含加载后的数据与 schema
+- **异常**: `FileNotFoundError`（路径无效），`RuntimeError`（解析失败）
+- **示例**:
+```python
+t = LTSeq.read_parquet("data.parquet")
+```
+
+### `LTSeq.scan` / `LTSeq.scan_parquet`（流式读取）
+- **签名**: `LTSeq.scan(path: str, has_header: bool = True) -> Cursor`；`LTSeq.scan_parquet(path: str) -> Cursor`
+- **行为**: 为 CSV/Parquet 文件创建流式游标，按批次惰性迭代，无需将整个文件载入内存
+- **参数**: `path` 文件路径；`has_header`（仅 CSV）首行是否为列名
+- **返回**: `Cursor`（可迭代的批次流）
+- **异常**: `FileNotFoundError`（路径无效），`RuntimeError`（扫描失败）
+- **示例**:
+```python
+for batch in LTSeq.scan("large.csv"):
+    process(batch)
+
+cursor = LTSeq.scan_parquet("large.parquet")
+```
+
+### `Cursor`（流式句柄）
+- **签名**: 由 `scan`/`scan_parquet` 返回的可迭代对象
+- **行为**: 惰性产出记录批次；也支持整体物化
+- **成员**:
+  - `__iter__()`: 逐批迭代
+  - `schema -> dict[str, str]`（属性）、`columns -> list[str]`（属性）
+  - `source -> str`（属性）：源文件路径；`exhausted -> bool`（属性）
+  - `to_pandas()`、`to_arrow()`: 物化剩余流
+  - `count() -> int`: 消费整个流并统计行数
+- **示例**:
+```python
+cursor = LTSeq.scan("large.csv")
+print(cursor.columns)
+for batch in cursor:
+    ...
+```
+
+### `LTSeq.from_rows`
+- **签名**: `LTSeq.from_rows(rows: list[dict[str, Any]], schema: dict[str, str] | None = None) -> LTSeq`
+- **行为**: 从行字典列表构造表。未提供 `schema` 时从第一行推断类型；`rows` 为空时必须显式给出 schema
+- **参数**: `rows` 行字典列表（各行键一致）；`schema` 可选的 `{列名: arrow 类型}` 映射
+- **返回**: 新 `LTSeq`
+- **异常**: `ValueError`（空 rows 且无 schema），`TypeError`（非字典列表）
+- **示例**:
+```python
+t = LTSeq.from_rows([{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}])
+empty = LTSeq.from_rows([], schema={"id": "Int64", "name": "Utf8"})
+```
+
+### `LTSeq.from_dict`
+- **签名**: `LTSeq.from_dict(data: dict[str, list[Any]]) -> LTSeq`
+- **行为**: 从列式字典构造表
+- **参数**: `data` 列名到取值列表的映射（各列等长）
+- **返回**: 新 `LTSeq`
+- **异常**: `ValueError`（列长度不一致），`TypeError`（非字典）
+- **示例**:
+```python
+t = LTSeq.from_dict({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
+```
+
+### `LTSeq.from_pandas` / `LTSeq.from_arrow`
+- **签名**: `LTSeq.from_pandas(df) -> LTSeq`；`LTSeq.from_arrow(arrow_table) -> LTSeq`
+- **行为**: 从 pandas DataFrame / PyArrow Table 构造表
+- **返回**: 新 `LTSeq`
+- **异常**: `ImportError`（未安装 pandas/pyarrow），`TypeError`（输入类型错误）
+- **示例**:
+```python
+t = LTSeq.from_pandas(df)
+t = LTSeq.from_arrow(arrow_table)
+```
+
+### `seq`（整数序列构造器）
+- **签名**: `seq(start_or_stop: int, stop: int | None = None, step: int = 1) -> LTSeq`
+- **行为**: 生成整数序列，返回单列 LTSeq（列名 `value`，Int64）。接口与 Python 内置 `range()` 一致
+- **导入**: `from ltseq import seq`
+- **示例**:
+```python
+from ltseq import seq
+
+seq(5)         # 0, 1, 2, 3, 4
+seq(2, 7)      # 2, 3, 4, 5, 6
+seq(0, 10, 2)  # 0, 2, 4, 6, 8
+```
+
+### `LTSeq.write_csv` / `LTSeq.write_parquet`
+- **签名**: `LTSeq.write_csv(path: str) -> None`；`LTSeq.write_parquet(path: str, compression: str | None = None) -> None`
+- **行为**: 将表写入 CSV/Parquet 文件。Parquet 的 `compression` 可选 `"snappy" | "zstd" | "gzip" | "lz4" | "none"`（默认不压缩）
+- **异常**: `RuntimeError`（写入失败），`ValueError`（未知压缩算法）
+- **示例**:
+```python
+t.write_csv("output.csv")
+t.write_parquet("output.parquet", compression="zstd")
 ```
 
 ### `LTSeq.schema`（属性）
-- **签名**: `LTSeq.schema -> Dict[str, str]`
-- **行为**: 以字典形式返回表的 schema，包含列名到类型字符串的映射
-- **参数**: 无（属性）
-- **返回**: 列名到类型字符串的字典
-- **异常**: 无
+- **签名**: `LTSeq.schema -> dict[str, str]`
+- **行为**: 以字典形式返回表的 schema，列名映射到 Arrow 类型字符串
 - **示例**:
 ```python
-t = LTSeq.read_csv("data.csv")
 print(t.schema)   # {"id": "Int64", "name": "Utf8", ...}
 
 for name, dtype in t.schema.items():
     print(f"{name}: {dtype}")
 ```
 
+### `LTSeq.python_schema`（属性）
+- **签名**: `LTSeq.python_schema -> dict[str, str]`
+- **行为**: 以 Python 友好的类型名返回 schema（`Int64` → `int`、`Utf8` → `str`、`Float64` → `float`、`Boolean` → `bool` 等）。未知类型原样返回
+- **示例**:
+```python
+print(t.python_schema)  # {"id": "int", "name": "str", "score": "float"}
+```
+
 ### `LTSeq.columns`（属性）
-- **签名**: `LTSeq.columns -> List[str]`
+- **签名**: `LTSeq.columns -> list[str]`
 - **行为**: 返回列名列表（`list(schema.keys())` 的快捷方式）
-- **参数**: 无（属性）
-- **返回**: 列名字符串列表
-- **异常**: 无
 - **示例**:
 ```python
 print(t.columns)  # ["id", "name", "age"]
 ```
 
-### `LTSeq.to_cursor`
-- **签名**: `LTSeq.to_cursor(chunk_size: int = 10000) -> Iterator[Record]`
-- **行为**: 将结果以游标方式流式输出，避免一次性物化
-- **参数**: `chunk_size` 每批次行数
-- **返回**: 记录迭代器
-- **异常**: `ValueError`（chunk_size 非法），`RuntimeError`（底层不支持流式或执行失败）
+### `LTSeq.dtypes`（属性）
+- **签名**: `LTSeq.dtypes -> list[tuple[str, str]]`
+- **行为**: 返回 `(列名, 类型)` 元组列表
 - **示例**:
 ```python
-for batch in t.to_cursor(chunk_size=5000):
-    print(batch)
+print(t.dtypes)  # [("id", "Int64"), ("name", "Utf8"), ...]
 ```
 
 ### `LTSeq.collect`
-- **签名**: `LTSeq.collect() -> List[Dict[str, Any]]`
-- **行为**: 将所有行物化为字典列表
-- **参数**: 无
+- **签名**: `LTSeq.collect() -> list[dict[str, Any]]`
+- **行为**: 将所有行物化为字典列表。注意：与 Polars 的 `collect()`（返回 DataFrame）不同，LTSeq 的 `collect()` 返回行字典；表形态导出请用 `to_pandas()`/`to_arrow()`
 - **返回**: 行字典列表
 - **异常**: `MemoryError`（数据集过大），`RuntimeError`（执行失败）
 - **示例**:
@@ -159,34 +277,40 @@ for row in rows:
     print(row["name"])
 ```
 
-### `LTSeq.to_pandas`
-- **签名**: `LTSeq.to_pandas() -> pandas.DataFrame`
-- **行为**: 转为 pandas DataFrame，便于互操作
-- **参数**: 无
-- **返回**: `pandas.DataFrame`
-- **异常**: `ImportError`（未安装 pandas），`MemoryError`（数据集过大）
+### `LTSeq.to_pandas` / `LTSeq.to_arrow`
+- **签名**: `LTSeq.to_pandas() -> pandas.DataFrame`；`LTSeq.to_arrow() -> pyarrow.Table`
+- **行为**: 物化为 pandas DataFrame / PyArrow Table
+- **异常**: `ImportError`（未安装 pandas/pyarrow），`MemoryError`（数据集过大）
 - **示例**:
 ```python
 df = t.to_pandas()
 df.plot(x="date", y="price")
+
+arrow_table = t.to_arrow()
 ```
 
-### `LTSeq.count`
-- **签名**: `LTSeq.count() -> int`
-- **行为**: 返回行数
-- **参数**: 无
-- **返回**: 整数行数
+### `LTSeq.count` / `len(t)`
+- **签名**: `LTSeq.count() -> int`；`LTSeq.__len__() -> int`
+- **行为**: 返回行数；`count()` 与 `len(t)` 等价
 - **异常**: `RuntimeError`（执行失败）
 - **示例**:
 ```python
 n = t.filter(lambda r: r.status == "active").count()
+n = len(t)
+```
+
+### `LTSeq.show`
+- **签名**: `LTSeq.show(n: int = 10) -> LTSeq`
+- **行为**: 以 ASCII 表格打印最多 `n` 行；返回 `self` 以便继续链式调用。LTSeq 的 REPL `repr` 也会展示行列数、schema 与 5 行预览
+- **示例**:
+```python
+t.show()
+t.filter(lambda r: r.active).show().derive(upper=lambda r: r.name.s.upper())
 ```
 
 ### `LTSeq.head`
 - **签名**: `LTSeq.head(n: int = 10) -> LTSeq`
 - **行为**: 返回前 n 行
-- **参数**: `n` 行数（默认 10）
-- **返回**: 包含前 n 行的 `LTSeq`
 - **异常**: `ValueError`（n < 0）
 - **示例**:
 ```python
@@ -196,35 +320,51 @@ top_10 = t.sort("score", desc=True).head(10)
 ### `LTSeq.tail`
 - **签名**: `LTSeq.tail(n: int = 10) -> LTSeq`
 - **行为**: 返回后 n 行
-- **参数**: `n` 行数（默认 10）
-- **返回**: 包含后 n 行的 `LTSeq`
 - **异常**: `ValueError`（n < 0）
 - **示例**:
 ```python
 recent = t.sort("date").tail(5)
 ```
 
-## 2. 基础关系操作
+### `LTSeq.pipe`
+- **签名**: `LTSeq.pipe(func: Callable[..., LTSeq], *args, **kwargs) -> LTSeq`
+- **行为**: 在链式调用中应用用户函数（同 pandas 的 `DataFrame.pipe`）
+- **示例**:
+```python
+def add_tax(t, rate):
+    return t.derive(tax=lambda r: r.price * rate)
+
+result = t.filter(lambda r: r.qty > 0).pipe(add_tax, 0.1).sort("tax")
+```
+
+### `LTSeq.explain_plan`
+- **签名**: `LTSeq.explain_plan() -> tuple[str, str]`
+- **行为**: 返回优化后的逻辑计划与物理计划（DataFusion），用于调试
+- **示例**:
+```python
+logical, physical = t.filter(lambda r: r.age > 18).explain_plan()
+print(logical)
+```
+
+## 2. 基础关系运算
 
 ### `LTSeq.filter`
 - **签名**: `LTSeq.filter(predicate: Callable[[Row], Expr]) -> LTSeq`
-- **行为**: 过滤满足条件的行，谓词尽量下推到 Rust 引擎
-- **参数**: `predicate` 行谓词表达式（返回布尔表达式）
-- **返回**: 过滤后的新 `LTSeq`
-- **SPL 对应**: `select()`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（谓词不是布尔表达式），`AttributeError`（列不存在）
+- **行为**: 过滤满足谓词的行；下推至 Rust 引擎执行
+- **参数**: `predicate` 行谓词表达式（返回布尔 Expr）
+- **返回**: 过滤后的 `LTSeq`
+- **异常**: `ValueError`（schema 未初始化），`TypeError`（谓词非布尔 Expr），`AttributeError`（列不存在）
 - **示例**:
 ```python
 filtered = t.filter(lambda r: r.amount > 100)
 ```
 
 ### `LTSeq.select`
-- **签名**: `LTSeq.select(*cols: Union[str, Callable]) -> LTSeq`
-- **行为**: 投影指定列或表达式，支持列裁剪
-- **参数**: `cols` 列名或 lambda（可返回单列或列表）
-- **返回**: 投影后的新 `LTSeq`
-- **SPL 对应**: `new()`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（返回非表达式/列表），`AttributeError`（列不存在）
+- **签名**: `LTSeq.select(*cols: str | Callable) -> LTSeq`
+- **行为**: 投影指定列或表达式；支持列裁剪
+- **参数**: `cols` 列名或 lambda（单个表达式或列表）
+- **返回**: 投影后的 `LTSeq`
+- **异常**: `ValueError`（schema 未初始化），`TypeError`（返回类型无效），`AttributeError`（列不存在）
 - **示例**:
 ```python
 t.select("id", "name")
@@ -232,83 +372,116 @@ t.select("id", "name")
 t.select(lambda r: [r.id, r.name])
 ```
 
-### `LTSeq.derive`
-- **签名**: `LTSeq.derive(**new_cols: Callable) -> LTSeq` 或 `LTSeq.derive(func: Callable[[Row], Dict[str, Expr]]) -> LTSeq`
-- **行为**: 新增或覆盖列；保留原有列
-- **参数**: `new_cols` 列名 -> lambda 映射；或返回字典的 lambda
-- **返回**: 新 `LTSeq`（包含派生列）
-- **SPL 对应**: `derive()`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（返回非表达式/字典），`AttributeError`（列不存在）
+### `LTSeq.derive`（别名: `with_columns`）
+- **签名**: `LTSeq.derive(**new_cols: Callable) -> LTSeq` 或 `LTSeq.derive(func: Callable[[Row], dict[str, Expr]]) -> LTSeq`
+- **行为**: 新增或覆盖列，保留已有列。`with_columns` 是面向 Polars 用户的别名
+- **参数**: `new_cols` 列名到 lambda 的映射；或返回字典的 lambda
+- **返回**: 带派生列的新 `LTSeq`
+- **异常**: `ValueError`（schema 未初始化），`TypeError`（返回类型无效），`AttributeError`（列不存在）
 - **示例**:
 ```python
-# 方式 1
+# 风格 1
 with_tax = t.derive(tax=lambda r: r.price * 0.1)
-# 方式 2
+# 风格 2
 with_tax = t.derive(lambda r: {"tax": r.price * 0.1})
+# Polars 风格别名
+with_tax = t.with_columns(tax=lambda r: r.price * 0.1)
+```
+
+### `LTSeq.rename`
+- **签名**: `LTSeq.rename(mapping: dict[str, str] | None = None, **kwargs: str) -> LTSeq`
+- **行为**: 通过字典或关键字参数（`旧名=新名`）重命名列
+- **返回**: 重命名后的新 `LTSeq`
+- **异常**: `AttributeError`（列不存在），`ValueError`（schema 未初始化）
+- **示例**:
+```python
+t.rename({"old_name": "new_name"})
+t.rename(price="unit_price", qty="quantity")
+```
+
+### `LTSeq.drop`
+- **签名**: `LTSeq.drop(*cols: str) -> LTSeq`
+- **行为**: 删除指定列，保留其余列
+- **异常**: `AttributeError`（列不存在），`ValueError`（schema 未初始化）
+- **示例**:
+```python
+t.drop("tmp", "debug_flag")
 ```
 
 ### `LTSeq.sort`
-- **签名**: `LTSeq.sort(*keys: Union[str, Callable], desc: Union[bool, list] = False) -> LTSeq`
-- **行为**: 按一个或多个键排序；窗口/有序计算必须先排序。同时更新 `sort_keys` 属性以追踪排序状态。
-- **参数**: `keys` 列名或表达式；`desc`（或 `descending`）全局或逐列降序标记
-- **返回**: 排序后的新 `LTSeq`（含追踪的排序键）
-- **SPL 对应**: `sort()`
-- **异常**: `ValueError`（schema 未初始化或 desc 长度不匹配），`TypeError`（键类型非法），`AttributeError`（列不存在）
+- **签名**: `LTSeq.sort(*keys: str | Callable, desc: bool | list[bool] = False, descending: bool | list[bool] | None = None) -> LTSeq`
+- **行为**: 按一个或多个键排序；窗口/有序计算的前置条件。同时填充 `sort_keys` 用于排序状态追踪。`descending` 是 `desc` 的别名（Polars 命名），两者同时给出时 `descending` 优先
+- **参数**: `keys` 列名或表达式；`desc`/`descending` 全局或逐键降序标志
+- **返回**: 排序后的 `LTSeq`（带排序键追踪）
+- **异常**: `ValueError`（schema 未初始化或 desc 长度不匹配），`TypeError`（键类型无效），`AttributeError`（列不存在）
 - **示例**:
 ```python
 t_sorted = t.sort("date", "id", desc=[False, True])
 print(t_sorted.sort_keys)  # [("date", False), ("id", True)]
+
+t.sort("price", descending=True)  # Polars 风格别名
 ```
 
 ### `LTSeq.sort_keys`（属性）
-- **签名**: `LTSeq.sort_keys -> Optional[List[Tuple[str, bool]]]`
-- **行为**: 返回当前排序键列表（列名, 是否降序），未排序时返回 None
-- **参数**: 无（属性）
-- **返回**: `Optional[List[Tuple[str, bool]]]`
-- **异常**: 无
+- **签名**: `LTSeq.sort_keys -> list[tuple[str, bool]] | None`
+- **行为**: 以 (列名, 是否降序) 元组列表返回当前排序键；排序状态未知时返回 None
 - **示例**:
 ```python
 t = LTSeq.read_csv("data.csv")
-print(t.sort_keys)         # None（未知排序顺序）
+print(t.sort_keys)  # None（排序状态未知）
 
 t_sorted = t.sort("date", "id")
 print(t_sorted.sort_keys)  # [("date", False), ("id", False)]
+
+t_desc = t.sort("price", desc=True)
+print(t_desc.sort_keys)  # [("price", True)]
 ```
 
 ### `LTSeq.is_sorted_by`
-- **签名**: `LTSeq.is_sorted_by(*keys: str, desc: Union[bool, List[bool]] = False) -> bool`
-- **行为**: 检查表是否已按给定键排序（前缀匹配）
-- **参数**: `keys` 要检查的列名；`desc` 期望的降序标记
-- **返回**: `bool`
+- **签名**: `LTSeq.is_sorted_by(*keys: str, desc: bool | list[bool] = False) -> bool`
+- **行为**: 检查表是否按给定键排序（前缀匹配）
+- **参数**: `keys` 待检查的列名；`desc` 期望的降序标志（单个布尔或逐键列表）
+- **返回**: `bool` - 按给定键（作为前缀）排序则为 True
 - **异常**: `ValueError`（未提供键或 desc 长度不匹配）
 - **示例**:
 ```python
 t_sorted = t.sort("a", "b", "c")
-t_sorted.is_sorted_by("a")           # True（前缀匹配）
-t_sorted.is_sorted_by("a", "b")      # True
-t_sorted.is_sorted_by("b")           # False（非前缀）
+t_sorted.is_sorted_by("a")          # True（前缀匹配）
+t_sorted.is_sorted_by("a", "b")     # True（前缀匹配）
+t_sorted.is_sorted_by("a", "b", "c") # True（完全匹配）
+t_sorted.is_sorted_by("b")          # False（非前缀）
 t_sorted.is_sorted_by("a", desc=True)  # False（方向不匹配）
 ```
 
+### `LTSeq.assume_sorted`
+- **签名**: `LTSeq.assume_sorted(*keys: str, desc: bool | list[bool] = False) -> LTSeq`
+- **行为**: 声明数据已按给定键排序，**不做物理排序**。可对预排序数据（如预排序的 Parquet）跳过排序开销，同时启用窗口函数与归并连接。正确性由调用方负责——错误的声明会产生错误结果
+- **参数**: `keys` 声明排序顺序的列名；`desc` 降序标志
+- **返回**: 设置了排序元数据的 `LTSeq`（底层数据不变）
+- **异常**: `ValueError`（schema 未初始化或 desc 长度不匹配），`TypeError`（desc 类型无效）
+- **示例**:
+```python
+t = LTSeq.read_parquet("presorted.parquet").assume_sorted("userid", "eventtime")
+t.is_sorted_by("userid")  # True
+```
+
 ### `LTSeq.distinct`
-- **签名**: `LTSeq.distinct(*keys: Union[str, Callable]) -> LTSeq`
-- **行为**: 去重；未指定 keys 时按所有列去重
-- **参数**: `keys` 去重键（列名或表达式）
-- **返回**: 去重后的新 `LTSeq`
-- **SPL 对应**: `id()`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（键类型非法），`AttributeError`（列不存在）
+- **签名**: `LTSeq.distinct(*keys: str | Callable) -> LTSeq`
+- **行为**: 去重；不传键时按所有列去重
+- **参数**: `keys` 键列或表达式
+- **返回**: 去重后的 `LTSeq`
+- **异常**: `ValueError`（schema 未初始化），`TypeError`（键类型无效），`AttributeError`（列不存在）
 - **示例**:
 ```python
 unique = t.distinct("customer_id")
 ```
 
 ### `LTSeq.slice`
-- **签名**: `LTSeq.slice(offset: int = 0, length: Optional[int] = None) -> LTSeq`
-- **行为**: 选择连续行区间，零拷贝语义
-- **参数**: `offset` 起始行（0 基）；`length` 行数（None 表示直到末尾）
-- **返回**: 截取后的新 `LTSeq`
-- **SPL 对应**: `T([start,end])`
-- **异常**: `ValueError`（offset/length 为负），`ValueError`（schema 未初始化）
+- **签名**: `LTSeq.slice(offset: int = 0, length: int | None = None) -> LTSeq`
+- **行为**: 选取连续行区间，逻辑零拷贝
+- **参数**: `offset` 起始行（0-based）；`length` 行数（None 表示到末尾）
+- **返回**: 截取后的 `LTSeq`
+- **异常**: `ValueError`（负 offset/length 或 schema 未初始化）
 - **示例**:
 ```python
 t.slice(offset=10, length=5)
@@ -318,26 +491,32 @@ t.slice(offset=10, length=5)
 
 ### 3.1 行级窗口操作
 
-> 这些操作要求在调用前使用 `sort` 建立顺序。
+> 这些操作依赖先行的 `.sort()`（或 `.assume_sorted()`）建立顺序。`shift` 还支持 `partition_by=` 参数（列名字符串或表达式），在分组边界处重置窗口。
 
 #### `r.col.shift`
-- **签名**: `r.col.shift(offset: int) -> Expr`
-- **行为**: 访问相对行的值。正偏移量表示向前（历史行），负偏移量表示向后（未来行），与 pandas `Series.shift()` 一致。
-- **参数**: `offset` 行偏移量（正 = 向前，负 = 向后）
-- **返回**: 表达式（边界处为 NULL）
-- **SPL 对应**: `col[-1]`
-- **异常**: `TypeError`（offset 非 int），`RuntimeError`（未排序使用）
+- **签名**: `r.col.shift(offset: int, default: Any = None, partition_by: str | Expr | None = None) -> Expr`
+- **行为**: 访问相对行。正偏移向前看（前面的行），负偏移向后看（后面的行），与 pandas `Series.shift()` 一致。指定 `partition_by` 时窗口在分组边界处重置（LAG/LEAD OVER PARTITION BY）
+- **参数**: `offset` 行偏移（正=向前，负=向后）；`default` 边界填充值（默认 NULL）；`partition_by` 可选分区列
+- **返回**: 表达式（偏移超出可用行的边界处为 NULL 或 `default`）
+- **异常**: `TypeError`（offset 非整数），`RuntimeError`（未排序使用）
 - **示例**:
 ```python
 with_prev = t.sort("date").derive(prev=lambda r: r.close.shift(1))
+
+# 分组 shift：每组边界处为 NULL
+t.sort("grp", "date").derive(
+    prev=lambda r: r.value.shift(1, partition_by="grp")
+)
+
+# 边界处填充默认值而非 NULL
+t.sort("date").derive(prev=lambda r: r.value.shift(1, default=0))
 ```
 
 #### `r.col.rolling`
 - **签名**: `r.col.rolling(window_size: int).agg_func() -> Expr`
-- **行为**: 滑动窗口聚合；常用聚合包括 `mean/sum/min/max/std`
+- **行为**: 滑动窗口聚合；支持的聚合：`mean/sum/min/max/count/std`
 - **参数**: `window_size` 窗口大小
 - **返回**: 窗口聚合表达式
-- **SPL 对应**: `col{-1,1}`
 - **异常**: `ValueError`（window_size <= 0），`RuntimeError`（未排序使用）
 - **示例**:
 ```python
@@ -346,167 +525,246 @@ ma5 = t.sort("date").derive(ma_5=lambda r: r.close.rolling(5).mean())
 
 #### `r.col.diff`
 - **签名**: `r.col.diff(offset: int = 1) -> Expr`
-- **行为**: 差分计算，等价于 `r.col - r.col.shift(offset)`
-- **参数**: `offset` 行偏移量
+- **行为**: 行差分，等价于 `r.col - r.col.shift(offset)`
+- **参数**: `offset` 行偏移
 - **返回**: 差分表达式
-- **SPL 对应**: `col - col[-1]`
-- **异常**: `TypeError`（非数值列或 offset 非 int），`RuntimeError`（未排序使用）
+- **异常**: `TypeError`（非数值或 offset 非整数），`RuntimeError`（未排序使用）
 - **示例**:
 ```python
 changes = t.sort("date").derive(daily=lambda r: r.close.diff())
 ```
 
-### 3.2 表级累积操作
+#### `r.col.pct_change`
+- **签名**: `r.col.pct_change() -> Expr`
+- **行为**: 相对上一行的变化率：`(x - x.shift(1)) / x.shift(1)`。需要先排序
+- **返回**: 数值表达式
+- **示例**:
+```python
+returns = t.sort("date").derive(daily_return=lambda r: r.close.pct_change())
+```
+
+#### `r.col.cum_sum`（表达式形式）
+- **签名**: `r.col.cum_sum() -> Expr`
+- **行为**: 按当前顺序累计求和，可在 `derive()` 内使用，输出列名由用户掌控
+- **异常**: `TypeError`（非数值），`RuntimeError`（未排序使用）
+- **示例**:
+```python
+t.sort("date").derive(cum_vol=lambda r: r.volume.cum_sum())
+```
+
+### 3.2 表级累计操作
 
 #### `LTSeq.cum_sum`
-- **签名**: `LTSeq.cum_sum(*cols: Union[str, Callable]) -> LTSeq`
-- **行为**: 对指定列做累计求和，并追加 `*_cumsum` 列
+- **签名**: `LTSeq.cum_sum(*cols: str | Callable) -> LTSeq`
+- **行为**: 添加带 `*_cumsum` 后缀的累计求和列。若需自定义列名，请在 `derive()` 中使用表达式形式 `r.col.cum_sum()`
 - **参数**: `cols` 列名或表达式
-- **返回**: 包含累计列的新 `LTSeq`
-- **SPL 对应**: `cum(col)`
-- **异常**: `ValueError`（未提供列或 schema 未初始化），`TypeError`（非数值列）
+- **返回**: 带累计列的新 `LTSeq`
+- **异常**: `ValueError`（无列或 schema 未初始化），`TypeError`（非数值）
 - **示例**:
 ```python
 with_cum = t.sort("date").cum_sum("volume", "amount")
+# → 新增 volume_cumsum、amount_cumsum
 ```
 
 ### 3.3 排名函数
 
-> 排名函数通过 `.over()` 指定排序，**不需要**提前调用 `.sort()`。
+> 排名函数使用 `.over()` 指定排序，不需要先行的 `.sort()`。
+
+排名函数在分区内为行分配位置或名次，必须配合 `.over()` 指定排序。
 
 #### `row_number`
 - **签名**: `row_number().over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **行为**: 在每个分区内从 1 开始连续编号，并列时也保持唯一值
-- **参数**: 通过 `.over()` 指定 `partition_by`（可选）、`order_by`（必填）、`descending`（可选）
+- **行为**: 为每行分配唯一的连续编号（1, 2, 3, ...）。与 `rank()` 不同，相同值也会得到不同编号
+- **参数**: 通过 `.over()` 指定 `partition_by`（可选）、`order_by`（必需）、`descending`（可选）
 - **返回**: 整数表达式
 - **异常**: `RuntimeError`（未指定 order_by）
 - **示例**:
 ```python
-from ltseq.expr import row_number
-t.derive(rn=lambda r: row_number().over(partition_by=r.region, order_by=r.date))
+from ltseq import row_number
+
+# 简单行编号
+t.derive(rn=lambda r: row_number().over(order_by=r.date))
+
+# 分区内行编号
+t.derive(rn=lambda r: row_number().over(partition_by=r.group, order_by=r.date))
 ```
 
 #### `rank`
 - **签名**: `rank().over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **行为**: 并列时共享同一排名，后续排名跳过（1,1,3,...）
+- **行为**: 分配带跳号的排名。相同值得到相同名次，其后的名次被跳过（1, 2, 2, 4, 5）
+- **参数**: 通过 `.over()` 指定 `partition_by`（可选）、`order_by`（必需）、`descending`（可选）
 - **返回**: 整数表达式
+- **异常**: `RuntimeError`（未指定 order_by）
 - **示例**:
 ```python
-from ltseq.expr import rank
-t.derive(rk=lambda r: rank().over(order_by=r.score, descending=True))
+from ltseq import rank
+
+# 按分数排名（并列同名次，随后跳号）
+t.derive(rnk=lambda r: rank().over(order_by=r.score))
+
+# 部门内排名
+t.derive(rnk=lambda r: rank().over(partition_by=r.dept, order_by=r.salary, descending=True))
 ```
 
 #### `dense_rank`
 - **签名**: `dense_rank().over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **行为**: 并列时共享同一排名，后续排名不跳过（1,1,2,...）
+- **行为**: 分配不跳号的排名。相同值得到相同名次，其后名次不跳过（1, 2, 2, 3, 4）
+- **参数**: 通过 `.over()` 指定 `partition_by`（可选）、`order_by`（必需）、`descending`（可选）
 - **返回**: 整数表达式
+- **异常**: `RuntimeError`（未指定 order_by）
 - **示例**:
 ```python
-from ltseq.expr import dense_rank
-t.derive(dr=lambda r: dense_rank().over(order_by=r.score, descending=True))
+from ltseq import dense_rank
+
+# 按分数密集排名（并列后不跳号）
+t.derive(drnk=lambda r: dense_rank().over(order_by=r.score))
+
+# 部门内密集排名
+t.derive(drnk=lambda r: dense_rank().over(partition_by=r.dept, order_by=r.salary))
 ```
 
 #### `ntile`
 - **签名**: `ntile(n: int).over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **行为**: 将行分为 n 个尽量等大的桶，返回桶号（1 ~ n）
-- **参数**: `n` 桶数
-- **返回**: 整数表达式（1 ~ n）
+- **行为**: 将行划分为 `n` 个大致等量的桶（1 到 n）。适用于分位数计算
+- **参数**: `n` 桶数；通过 `.over()` 指定分区/排序
+- **返回**: 整数表达式（桶号 1 到 n）
+- **异常**: `ValueError`（n <= 0），`RuntimeError`（未指定 order_by）
 - **示例**:
 ```python
-from ltseq.expr import ntile
-t.derive(quartile=lambda r: ntile(4).over(order_by=r.value))
+from ltseq import ntile
+
+# 四分位
+t.derive(quartile=lambda r: ntile(4).over(order_by=r.score))
+
+# 组内十分位
+t.derive(decile=lambda r: ntile(10).over(partition_by=r.group, order_by=r.value))
 ```
 
-#### `.over()` 窗口说明
-- **签名**: `expr.over(partition_by=None, order_by=None, descending=False) -> WindowExpr`
-- **行为**: 为排名函数附加窗口规范
+#### `CallExpr.over`（窗口规格）
+- **签名**: `expr.over(partition_by: Expr | None = None, order_by: Expr | None = None, descending: bool = False) -> WindowExpr`
+- **行为**: 为排名函数应用窗口规格。`partition_by` 和 `order_by` 各接受**单个列表达式**；`descending` 是作用于 `order_by` 的单个布尔值
 - **参数**:
-  - `partition_by`: 分区列（单个 Expr 或列表）
-  - `order_by`: 排序列（单个 Expr 或列表）
-  - `descending`: 降序标记（单个 bool 或逐列列表）
+  - `partition_by` 分区列（可选）
+  - `order_by` 排序列（排名函数必需）
+  - `descending` order_by 的排序方向（默认 False）
+- **返回**: 可用于 derive() 的 `WindowExpr`
+- **异常**: `TypeError`（partition_by/order_by 类型无效）
 - **示例**:
 ```python
-# 单列分区
-t.derive(rn=lambda r: row_number().over(partition_by=r.region, order_by=r.date))
-
-# 多列分区
 t.derive(rn=lambda r: row_number().over(
-    partition_by=[r.region, r.category],
-    order_by=[r.date, r.id],
-    descending=[True, False]
+    partition_by=r.region,
+    order_by=r.date,
+    descending=True,
 ))
 ```
 
-### 3.4 有序搜索与对齐
+### 3.4 有序查找
 
 #### `LTSeq.search_first`
 - **签名**: `LTSeq.search_first(predicate: Callable[[Row], Expr]) -> LTSeq`
-- **行为**: 返回首个匹配行（单行 LTSeq）；在有序数据上可实现二分搜索优化
+- **行为**: 返回第一个匹配行（单行 LTSeq）；对已排序数据可做二分查找
 - **参数**: `predicate` 行谓词
-- **返回**: 单行 `LTSeq`（未找到则为空表）
-- **SPL 对应**: `pselect`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（谓词非法），`RuntimeError`（执行失败）
+- **返回**: 单行 `LTSeq`（未找到时为空）
+- **异常**: `ValueError`（schema 未初始化），`TypeError`（谓词无效），`RuntimeError`（谓词无法转译）
 - **示例**:
 ```python
 first_big = t.sort("price").search_first(lambda r: r.price > 100)
 ```
 
+#### `LTSeq.search_pattern`
+- **签名**: `LTSeq.search_pattern(*step_predicates: Callable, partition_by: str | None = None) -> LTSeq`
+- **行为**: 查找**连续行**依次匹配一组谓词的位置（漏斗/序列匹配）。返回第 1 步匹配的行，即满足 `step1(i), step2(i+1), ..., stepN(i+N-1)` 全部成立的行 `i`。指定 `partition_by` 时模式不跨分区边界
+- **参数**: `step_predicates` 每步一个 lambda；`partition_by` 可选分区列
+- **返回**: 第 1 步所在行组成的 `LTSeq`
+- **异常**: `ValueError`（无谓词或 schema 未初始化）
+- **示例**:
+```python
+# 按用户查找三步 URL 漏斗
+matches = t.search_pattern(
+    lambda r: r.url.s.starts_with("/landing"),
+    lambda r: r.url.s.starts_with("/product"),
+    lambda r: r.url.s.starts_with("/checkout"),
+    partition_by="userid",
+)
+```
+
+#### `LTSeq.search_pattern_count`
+- **签名**: `LTSeq.search_pattern_count(*step_predicates: Callable, partition_by: str | None = None) -> int`
+- **行为**: 同 `search_pattern`，但只返回匹配数量
+- **返回**: `int`
+- **示例**:
+```python
+n = t.search_pattern_count(
+    lambda r: r.event == "view",
+    lambda r: r.event == "buy",
+    partition_by="userid",
+)
+```
+
 #### `LTSeq.align`
-- **签名**: `LTSeq.align(ref_sequence: List[Any], key: Callable[[Row], Expr]) -> LTSeq`
-- **行为**: 将序列对齐到 `ref_sequence` 的顺序，缺失键以 NULL 填充
-- **参数**: `ref_sequence` 参考键序列；`key` 从行中提取对齐键
-- **返回**: 对齐后的新 `LTSeq`
-- **SPL 对应**: `align`
-- **异常**: `TypeError`（key 非法），`ValueError`（ref_sequence 为空）
+- **签名**: `LTSeq.align(ref_sequence: list[Any], key: Callable[[Row], Expr]) -> LTSeq`
+- **行为**: 按 `ref_sequence` 的顺序对齐，缺失键处填 NULL
+- **参数**: `ref_sequence` 参考键序列；`key` 键提取器
+- **返回**: 对齐后的 `LTSeq`
+- **异常**: `TypeError`（键无效），`ValueError`（ref_sequence 为空）
 - **示例**:
 ```python
 aligned = t.align(["2024-01-01", "2024-01-02"], key=lambda r: r.date)
 ```
 
-## 4. 有序分组与过程计算
+### 3.5 物理行序操作
 
-### `LTSeq.group_ordered`
+#### `LTSeq.rvs`
+- **签名**: `LTSeq.rvs() -> LTSeq`
+- **行为**: 反转表的行序
+- **示例**:
+```python
+reversed_t = t.sort("date").rvs()
+```
+
+#### `LTSeq.step`
+- **签名**: `LTSeq.step(n: int) -> LTSeq`
+- **行为**: 每隔 n 行取一行（0-based：第 0, n, 2n, ... 行）
+- **参数**: `n` 步长（必须 >= 1）
+- **异常**: `ValueError`（n < 1）
+- **示例**:
+```python
+every_other = t.step(2)   # 第 0, 2, 4, ... 行
+every_tenth = t.step(10)
+```
+
+## 4. 有序分组与过程化计算
+
+### `LTSeq.group_ordered`（别名: `group_consecutive`）
 - **签名**: `LTSeq.group_ordered(key: Callable[[Row], Expr]) -> NestedTable`
-- **行为**: 仅按"连续相同值"分组，不会重新排序
+- **行为**: 只把连续相等的值归为一组；不重排数据。`group_consecutive` 是同一方法的更直白别名
 - **参数**: `key` 分组键表达式
-- **返回**: `NestedTable`（支持组级操作）
-- **SPL 对应**: `group@o`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（key 非法），`AttributeError`（列不存在）
+- **返回**: `NestedTable`（组级操作）
+- **异常**: `ValueError`（schema 未初始化），`TypeError`（键无效），`AttributeError`（列不存在）
 - **示例**:
 ```python
 groups = t.sort("date").group_ordered(lambda r: r.is_up)
+# 等价：
+groups = t.sort("date").group_consecutive(lambda r: r.is_up)
 ```
 
 ### `LTSeq.group_sorted`
 - **签名**: `LTSeq.group_sorted(key: Callable[[Row], Expr]) -> NestedTable`
-- **行为**: 假设全局已按 key 排序，单次扫描完成分组（避免哈希）
+- **行为**: 假定数据已按键全局排序；单遍分组，无需哈希
 - **参数**: `key` 分组键表达式
 - **返回**: `NestedTable`
-- **SPL 对应**: `groups@o`
-- **异常**: `ValueError`（未排序或 schema 未初始化），`TypeError`（key 非法）
+- **异常**: `ValueError`（未排序或 schema 未初始化），`TypeError`（键无效）
 - **示例**:
 ```python
 groups = t.sort("user_id").group_sorted(lambda r: r.user_id)
 ```
 
-### `LTSeq.scan`
-- **签名**: `LTSeq.scan(func: Callable[[State, Row], State], init: Any) -> LTSeq`
-- **行为**: 按当前顺序进行状态累积，输出每行对应的累计状态
-- **参数**: `func` 状态转移函数；`init` 初始状态
-- **返回**: `LTSeq`（通常为单列状态序列或追加状态列）
-- **SPL 对应**: `iterate`
-- **异常**: `TypeError`（func 非法），`RuntimeError`（执行失败）
-- **示例**:
-```python
-# 复利累积
-rates = t.sort("date").scan(lambda s, r: s * (1 + r.rate), init=1.0)
-```
-
-### `NestedTable`（来自 `group_ordered` / `group_sorted`）
+### `NestedTable`（由 `group_ordered` / `group_sorted` 产生）
 
 #### `NestedTable.first`
 - **签名**: `nested.first() -> LTSeq`
-- **行为**: 取每组首行
+- **行为**: 每组的第一行
+- **返回**: 首行组成的 `LTSeq`（每组一行）
 - **示例**:
 ```python
 first_rows = groups.first()
@@ -514,23 +772,17 @@ first_rows = groups.first()
 
 #### `NestedTable.last`
 - **签名**: `nested.last() -> LTSeq`
-- **行为**: 取每组末行
+- **行为**: 每组的最后一行
+- **返回**: 末行组成的 `LTSeq`（每组一行）
 - **示例**:
 ```python
 last_rows = groups.last()
 ```
 
-#### `NestedTable.count`
-- **签名**: `nested.count() -> LTSeq`
-- **行为**: 返回每组的行数
-- **示例**:
-```python
-sizes = groups.count()
-```
-
 #### `NestedTable.flatten`
 - **签名**: `nested.flatten() -> LTSeq`
-- **行为**: 将嵌套表展开为普通表，附带 `__group_id__`
+- **行为**: 返回带 `__group_id__` 列的底层行，该列标识每个连续分组
+- **返回**: 展平后的 `LTSeq`
 - **示例**:
 ```python
 flat = groups.flatten()
@@ -538,98 +790,83 @@ flat = groups.flatten()
 
 #### `NestedTable.filter`
 - **签名**: `nested.filter(predicate: Callable[[GroupProxy], Expr]) -> NestedTable`
-- **行为**: 按组级条件过滤组
+- **行为**: 只保留满足组级谓词的组；保留组的全部行
+- **参数**: `predicate` 组谓词（`g` 为组代理，见下）
+- **返回**: 过滤后的 `NestedTable`
+- **异常**: `TypeError`（谓词无效），`RuntimeError`（执行失败）
 - **示例**:
 ```python
-a = groups.filter(lambda g: g.count() > 3)
+big_groups = groups.filter(lambda g: g.count() > 3)
 ```
 
 #### `NestedTable.derive`
-- **签名**: `nested.derive(func: Callable[[GroupProxy], Dict[str, Expr]]) -> LTSeq`
-- **行为**: 生成组级派生列
+- **签名**: `nested.derive(func: Callable[[GroupProxy], dict[str, Expr]]) -> LTSeq`
+- **行为**: 计算组级值并**广播到组内每一行**。结果保留所有原始行和列，外加新列。（若需坍缩为每组一行，可对派生列接 `distinct()`，或使用 `first()`/`last()`；哈希式的每组一行聚合见第 7 节 `agg()`/`group_by()`）
+- **参数**: `func` 返回组表达式字典
+- **返回**: 原始行 + 广播组级列的 `LTSeq`
+- **异常**: `ValueError`（lambda 未返回字典），`RuntimeError`（执行失败）
 - **示例**:
 ```python
-spans = groups.derive(lambda g: {"start": g.first().date, "end": g.last().date})
+# 每行都拿到所在组的大小与起止
+enriched = groups.derive(lambda g: {
+    "group_size": g.count(),
+    "start": g.first().date,
+    "end": g.last().date,
+})
 ```
 
-### `GroupProxy` 聚合方法
-
-#### 基础聚合（列访问风格）
-- **签名**: `g.col.sum()`, `g.col.avg()`, `g.col.min()`, `g.col.max()`
-- **行为**: 在组范围内对指定列做基础聚合
+#### `len(nested)` / `NestedTable.to_pandas`
+- **签名**: `NestedTable.__len__() -> int`；`NestedTable.to_pandas()`
+- **行为**: `len()` 返回组数；`to_pandas()` 物化展平后的行
 - **示例**:
 ```python
-groups.derive(lambda g: {"avg": g.price.avg(), "hi": g.price.max()})
+n_groups = len(groups)
 ```
 
-#### `GroupProxy.variance` / `GroupProxy.std`
-- **签名**: `g.variance(column: str) -> Expr` / `g.std(column: str) -> Expr`
-- **行为**: 组内方差 / 标准差
+### 组代理（NestedTable filter/derive 中的 `g`）
+
+组聚合以**字符串列名**为参数；`first()`/`last()` 返回可属性访问的行代理。
+
+#### 聚合: `g.count()`、`g.sum()`、`g.avg()`、`g.min()`、`g.max()`
+- **签名**: `g.count() -> Expr`；`g.sum(column: str) -> Expr`（`avg`/`min`/`max` 同）
+- **行为**: 组内行数 / 对单列的组内聚合
 - **示例**:
 ```python
-groups.derive(lambda g: {"vol": g.variance("price")})
+groups.derive(lambda g: {"avg_price": g.avg("price"), "hi": g.max("price")})
+groups.filter(lambda g: g.sum("amount") > 1000)
 ```
 
-#### `GroupProxy.median`
-- **签名**: `g.median(column: str) -> Expr`
-- **行为**: 组内中位数
+#### 行访问: `g.first()`、`g.last()`
+- **签名**: `g.first() -> RowProxy`；`g.last() -> RowProxy`
+- **行为**: 组的第一行/最后一行；以属性访问列
 - **示例**:
 ```python
-groups.derive(lambda g: {"mid": g.median("price")})
+groups.derive(lambda g: {"start": g.first().date, "end": g.last().date})
 ```
 
-#### `GroupProxy.percentile`
-- **签名**: `g.percentile(column: str, p: float) -> Expr`
-- **行为**: 组内百分位数（0 ≤ p ≤ 1）
+#### 量词（仅 filter）: `g.all()`、`g.any()`、`g.none()`
+- **签名**: `g.all(predicate: Callable[[Row], Expr]) -> Expr`（`any`/`none` 同）
+- **行为**: 组内所有行 / 至少一行 / 没有任何行满足行级谓词时为 True。用于 `NestedTable.filter`
+- **参数**: `predicate` 行级谓词（可使用完整的行表达式能力）
 - **示例**:
 ```python
-groups.derive(lambda g: {"p95": g.percentile("response_ms", 0.95)})
-```
-
-#### `GroupProxy.mode`
-- **签名**: `g.mode(column: str) -> Expr`
-- **行为**: 组内众数（出现频率最高的值）
-- **示例**:
-```python
-groups.derive(lambda g: {"common_category": g.mode("category")})
-```
-
-#### `GroupProxy.top_k`
-- **签名**: `g.top_k(column: str, k: int) -> List[Any]`
-- **行为**: 组内 Top-K 值列表（降序排列）
-- **参数**: `column` 列名；`k` 个数
-- **示例**:
-```python
-groups.derive(lambda g: {"top_3_prices": g.top_k("price", 3)})
-```
-
-#### `GroupProxy.all` / `GroupProxy.any` / `GroupProxy.none`
-- **签名**: `g.all(predicate)` / `g.any(predicate)` / `g.none(predicate)`
-- **行为**: 检查组内所有/任意/无行满足谓词
-- **示例**:
-```python
+# 所有金额均为正的组
 groups.filter(lambda g: g.all(lambda r: r.amount > 0))
+
+# 至少包含一条错误记录的组
 groups.filter(lambda g: g.any(lambda r: r.status == "error"))
+
+# 不含已删除行的组
 groups.filter(lambda g: g.none(lambda r: r.is_deleted == True))
 ```
 
-#### `GroupProxy.count_if` / `GroupProxy.sum_if` / `GroupProxy.avg_if` / `GroupProxy.min_if` / `GroupProxy.max_if`
-- **签名**: `g.count_if(predicate)` / `g.sum_if(predicate, column)` / 等
-- **行为**: 组内满足谓词的行的条件聚合
-- **示例**:
-```python
-groups.derive(lambda g: {"high_count": g.count_if(lambda r: r.price > 100)})
-groups.derive(lambda g: {"vip_sales": g.sum_if(lambda r: r.is_vip, "amount")})
-```
-
-## 5. 集合代数
+## 5. 集合运算
 
 ### `LTSeq.union`
 - **签名**: `LTSeq.union(other: LTSeq) -> LTSeq`
-- **行为**: 纵向拼接（类似 SQL UNION ALL）
-- **参数**: `other` 另一个同 schema 的 LTSeq
+- **行为**: 纵向拼接，**保留重复行**（SQL UNION ALL 语义）
+- **参数**: `other` 另一个 schema 相同的 LTSeq
 - **返回**: 合并后的 `LTSeq`
-- **SPL 对应**: `A & B`
 - **异常**: `TypeError`（other 非 LTSeq），`ValueError`（schema 不匹配）
 - **示例**:
 ```python
@@ -637,208 +874,290 @@ combined = t1.union(t2)
 ```
 
 ### `LTSeq.intersect`
-- **签名**: `LTSeq.intersect(other: LTSeq, on: Optional[Callable] = None) -> LTSeq`
-- **行为**: 返回两表交集
-- **参数**: `other` 另一表；`on` 指定比较键（None 表示全列）
+- **签名**: `LTSeq.intersect(other: LTSeq, on: Callable | None = None) -> LTSeq`
+- **行为**: 两表交集
+- **参数**: `other` 另一个表；`on` 键选择器（None 表示全列）
 - **返回**: 交集 `LTSeq`
-- **SPL 对应**: `A ^ B`
-- **异常**: `TypeError`（other 非 LTSeq 或 on 非法），`ValueError`（schema 未初始化）
+- **异常**: `TypeError`（other 非 LTSeq 或 on 无效），`ValueError`（schema 未初始化）
 - **示例**:
 ```python
 common = t1.intersect(t2, on=lambda r: r.id)
 ```
 
-### `LTSeq.except_`（集合差）
-- **签名**: `LTSeq.except_(other: LTSeq, on: Optional[Callable] = None) -> LTSeq`
-- **行为**: 返回左表中不存在于右表的行（SQL EXCEPT 语义）
-- **参数**: `other` 另一表；`on` 指定比较键
+### `LTSeq.except_`（差集）
+- **签名**: `LTSeq.except_(other: LTSeq, on: Callable | None = None) -> LTSeq`
+- **行为**: 左表中有而右表中没有的行（SQL EXCEPT 语义）
+- **参数**: `other` 另一个表；`on` 键选择器
 - **返回**: 差集 `LTSeq`
-- **SQL 对应**: `EXCEPT` / `MINUS`
-- **SPL 对应**: `A \ B`
-- **异常**: `TypeError`（other 非 LTSeq 或 on 非法），`ValueError`（schema 未初始化）
+- **SQL 等价**: `EXCEPT` / `MINUS`
+- **异常**: `TypeError`（other 非 LTSeq 或 on 无效），`ValueError`（schema 未初始化）
 - **示例**:
 ```python
 only_left = t1.except_(t2, on=lambda r: r.id)
 ```
 
-> 注意：表达式里的 `Expr.diff()`（第 3 节中的行级差分）与表级差集不同。表级差集请使用 `except_()`。
+> 注意：`Expr.diff()`（行级差分，第 3 节）与表级差集无关。表级差集请使用 `except_()`。
+
+### `LTSeq.xunion`（对称差）
+- **签名**: `LTSeq.xunion(other: LTSeq, on: Callable | None = None) -> LTSeq`
+- **行为**: 只在其中一个表中出现的行；等价于 `(a except b) union (b except a)`
+- **参数**: `other` 另一个表；`on` 键选择器（None 表示全列）
+- **返回**: 对称差 `LTSeq`
+- **示例**:
+```python
+unique_to_either = t1.xunion(t2, on=lambda r: r.id)
+```
 
 ### `LTSeq.is_subset`
-- **签名**: `LTSeq.is_subset(other: LTSeq, on: Optional[Callable] = None) -> bool`
-- **行为**: 判断当前表是否为另一表的子集
-- **参数**: `other` 另一表；`on` 指定比较键
+- **签名**: `LTSeq.is_subset(other: LTSeq, on: Callable | None = None) -> bool`
+- **行为**: 检查本表是否为另一个表的子集
+- **参数**: `other` 另一个表；`on` 键选择器
 - **返回**: `bool`
-- **异常**: `TypeError`（other 非 LTSeq 或 on 非法），`ValueError`（schema 未初始化）
+- **异常**: `TypeError`（other 非 LTSeq 或 on 无效），`ValueError`（schema 未初始化）
 - **示例**:
 ```python
 flag = t_small.is_subset(t_big, on=lambda r: r.id)
 ```
 
+### `LTSeq.contain`
+- **签名**: `LTSeq.contain(key_col: str, *values) -> bool`
+- **行为**: 检查给定的**所有**值是否都出现在该列中
+- **参数**: `key_col` 列名；`values` 待查找的值
+- **返回**: `bool`（全部找到为 True；values 为空时为 True）
+- **异常**: `AttributeError`（列不存在）
+- **示例**:
+```python
+t.contain("status", "active", "pending")
+t.contain("id", 1, 2, 3)
+```
+
 ## 6. 关联与连接
 
 ### `LTSeq.join`
-- **签名**: `LTSeq.join(other: LTSeq, on: Callable, how: str = "inner") -> LTSeq`
-- **行为**: 标准哈希连接，不要求排序
-- **参数**: `other` 另一表；`on` 连接条件；`how` in {inner,left,right,full}
-- **返回**: 连接后的 `LTSeq`（冲突列名会加后缀）
-- **SPL 对应**: `join`
-- **异常**: `TypeError`（other/on 非法），`ValueError`（how 非法或 schema 未初始化）
+- **签名**: `LTSeq.join(other: LTSeq, on: Callable, how: str = "inner", strategy: str | None = None) -> LTSeq`
+- **行为**: 两表连接。默认哈希连接（无需排序）；`strategy="merge"` 对预排序输入做归并连接并校验排序状态。右表冲突列名会加 `_other_` **前缀**（如 `product` → `_other_product`）
+- **参数**: `other` 另一个表；`on` 连接条件 lambda（如 `lambda a, b: a.id == b.id`）；`how` 取值 {inner,left,right,full}；`strategy` 取值 {None,"hash","merge"}
+- **返回**: 连接后的 `LTSeq`
+- **异常**: `TypeError`（other/on 无效），`ValueError`（how/strategy 无效，或 merge 输入未排序）
 - **示例**:
 ```python
 joined = users.join(orders, on=lambda u, o: u.id == o.user_id, how="left")
-```
 
-### 归并连接策略
-- **签名**: `LTSeq.join(other: LTSeq, on: Callable, how: str = "inner", strategy: str = "hash") -> LTSeq`
-- **行为**: 通过 `strategy="merge"` 在已排序输入上执行归并连接
-- **参数**: `other` 另一表；`on` 连接条件；`how` in {inner,left,right,full}；`strategy` in {hash,merge}
-- **返回**: 连接后的 `LTSeq`
-- **异常**: `TypeError`（other/on 非法），`ValueError`（strategy 非法或归并连接输入未排序）
-- **示例**:
-```python
-t1_sorted = t1.sort("id")
-t2_sorted = t2.sort("id")
-result = t1_sorted.join(
-    t2_sorted,
+# 预排序表的归并连接
+result = t1.sort("id").join(
+    t2.sort("id"),
     on=lambda a, b: a.id == b.id,
     strategy="merge",
 )
 ```
 
-### `LTSeq.semi_join`
-- **签名**: `LTSeq.semi_join(other: LTSeq, on: Callable) -> LTSeq`
-- **行为**: 返回左表中在右表有匹配的行（仅返回左表列，无重复）
-- **参数**: `other` 用于匹配的右表；`on` 连接条件 lambda
-- **返回**: 匹配行的 `LTSeq`（仅含左表列）
-- **SQL 对应**: `WHERE EXISTS`
-- **异常**: `TypeError`（other/on 非法），`ValueError`（schema 未初始化）
+### `LTSeq.asof_join`
+- **签名**: `LTSeq.asof_join(other: LTSeq, on: Callable, direction: str = "backward", is_sorted: bool = False) -> LTSeq`
+- **行为**: 时序就近连接（as-of join）。`is_sorted=True` 时跳过排序校验（已知双方有序时更快）
+- **参数**: `other` 另一个表；`on` 连接条件（如 `lambda t, q: t.time >= q.time`）；`direction` 取值 {"backward","forward","nearest"}；`is_sorted` 跳过排序检查
+- **返回**: as-of 连接后的 `LTSeq`
+- **异常**: `TypeError`（other/on 无效），`ValueError`（direction 无效）
 - **示例**:
 ```python
-# 找出有订单的用户
+result = trades.asof_join(quotes, on=lambda t, q: t.time >= q.time, direction="backward")
+```
+
+### `LTSeq.semi_join`
+- **签名**: `LTSeq.semi_join(other: LTSeq, on: Callable) -> LTSeq`
+- **行为**: 返回左表中键存在于右表的行。只返回左表列，多次匹配不产生重复
+- **参数**: `other` 用于匹配的右表；`on` 连接条件 lambda
+- **返回**: 左表匹配行组成的 `LTSeq`
+- **异常**: `TypeError`（other/on 无效），`ValueError`（schema 未初始化）
+- **示例**:
+```python
+# 至少下过一单的用户
 active_users = users.semi_join(orders, on=lambda u, o: u.id == o.user_id)
 ```
 
 ### `LTSeq.anti_join`
 - **签名**: `LTSeq.anti_join(other: LTSeq, on: Callable) -> LTSeq`
-- **行为**: 返回左表中在右表**无匹配**的行（仅返回左表列）
+- **行为**: 返回左表中键**不**存在于右表的行。只返回左表列
 - **参数**: `other` 用于匹配的右表；`on` 连接条件 lambda
-- **返回**: 非匹配行的 `LTSeq`（仅含左表列）
-- **SQL 对应**: `WHERE NOT EXISTS`
-- **异常**: `TypeError`（other/on 非法），`ValueError`（schema 未初始化）
+- **返回**: 左表未匹配行组成的 `LTSeq`
+- **异常**: `TypeError`（other/on 无效），`ValueError`（schema 未初始化）
 - **示例**:
 ```python
-# 找出没有任何订单的用户
+# 从未下单的用户
 inactive_users = users.anti_join(orders, on=lambda u, o: u.id == o.user_id)
-```
-
-### `LTSeq.asof_join`
-- **签名**: `LTSeq.asof_join(other: LTSeq, on: Callable, direction: str = "backward") -> LTSeq`
-- **行为**: 时间序列最近匹配连接（as-of join）
-- **参数**: `other` 另一表；`on` 连接条件；`direction` in {"backward","forward","nearest"}
-- **返回**: as-of 连接结果 `LTSeq`
-- **SPL 对应**: `joinx`（区间/最近匹配）
-- **异常**: `TypeError`（other/on 非法），`ValueError`（direction 非法或未排序）
-- **示例**:
-```python
-quotes = trades.asof_join(quotes, on=lambda t, q: t.time >= q.time, direction="backward")
 ```
 
 ### `LTSeq.link`
 - **签名**: `LTSeq.link(target_table: LTSeq, on: Callable, as_: str, join_type: str = "inner") -> LinkedTable`
-- **行为**: 指针式关联，不立即物化连接，按 alias 访问右表字段
-- **参数**: `target_table` 目标表；`on` 连接条件；`as_` 关联别名；`join_type` 连接类型
-- **返回**: `LinkedTable`（可当作 LTSeq 使用）
-- **SPL 对应**: `switch`（指针关联）
-- **异常**: `TypeError`（on 非法），`ValueError`（join_type 非法或 schema 未初始化）
+- **行为**: 指针式关联；按需物化；通过别名访问目标表的列
+- **参数**: `target_table` 目标表；`on` 连接条件；`as_` 别名；`join_type` 取值 {inner,left,right,full}
+- **返回**: `LinkedTable`
+- **异常**: `TypeError`（on 无效），`ValueError`（join_type 无效或 schema 未初始化）
 - **示例**:
 ```python
 linked = orders.link(products, on=lambda o, p: o.product_id == p.id, as_="prod")
 result = linked.select(lambda r: [r.id, r.prod.name, r.prod.price])
 ```
 
-### `LTSeq.lookup`（表级地址化）
-- **签名**: `LTSeq.lookup(dim_table: LTSeq, on: Callable, as_: str) -> LTSeq`
-- **行为**: 维表装入内存，构建直接索引以加速事实表访问
-- **参数**: `dim_table` 维表；`on` 连接条件；`as_` 维表别名
-- **返回**: `LTSeq`（内部持有指针/索引）
-- **SPL 对应**: `switch`（地址化）
-- **异常**: `MemoryError`/`RuntimeError`（维表过大或构建失败），`TypeError`（参数非法）
+### `LinkedTable`
+- **行为**: 关联表对上的可链式视图。支持 `select`、`filter`、`derive`、`sort`、`slice`、`distinct`、`show`，以及继续 `link`（多跳链式关联）。仅在需要时通过底层连接物化
 - **示例**:
 ```python
-fact = orders.lookup(products, on=lambda o, p: o.product_id == p.id, as_="prod")
+linked = orders.link(products, on=lambda o, p: o.product_id == p.id, as_="prod")
+cheap = linked.filter(lambda r: r.prod.price < 10)
+chained = linked.link(categories, on=lambda o, c: o.category_id == c.id, as_="cat")
 ```
 
-### 连接策略对比
+完整说明见 `docs/LINKING_GUIDE.cn.md`。
 
-| 方法 | 适用场景 | 算法 | SQL 对应 |
+### `r.col.lookup`（表达式级 lookup）
+- **签名**: `r.col.lookup(target_table: LTSeq, column: str, join_key: str | None = None) -> Expr`
+- **行为**: 表达式内的轻量查表，从关联表取回单列值。可作用于任意表达式（列或变换后的值）。在 `derive()` 中通过连接解析
+- **参数**: `target_table` 目标表；`column` 输出列；`join_key` 目标表中的连接键（可选）
+- **返回**: lookup 表达式
+- **异常**: `TypeError`（参数无效），`RuntimeError`（执行失败）
+- **示例**:
+```python
+enriched = orders.derive(product_name=lambda r: r.product_id.lookup(products, "name"))
+
+# 对变换后的键做 lookup
+enriched = orders.derive(
+    product_name=lambda r: r.product_id.lower().lookup(products, "name")
+)
+```
+
+### 连接策略速查
+
+| 方法 | 适用场景 | 算法 | SQL 等价 |
 | --- | --- | --- | --- |
-| `join` | 无序通用数据 | Hash Join | `JOIN` |
-| `join(..., strategy="merge")` | 已排序大表 | Merge Join | `JOIN`（优化） |
+| `join` | 未排序的一般数据 | Hash Join | `JOIN` |
+| `join(..., strategy="merge")` | 预排序的大表 | Merge Join | `JOIN`（优化）|
 | `semi_join` | 按键存在性过滤 | Hash Semi-Join | `WHERE EXISTS` |
 | `anti_join` | 按键不存在性过滤 | Hash Anti-Join | `WHERE NOT EXISTS` |
-| `link` | 事实表到维表的指针访问 | Pointer | `LEFT JOIN`（懒加载） |
-| `lookup` | 事实表 + 小维表 | Direct Address | `LEFT JOIN`（索引） |
-| `asof_join` | 金融时间序列 | Ordered Search | `LATERAL JOIN` |
+| `link` | 事实表→维表指针访问 | Pointer | `LEFT JOIN`（惰性）|
+| `r.col.lookup(...)` | 从维表取单列 | derive 中的连接 | `LEFT JOIN`（单列）|
+| `asof_join` | 金融时序 | 有序查找 | `LATERAL JOIN` |
 
-## 7. 聚合、分区与透视
+## 7. 聚合、分区、透视
 
-### `LTSeq.agg`
-- **签名**: `LTSeq.agg(by: Optional[Callable] = None, **aggs: Callable[[GroupProxy], Expr]) -> LTSeq`
-- **行为**: 分组聚合（或全表聚合），返回每组一行
-- **参数**: `by` 分组键（可返回单列或列表）；`aggs` 组聚合表达式
-- **返回**: 聚合结果 `LTSeq`
-- **SPL 对应**: `groups`
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（表达式非法）
+### `LTSeq.group_by`（链式）
+- **签名**: `LTSeq.group_by(key: str | Callable) -> GroupBy`；`GroupBy.agg(**aggregations: Callable) -> LTSeq`
+- **行为**: Polars/pandas 风格的两段式分组聚合。`key` 可以是列名字符串或 lambda；`agg` 每组产出一行
+- **参数**: `key` 分组键；`aggregations` 命名聚合 lambda
+- **返回**: `GroupBy` 中间对象，随后是聚合后的 `LTSeq`
+- **异常**: `TypeError`（键无效），`AttributeError`（列不存在），`ValueError`（无聚合表达式）
 - **示例**:
 ```python
-summary = t.agg(by=lambda r: r.region, total=lambda r: r.sales.sum())
+summary = t.group_by("region").agg(
+    total=lambda g: g.sales.sum(),
+    avg_price=lambda g: g.price.avg(),
+)
+
+# 表达式分组键
+summary = t.group_by(lambda r: r.date.dt.year()).agg(n=lambda g: g.id.count())
 ```
 
-### `top_k`（聚合函数）
-- **签名**: `top_k(col: Union[Expr, Callable], k: int) -> List[Value]`
-- **行为**: 返回指定列 Top-K（聚合语义）
-- **参数**: `col` 目标列（表达式或可调用）；`k` Top 个数
-- **异常**: `ValueError`（k <= 0），`TypeError`（col 非法）
+### `LTSeq.agg`
+- **签名**: `LTSeq.agg(by: Callable | None = None, **aggs: Callable) -> LTSeq`
+- **行为**: 分组聚合（`by=None` 时为全表聚合）；每组一行。`by` 必须是 lambda（字符串列名请用 `group_by`）
+- **参数**: `by` 分组键 lambda；`aggs` 聚合表达式
+- **返回**: 聚合后的 `LTSeq`
+- **异常**: `ValueError`（schema 未初始化或无聚合表达式），`TypeError`（by/聚合非 callable）
 - **示例**:
 ```python
-result = t.agg(top_prices=lambda r: top_k(r.price, 5))
+summary = t.agg(by=lambda r: r.region, total=lambda g: g.sales.sum())
+
+# 全表聚合
+total = t.agg(total=lambda g: g.sales.sum())
+```
+
+### 聚合列方法（`agg` / `group_by().agg()` 的 lambda 内）
+- **签名**: `g.col.sum() / .avg() / .count() / .min() / .max() / .median() / .var() / .variance() / .std() / .stddev() / .percentile(p)`
+- **行为**: 聚合上下文可用的列聚合。`var`/`variance` 为样本方差；`std`/`stddev` 为样本标准差；`percentile(p)` 的 `p` 取 0–1（近似分位数）
+- **示例**:
+```python
+stats = t.group_by("region").agg(
+    total=lambda g: g.sales.sum(),
+    med=lambda g: g.sales.median(),
+    sd=lambda g: g.sales.std(),
+    p95=lambda g: g.latency.percentile(0.95),
+    n=lambda g: g.id.count(),
+)
+```
+
+### 条件聚合函数
+- **签名**: `count_if(predicate: Expr)`、`sum_if(predicate: Expr, column: Expr)`、`avg_if(...)`、`min_if(...)`、`max_if(...)`
+- **行为**: 只对谓词成立的行聚合。用于 `agg`/`group_by().agg()` 的 lambda 内
+- **导入**: `from ltseq import count_if, sum_if, avg_if, min_if, max_if`
+- **示例**:
+```python
+from ltseq import count_if, sum_if
+
+result = t.group_by("region").agg(
+    high_count=lambda g: count_if(g.price > 100),
+    high_sales=lambda g: sum_if(g.price > 100, g.quantity),
+)
+```
+
+### 统计聚合函数
+- **签名**: `skew(col: Expr)`、`corr(a: Expr, b: Expr)`、`covar(a: Expr, b: Expr)`、`concat_agg(col: Expr, delimiter: str = ",")`
+- **行为**: 偏度、皮尔逊相关系数、样本协方差、字符串拼接聚合。用于 `agg`/`group_by().agg()` 的 lambda 内
+- **导入**: `from ltseq import skew, corr, covar, concat_agg`
+- **示例**:
+```python
+from ltseq import corr, concat_agg
+
+result = t.group_by("region").agg(
+    price_qty_corr=lambda g: corr(g.price, g.quantity),
+    names=lambda g: concat_agg(g.name, delimiter="|"),
+)
 ```
 
 ### `LTSeq.partition`
 - **签名**: `LTSeq.partition(*cols: str) -> PartitionedTable` 或 `LTSeq.partition(by: Callable) -> PartitionedTable`
-- **行为**: 按键拆分为子表序列（不聚合）
-- **参数**: 列名或 lambda
-- **返回**: `PartitionedTable`（键 -> LTSeq）
-- **SPL 对应**: `group`
-- **异常**: `TypeError`（参数非法），`AttributeError`（列不存在），`ValueError`（schema 未初始化）
+- **行为**: 按键拆分为子表（不聚合）。字符串列走快速 SQL 路径；callable 走灵活的 Python 路径
+- **参数**: 列名、单个 callable，或 `by=` callable
+- **返回**: `PartitionedTable`（字典式：键 → LTSeq）
+- **异常**: `TypeError`（参数无效），`AttributeError`（列不存在），`ValueError`（schema 未初始化）
 - **示例**:
 ```python
 parts = t.partition("region")
 west = parts["West"]
+
+parts = t.partition("year", "region")       # 多列
+parts = t.partition(by=lambda r: r.region)  # lambda 键
+```
+
+### `PartitionedTable`
+- **行为**: 字典式分区容器。支持 `parts[key]`、迭代、`keys()`、`values()`、`items()`、`map(fn)`（对每个分区应用函数）与 `to_list()`
+- **示例**:
+```python
+for key, sub in parts.items():
+    print(key, len(sub))
+
+filtered = parts.map(lambda sub: sub.filter(lambda r: r.amount > 0))
 ```
 
 ### `LTSeq.pivot`
-- **签名**: `LTSeq.pivot(index: Union[str, List[str]], columns: str, values: str, agg_fn: str = "sum") -> LTSeq`
-- **行为**: 长表转宽表的透视操作
+- **签名**: `LTSeq.pivot(index: str | list[str], columns: str, values: str, agg_fn: str = "sum") -> LTSeq`
+- **行为**: 长表转宽表
 - **参数**:
   - `index` 行索引列
-  - `columns` 列展开字段（其值成为新列名）
-  - `values` 值字段
+  - `columns` 透视列（取值变为列名）
+  - `values` 待聚合的值列
   - `agg_fn` 聚合函数：`"sum"` | `"mean"` | `"min"` | `"max"` | `"count"` | `"first"` | `"last"`（默认 `"sum"`）
 - **返回**: 透视后的 `LTSeq`
-- **SPL 对应**: `pivot`
-- **异常**: `ValueError`（agg_fn 非法或 schema 未初始化），`AttributeError`（列不存在）
+- **异常**: `ValueError`（agg_fn 无效或 schema 未初始化），`AttributeError`（列不存在）
 - **示例**:
 ```python
 pivoted = t.pivot(index="date", columns="region", values="amount", agg_fn="sum")
 ```
 
-## 8. 表达式 API（lambda 内）
+## 8. 表达式 API（lambda 内部）
 
 ### 表达式运算符
-- **签名**: `+ - * / // %`，`== != > >= < <=`，`& | ~`
+- **签名**: `+ - * / // %`、`== != > >= < <=`、`& | ~`
 - **行为**: 构建表达式树，不在 Python 侧执行
-- **参数**: 左右操作数（Expr 或常量）
+- **参数**: 左右操作数（Expr 或字面量）
 - **返回**: 表达式对象
 - **异常**: `TypeError`（类型不匹配）
 - **示例**:
@@ -849,126 +1168,120 @@ expr = (r.price * r.qty) > 100
 ### `if_else`
 - **签名**: `if_else(condition: Expr, true_value: Any, false_value: Any) -> Expr`
 - **行为**: 条件表达式（SQL CASE WHEN）
-- **参数**: `condition` 条件；`true_value` 真值；`false_value` 假值
+- **参数**: `condition`、`true_value`、`false_value`
 - **返回**: 表达式
-- **SQL 对应**: `CASE WHEN condition THEN true_value ELSE false_value END`
-- **异常**: `TypeError`（condition 非布尔表达式）
+- **导入**: `from ltseq import if_else`
+- **异常**: `TypeError`（condition 非布尔）
 - **示例**:
 ```python
-from ltseq.expr import if_else
+from ltseq import if_else
 status = if_else(r.amount > 100, "VIP", "Normal")
 ```
 
-### `r.col.fill_null`
+### `ifa` / `nvl` / `coalesce`
+- **签名**: `ifa(cond: Expr, value: Expr) -> Expr`；`nvl(x: Expr, default: Expr) -> Expr`；`coalesce(*args: Expr) -> Expr`
+- **行为**: `ifa(cond, v)` = `if_else(cond, v, NULL)`；`nvl(x, d)` = `coalesce(x, d)`；`coalesce` 返回第一个非 NULL 参数
+- **导入**: `from ltseq import ifa, nvl, coalesce`
+- **示例**:
+```python
+from ltseq import nvl, coalesce
+t.derive(price2=lambda r: nvl(r.price, 0))
+t.derive(contact=lambda r: coalesce(r.mobile, r.phone, r.email))
+```
+
+### NULL / 成员 / 类型辅助（`Expr` 方法）
+
+#### `r.col.fill_null`
 - **签名**: `r.col.fill_null(default: Any) -> Expr`
 - **行为**: NULL 填充（SQL COALESCE）
-- **参数**: `default` 默认值
-- **返回**: 表达式
-- **SQL 对应**: `COALESCE(col, default)`
-- **异常**: `TypeError`（默认值类型不兼容）
 - **示例**:
 ```python
 safe_price = r.price.fill_null(0)
 ```
 
-### `r.col.is_null`
-- **签名**: `r.col.is_null() -> Expr`
-- **行为**: 判断是否为 NULL
-- **返回**: 布尔表达式
-- **SQL 对应**: `col IS NULL`
+#### `r.col.is_null` / `r.col.is_not_null`
+- **签名**: `r.col.is_null() -> Expr`；`r.col.is_not_null() -> Expr`
+- **行为**: NULL / NOT NULL 判断
 - **示例**:
 ```python
 missing = t.filter(lambda r: r.email.is_null())
+valid = t.filter(lambda r: r.email.is_not_null())
 ```
 
-### `r.col.is_not_null`
-- **签名**: `r.col.is_not_null() -> Expr`
-- **行为**: 判断是否非 NULL
-- **返回**: 布尔表达式
-- **SQL 对应**: `col IS NOT NULL`
+#### `r.col.is_in`
+- **签名**: `r.col.is_in(values: list[Any]) -> Expr`
+- **行为**: 成员判断（SQL `IN`）
 - **示例**:
 ```python
-valid = t.filter(lambda r: r.email.is_not_null())
+t.filter(lambda r: r.status.is_in(["active", "pending", "review"]))
+```
+
+#### `r.col.between`
+- **签名**: `r.col.between(low: Any, high: Any) -> Expr`
+- **行为**: 闭区间判断，等价于 `(x >= low) & (x <= high)`
+- **示例**:
+```python
+t.filter(lambda r: r.price.between(10, 100))
+```
+
+#### `r.col.cast`
+- **签名**: `r.col.cast(dtype: str) -> Expr`
+- **行为**: 类型转换。支持：`"int32"`、`"int64"`、`"float32"`、`"float64"`、`"utf8"`/`"string"`、`"bool"`、`"date32"`、`"timestamp"`
+- **示例**:
+```python
+t.derive(amount=lambda r: r.amount_str.cast("float64"))
+```
+
+#### `r.col.abs` / `r.col.round` / `r.col.floor` / `r.col.ceil`
+- **签名**: `r.col.abs() -> Expr`；`r.col.round(decimals: int = 0) -> Expr`；`r.col.floor() -> Expr`；`r.col.ceil() -> Expr`
+- **行为**: 数值取整辅助函数
+- **示例**:
+```python
+t.derive(
+    abs_change=lambda r: (r.price - r.prev).abs(),
+    rounded=lambda r: r.score.round(2),
+)
 ```
 
 ### 字符串操作（`r.col.s.*`）
 
 #### `contains`
 - **签名**: `r.col.s.contains(pattern: str) -> Expr`
-- **行为**: 判断是否包含子串
-- **SQL 对应**: `POSITION(pattern IN col) > 0`
+- **行为**: 子串包含判断
 - **示例**:
 ```python
 gmail = t.filter(lambda r: r.email.s.contains("gmail"))
 ```
 
-#### `starts_with`
-- **签名**: `r.col.s.starts_with(prefix: str) -> Expr`
-- **行为**: 判断是否以指定前缀开头
+#### `starts_with` / `ends_with`
+- **签名**: `r.col.s.starts_with(prefix: str) -> Expr`；`r.col.s.ends_with(suffix: str) -> Expr`
+- **行为**: 前缀 / 后缀匹配
 - **示例**:
 ```python
 orders = t.filter(lambda r: r.code.s.starts_with("ORD"))
-```
-
-#### `ends_with`
-- **签名**: `r.col.s.ends_with(suffix: str) -> Expr`
-- **行为**: 判断是否以指定后缀结尾
-- **示例**:
-```python
 pdfs = t.filter(lambda r: r.filename.s.ends_with(".pdf"))
 ```
 
-#### `lower`
-- **签名**: `r.col.s.lower() -> Expr`
-- **行为**: 转小写
-- **SQL 对应**: `LOWER(col)`
+#### `lower` / `upper`
+- **签名**: `r.col.s.lower() -> Expr`；`r.col.s.upper() -> Expr`
+- **行为**: 大小写转换
 - **示例**:
 ```python
 normalized = t.derive(email_lower=lambda r: r.email.s.lower())
 ```
 
-#### `upper`
-- **签名**: `r.col.s.upper() -> Expr`
-- **行为**: 转大写
-- **SQL 对应**: `UPPER(col)`
-- **示例**:
-```python
-normalized = t.derive(email_upper=lambda r: r.email.s.upper())
-```
-
-#### `strip`
-- **签名**: `r.col.s.strip() -> Expr`
-- **行为**: 去除首尾空白
-- **SQL 对应**: `TRIM(col)`
+#### `strip` / `lstrip` / `rstrip`
+- **签名**: `r.col.s.strip() -> Expr`；`r.col.s.lstrip() -> Expr`；`r.col.s.rstrip() -> Expr`
+- **行为**: 去除空白（两侧 / 仅左侧 / 仅右侧）
+- **SQL 等价**: `TRIM` / `LTRIM` / `RTRIM`
 - **示例**:
 ```python
 clean = t.derive(name_clean=lambda r: r.name.s.strip())
 ```
 
-#### `lstrip`
-- **签名**: `r.col.s.lstrip() -> Expr`
-- **行为**: 仅去除左侧（前置）空白
-- **SQL 对应**: `LTRIM(col)`
-- **SPL 对应**: `ltrim(s)`
-- **示例**:
-```python
-clean = t.derive(name=lambda r: r.name.s.lstrip())  # "  hello" → "hello"
-```
-
-#### `rstrip`
-- **签名**: `r.col.s.rstrip() -> Expr`
-- **行为**: 仅去除右侧（后置）空白
-- **SQL 对应**: `RTRIM(col)`
-- **SPL 对应**: `rtrim(s)`
-- **示例**:
-```python
-clean = t.derive(name=lambda r: r.name.s.rstrip())  # "hello  " → "hello"
-```
-
 #### `len`
 - **签名**: `r.col.s.len() -> Expr`
-- **行为**: 字符串字符数（Unicode 字符数）
-- **SQL 对应**: `CHARACTER_LENGTH(col)`
+- **行为**: 字符串长度
 - **示例**:
 ```python
 long_names = t.filter(lambda r: r.name.s.len() > 50)
@@ -976,9 +1289,8 @@ long_names = t.filter(lambda r: r.name.s.len() > 50)
 
 #### `slice`
 - **签名**: `r.col.s.slice(start: int, length: int) -> Expr`
-- **行为**: 子串截取（0 基起始）
-- **参数**: `start` 起始位置（0 基）；`length` 长度
-- **SQL 对应**: `SUBSTRING(col, start+1, length)`
+- **行为**: 子串截取
+- **参数**: `start` 起始下标（0-based）；`length` 长度
 - **示例**:
 ```python
 year = t.derive(year=lambda r: r.date.s.slice(0, 4))
@@ -986,19 +1298,24 @@ year = t.derive(year=lambda r: r.date.s.slice(0, 4))
 
 #### `regex_match`
 - **签名**: `r.col.s.regex_match(pattern: str) -> Expr`
-- **行为**: 正则匹配（返回布尔值）
-- **参数**: `pattern` 正则表达式
-- **SQL 对应**: `REGEXP_LIKE(col, pattern)`
+- **行为**: 正则匹配（布尔）
+- **异常**: `ValueError`（正则无效）
 - **示例**:
 ```python
 valid = t.filter(lambda r: r.email.s.regex_match(r"^[a-z]+@"))
 ```
 
+#### `like`
+- **签名**: `r.col.s.like(pattern: str) -> Expr`
+- **行为**: SQL LIKE 模式匹配（`%` 任意字符，`_` 单个字符）
+- **示例**:
+```python
+t.filter(lambda r: r.code.s.like("ORD-%"))
+```
+
 #### `replace`
 - **签名**: `r.col.s.replace(old: str, new: str) -> Expr`
 - **行为**: 替换所有出现的子串
-- **参数**: `old` 要替换的子串；`new` 替换内容
-- **SQL 对应**: `REPLACE(col, old, new)`
 - **示例**:
 ```python
 clean = t.derive(clean_name=lambda r: r.name.s.replace("-", "_"))
@@ -1006,411 +1323,348 @@ clean = t.derive(clean_name=lambda r: r.name.s.replace("-", "_"))
 
 #### `concat`
 - **签名**: `r.col.s.concat(*others) -> Expr`
-- **行为**: 将当前字符串与其他字符串或列表达式连接
-- **参数**: `others` 字符串或列表达式
+- **行为**: 与其他字符串或列表达式拼接
 - **示例**:
 ```python
 greeting = t.derive(msg=lambda r: r.name.s.concat(" says hello"))
 full = t.derive(full_name=lambda r: r.first.s.concat(" ", r.last))
 ```
 
-#### `pad_left`
-- **签名**: `r.col.s.pad_left(width: int, char: str = " ") -> Expr`
-- **行为**: 左填充至指定宽度；若字符串本身超过宽度则截断（SQL LPAD 行为）
-- **参数**: `width` 目标宽度；`char` 填充字符（默认空格）
-- **SQL 对应**: `LPAD(col, width, char)`
+#### `pad_left` / `pad_right`
+- **签名**: `r.col.s.pad_left(width: int, char: str = " ") -> Expr`；`r.col.s.pad_right(width: int, char: str = " ") -> Expr`
+- **行为**: 填充到指定宽度。注意：字符串超出宽度时会被截断（SQL LPAD/RPAD 行为）
 - **示例**:
 ```python
 padded = t.derive(padded_id=lambda r: r.id.s.pad_left(5, "0"))
 ```
 
-#### `pad_right`
-- **签名**: `r.col.s.pad_right(width: int, char: str = " ") -> Expr`
-- **行为**: 右填充至指定宽度；若字符串本身超过宽度则截断（SQL RPAD 行为）
-- **参数**: `width` 目标宽度；`char` 填充字符（默认空格）
-- **SQL 对应**: `RPAD(col, width, char)`
-- **示例**:
-```python
-padded = t.derive(padded_name=lambda r: r.name.s.pad_right(20, "."))
-```
-
 #### `split`
 - **签名**: `r.col.s.split(delimiter: str, index: int) -> Expr`
-- **行为**: 按分隔符切分字符串，返回第 index 部分（1 基，与 SQL SPLIT_PART 一致）
-- **参数**: `delimiter` 分隔符；`index` 部分编号（1 = 第一部分）
-- **SQL 对应**: `SPLIT_PART(col, delimiter, index)`
+- **行为**: 按分隔符拆分并返回指定位置的部分。下标为 **1-based**（1 = 第一段），与 SQL SPLIT_PART 一致。越界返回空字符串
+- **异常**: `ValueError`（index <= 0）
 - **示例**:
 ```python
-domain = t.derive(domain=lambda r: r.email.s.split("@", 2))     # "user@example.com" → "example.com"
-first  = t.derive(first_name=lambda r: r.username.s.split(".", 1))
+# 从 "user@example.com" 取域名
+domain = t.derive(domain=lambda r: r.email.s.split("@", 2))
 ```
 
 #### `pos`
 - **签名**: `r.col.s.pos(sub: str) -> Expr`
-- **行为**: 返回子串第一次出现的 1-based 位置；未找到返回 0
-- **参数**: `sub` 要查找的子串
-- **SQL 对应**: `STRPOS(col, sub)`
-- **SPL 对应**: `pos(s, sub)`
+- **行为**: 返回子串首次出现的 **1-based** 位置；未找到返回 0
+- **SQL 等价**: `STRPOS(col, sub)`
 - **示例**:
 ```python
 at_pos = t.derive(pos=lambda r: r.email.s.pos("@"))  # "user@example" → 5
 ```
 
-#### `left`
-- **签名**: `r.col.s.left(n: int) -> Expr`
-- **行为**: 取左 n 个字符；若 n 超过字符串长度则返回完整字符串
-- **SQL 对应**: `LEFT(col, n)`
-- **SPL 对应**: `left(s, n)`
+#### `left` / `right`
+- **签名**: `r.col.s.left(n: int) -> Expr`；`r.col.s.right(n: int) -> Expr`
+- **行为**: 最左 / 最右 `n` 个字符；`n` 超长时返回整串
+- **SQL 等价**: `LEFT(col, n)` / `RIGHT(col, n)`
 - **示例**:
 ```python
-prefix = t.derive(pfx=lambda r: r.code.s.left(3))  # "ABC123" → "ABC"
-```
-
-#### `right`
-- **签名**: `r.col.s.right(n: int) -> Expr`
-- **行为**: 取右 n 个字符；若 n 超过字符串长度则返回完整字符串
-- **SQL 对应**: `RIGHT(col, n)`
-- **SPL 对应**: `right(s, n)`
-- **示例**:
-```python
-suffix = t.derive(sfx=lambda r: r.code.s.right(3))  # "ABC123" → "123"
+prefix = t.derive(pfx=lambda r: r.code.s.left(3))    # "ABC123" → "ABC"
+suffix = t.derive(sfx=lambda r: r.code.s.right(3))   # "ABC123" → "123"
 ```
 
 #### `asc`
 - **签名**: `r.col.s.asc() -> Expr`
-- **行为**: 返回字符串首字符的 ASCII/Unicode 码点
-- **SQL 对应**: `ASCII(col)`
-- **SPL 对应**: `asc(s)`
+- **行为**: 返回字符串首字符的 ASCII/Unicode 码点（类似 Python 的 `ord()`）
+- **SQL 等价**: `ASCII(col)`
 - **示例**:
 ```python
-code = t.derive(code=lambda r: r.ch.s.asc())  # "A" → 65，"a" → 97
+code = t.derive(code=lambda r: r.ch.s.asc())  # "A" → 65, "a" → 97
+```
+
+#### `isalpha` / `isdigit` / `islower` / `isupper`
+- **签名**: `r.col.s.isalpha() -> Expr`（其余同）
+- **行为**: 字符类别判断，与 Python `str` 同名方法对应
+- **示例**:
+```python
+numeric_codes = t.filter(lambda r: r.code.s.isdigit())
 ```
 
 ### 字符串全局函数
 
 #### `str_char`
 - **签名**: `str_char(n: Expr) -> Expr`
-- **行为**: 将 Unicode 码点整数转为对应的单字符字符串
-- **参数**: `n` 整数表达式（Unicode 码点）
-- **SQL 对应**: `CHR(n)`
-- **SPL 对应**: `char(n)`
+- **行为**: 将 Unicode 码点整数转换为单字符字符串（类似 Python 的 `chr()`）
+- **SQL 等价**: `CHR(n)`
 - **导入**: `from ltseq.expr import str_char`
 - **示例**:
 ```python
 from ltseq.expr import str_char
-ch = t.derive(ch=lambda r: str_char(r.code))  # 65 → "A"，97 → "a"
+ch = t.derive(ch=lambda r: str_char(r.code))  # 65 → "A", 97 → "a"
 ```
 
 #### `concat_ws`
 - **签名**: `concat_ws(delimiter: str, *cols: Expr) -> Expr`
-- **行为**: 用分隔符连接两个或多个列表达式
-- **参数**: `delimiter` 分隔符字符串；`cols` 两个或多个字符串列表达式
-- **SQL 对应**: `CONCAT_WS(delimiter, col1, col2, ...)`
+- **行为**: 以分隔符拼接两个及以上的列表达式
+- **SQL 等价**: `CONCAT_WS(delimiter, col1, col2, ...)`
 - **导入**: `from ltseq.expr import concat_ws`
 - **示例**:
 ```python
 from ltseq.expr import concat_ws
 full = t.derive(full_name=lambda r: concat_ws(" ", r.first, r.last))
-row  = t.derive(row=lambda r: concat_ws(",", r.a, r.b, r.c))
 ```
 
 ### 时间操作（`r.col.dt.*`）
 
 #### `year` / `month` / `day`
-- **签名**: `r.col.dt.year() -> Expr`（month/day 同理）
-- **行为**: 提取日期部件
-- **SQL 对应**: `EXTRACT(YEAR/MONTH/DAY FROM col)`
-- **异常**: `TypeError`（非日期列）
+- **签名**: `r.col.dt.year() -> Expr`（month/day 同）
+- **行为**: 提取日期分量
 - **示例**:
 ```python
 by_date = t.derive(year=lambda r: r.date.dt.year())
 ```
 
-#### `hour` / `minute` / `second`
-- **签名**: `r.col.dt.hour() -> Expr`（minute/second 同理）
-- **行为**: 提取时间部件
-- **SQL 对应**: `EXTRACT(HOUR/MINUTE/SECOND FROM col)`
-- **异常**: `TypeError`（非时间列）
+#### `hour` / `minute` / `second` / `millisecond`
+- **签名**: `r.col.dt.hour() -> Expr`（minute/second/millisecond 同）
+- **行为**: 提取时间分量（`millisecond` 返回 0–999）
 - **示例**:
 ```python
 with_time = t.derive(hour=lambda r: r.ts.dt.hour())
 ```
 
+#### `weekday`
+- **签名**: `r.col.dt.weekday() -> Expr`
+- **行为**: 提取星期（0-based：周一=0 ... 周日=6）
+- **示例**:
+```python
+t.derive(wd=lambda r: r.date.dt.weekday())
+```
+
 #### `add`
 - **签名**: `r.col.dt.add(days: int = 0, months: int = 0, years: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0, weeks: int = 0) -> Expr`
-- **行为**: 日期/时间加减。`weeks` 自动转为 `days × 7`；`hours/minutes/seconds` 通过纳秒精度传入。
-- **参数**: 所有参数默认为 0
-- **SPL 对应**: `elapse(t, k, unit)`
-- **异常**: `TypeError`（非日期列）
+- **行为**: 日期/时间运算。`weeks` 转换为 `days × 7`；`hours/minutes/seconds` 内部使用纳秒精度
+- **参数**: 整数偏移量（默认全为 0；负数表示减）
+- **返回**: 日期/时间戳表达式
+- **SPL 等价**: `elapse(t, k, unit)`
 - **示例**:
 ```python
 delivery   = t.derive(delivery=lambda r: r.order_date.dt.add(days=5))
 after_2h   = t.derive(ts2=lambda r: r.ts.dt.add(hours=2, minutes=30))
 next_week  = t.derive(d2=lambda r: r.date.dt.add(weeks=1))
-next_month = t.derive(d3=lambda r: r.date.dt.add(days=10, months=1))
 ```
 
 #### `diff`
 - **签名**: `r.col.dt.diff(other: Expr, unit: str = "day") -> Expr`
-- **行为**: 返回 `self` 与 `other` 之间的整数差值（以 unit 为单位）。`unit` 可为 `"day"`（默认）、`"month"`、`"year"`、`"hour"`、`"minute"`、`"second"`。
-- **参数**: `other` 另一日期/时间列；`unit` 时间单位
-- **SPL 对应**: `interval(t1, t2, unit)`
-- **异常**: `TypeError`（非日期列），`ValueError`（unit 非法）
+- **行为**: 返回 `self` 与 `other` 在指定单位下的整数差。`unit` 可取 `"day"`（默认）、`"month"`、`"year"`、`"hour"`、`"minute"`、`"second"`
+- **SPL 等价**: `interval(t1, t2, unit)`
 - **示例**:
 ```python
 days   = t.derive(d=lambda r: r.end.dt.diff(r.start))
 months = t.derive(m=lambda r: r.end.dt.diff(r.start, unit="month"))
-years  = t.derive(y=lambda r: r.end.dt.diff(r.start, unit="year"))
-hours  = t.derive(h=lambda r: r.end.dt.diff(r.start, unit="hour"))
 ```
 
 #### `age`
 - **签名**: `r.col.dt.age() -> Expr`
-- **行为**: 返回日期列与今天之间的完整年数（今天 - 列日期）；未来日期返回负数
-- **SPL 对应**: `age(dt)`
-- **异常**: `TypeError`（非日期列）
+- **行为**: 返回该日期到今天的完整年数。未来日期返回负数
+- **SPL 等价**: `age(dt)`
 - **示例**:
 ```python
 age = t.derive(age=lambda r: r.birth_date.dt.age())
 ```
 
+#### `now` / `today`（全局函数）
+- **签名**: `now() -> Expr`；`today() -> Expr`
+- **行为**: 当前时间戳 / 当前日期
+- **导入**: `from ltseq import now, today`
+- **示例**:
+```python
+from ltseq import now
+t.derive(fetched_at=lambda r: now())
+```
+
 ### 数学全局函数
 
-#### `gcd`
-- **签名**: `gcd(a: Expr, b: Expr) -> Expr`
-- **行为**: 两个整数表达式的最大公约数
-- **SQL 对应**: `GCD(a, b)`（DataFusion）
-- **SPL 对应**: `gcd(a, b)`
-- **导入**: `from ltseq.expr import gcd`
+#### `gcd` / `lcm` / `factorial`
+- **签名**: `gcd(a: Expr, b: Expr) -> Expr`；`lcm(a: Expr, b: Expr) -> Expr`；`factorial(n: Expr) -> Expr`
+- **行为**: 最大公约数、最小公倍数、阶乘（DataFusion `GCD`/`LCM`/`FACTORIAL`）
+- **导入**: `from ltseq.expr import gcd, lcm, factorial`
 - **示例**:
 ```python
-from ltseq.expr import gcd
-t.derive(g=lambda r: gcd(r.a, r.b))  # gcd(12, 8) → 4
+from ltseq.expr import gcd, lcm, factorial
+t.derive(g=lambda r: gcd(r.a, r.b))       # gcd(12, 8) → 4
+t.derive(l=lambda r: lcm(r.a, r.b))       # lcm(4, 6) → 12
+t.derive(f=lambda r: factorial(r.n))      # factorial(5) → 120
 ```
 
-#### `lcm`
-- **签名**: `lcm(a: Expr, b: Expr) -> Expr`
-- **行为**: 两个整数表达式的最小公倍数
-- **SQL 对应**: `LCM(a, b)`（DataFusion）
-- **SPL 对应**: `lcm(a, b)`
-- **导入**: `from ltseq.expr import lcm`
+#### 通用数学: `sqrt`、`power`、`sign`、`log`、`ln`、`exp`、三角函数、`rand`
+- **签名**: `sqrt(x)`、`power(x, n)`、`sign(x)`、`log(x, base=None)`、`ln(x)`、`exp(x)`、`sin/cos/tan/asin/acos/atan(x)`、`atan2(y, x)`、`rand()`
+- **行为**: 标准数学函数，映射到 DataFusion 等价物
+- **导入**: `from ltseq import sqrt, power, log, ...`
 - **示例**:
 ```python
-from ltseq.expr import lcm
-t.derive(l=lambda r: lcm(r.a, r.b))  # lcm(4, 6) → 12
+from ltseq import sqrt, power, log
+
+t.derive(
+    dist=lambda r: sqrt(power(r.x, 2) + power(r.y, 2)),
+    log_amt=lambda r: log(r.amount, 10),
+)
 ```
 
-#### `factorial`
-- **签名**: `factorial(n: Expr) -> Expr`
-- **行为**: 非负整数的阶乘；`n! = 1 × 2 × ... × n`，`0! = 1`
-- **SQL 对应**: `FACTORIAL(n)`（DataFusion）
-- **SPL 对应**: `fact(n)`
-- **导入**: `from ltseq.expr import factorial`
+## 9. 行变更操作（写时复制）
+
+所有变更操作都返回**新的** LTSeq，原表不变。
+
+### `LTSeq.insert`
+- **签名**: `LTSeq.insert(pos: int, row_dict: dict[str, Any]) -> LTSeq`
+- **行为**: 在指定的 0-based 位置插入一行。`pos` 超出末尾时追加；负数被截断为 0
 - **示例**:
 ```python
-from ltseq.expr import factorial
-t.derive(f=lambda r: factorial(r.n))  # factorial(5) → 120
+t2 = t.insert(0, {"id": 99, "name": "Alice"})     # 头部插入
+t2 = t.insert(len(t), {"id": 100, "name": "Bob"}) # 尾部追加
 ```
 
-### `r.col.lookup`（表达式查找）
-- **签名**: `r.col.lookup(target_table: LTSeq, column: str, join_key: Optional[str] = None) -> Expr`
-- **行为**: 在表达式中进行轻量查找，返回目标表单列值
-- **参数**: `target_table` 目标表；`column` 返回列；`join_key` 目标表匹配键
-- **返回**: 查找表达式
-- **异常**: `TypeError`（参数非法），`RuntimeError`（执行失败）
+### `LTSeq.delete`
+- **签名**: `LTSeq.delete(predicate_or_pos: Callable | int) -> LTSeq`
+- **行为**: 删除满足谓词的行，或删除 0-based 下标处的单行
 - **示例**:
 ```python
-enriched = orders.derive(product_name=lambda r: r.product_id.lookup(products, "name"))
+t2 = t.delete(lambda r: r.status == "expired")
+t2 = t.delete(0)   # 删除第一行
 ```
 
-### 条件聚合函数（全局）
-
-用于在 `.agg()` 上下文中基于谓词表达式进行条件聚合，与 `GroupProxy g` 参数配合使用。
-
-#### `count_if`
-- **签名**: `count_if(predicate: Expr) -> Expr`
-- **行为**: 统计谓词为 True 的行数
-- **SQL 对应**: `COUNT(CASE WHEN predicate THEN 1 END)`
+### `LTSeq.update`
+- **签名**: `LTSeq.update(predicate: Callable, **updates: Any) -> LTSeq`
+- **行为**: 条件更新——谓词为 True 的行更新列值。每列变为 `if_else(predicate, 新值, 旧值)`
 - **示例**:
 ```python
-from ltseq.expr import count_if
-result = t.agg(by=lambda r: r.region, high_count=lambda r: count_if(r.price > 100))
+t2 = t.update(lambda r: r.age > 65, discount=0.2)
+t2 = t.update(lambda r: r.status == "old", status="archived")
 ```
 
-#### `sum_if`
-- **签名**: `sum_if(predicate: Expr, column: Expr) -> Expr`
-- **行为**: 对谓词为 True 的行求列的和
-- **SQL 对应**: `SUM(CASE WHEN predicate THEN column END)`
+### `LTSeq.modify`
+- **签名**: `LTSeq.modify(pos: int, **updates: Any) -> LTSeq`
+- **行为**: 修改 0-based 位置 `pos` 处单行的指定列。`pos` 越界时静默忽略
 - **示例**:
 ```python
-from ltseq.expr import sum_if
-result = t.agg(by=lambda r: r.region, high_sales=lambda r: sum_if(r.price > 100, r.quantity))
+t2 = t.modify(0, status="active", score=100)
 ```
 
-#### `avg_if`
-- **签名**: `avg_if(predicate: Expr, column: Expr) -> Expr`
-- **行为**: 对谓词为 True 的行求列的均值
-- **示例**:
-```python
-from ltseq.expr import avg_if
-result = t.agg(by=lambda r: r.region, avg_high=lambda r: avg_if(r.price > 100, r.sales))
-```
-
-#### `min_if`
-- **签名**: `min_if(predicate: Expr, column: Expr) -> Expr`
-- **行为**: 对谓词为 True 的行求列的最小值
-- **示例**:
-```python
-from ltseq.expr import min_if
-result = t.agg(by=lambda r: r.region, min_active=lambda r: min_if(r.is_active, r.score))
-```
-
-#### `max_if`
-- **签名**: `max_if(predicate: Expr, column: Expr) -> Expr`
-- **行为**: 对谓词为 True 的行求列的最大值
-- **示例**:
-```python
-from ltseq.expr import max_if
-result = t.agg(by=lambda r: r.region, max_active=lambda r: max_if(r.is_active, r.score))
-```
-
-## 9. 综合示例
+## 10. 端到端示例
 
 ### 有序计算 + 连续分组
 ```python
 from ltseq import LTSeq
 
-# 任务：找出连续上涨超过 3 天的区间
-result = (
+# 任务：找出股价连续上涨超过 3 天的区间
+runs = (
     LTSeq.read_csv("stock.csv")
-    .sort(lambda r: r.date)
-    .derive(lambda r: {"is_up": r.price > r.price.shift(1)})
+    .sort("date")
+    .derive(is_up=lambda r: r.price > r.price.shift(1))
     .group_ordered(lambda r: r.is_up)
-    .filter(lambda g: (g.first().is_up == True) & (g.count() > 3))
-    .derive(lambda g: {
+    .filter(lambda g: g.count() > 3)
+    .filter(lambda g: g.all(lambda r: r.is_up == True))
+    .derive(lambda g: {          # 广播：每行都拿到所在组的区间信息
         "start": g.first().date,
         "end": g.last().date,
-        "gain": (g.last().price - g.first().price) / g.first().price,
+        "gain": g.last().price - g.first().price,
     })
 )
+intervals = runs.distinct("start", "end")   # 每个区间一行
 ```
 
-### 字符串/时间/条件与 Lookup 混合
+### 字符串 + 时间 + 条件 + Lookup
 ```python
-from ltseq import LTSeq
-from ltseq.expr import if_else, concat_ws
+from ltseq import LTSeq, if_else
 
 orders = LTSeq.read_csv("orders.csv")
 products = LTSeq.read_csv("products.csv")
 
 result = orders.derive(
     order_id_clean=lambda r: r.order_id.s.strip(),
-    full_name=lambda r: concat_ws(" ", r.first_name, r.last_name),
     product_name=lambda r: r.product_id.lookup(products, "name"),
     order_year=lambda r: r.order_date.dt.year(),
-    customer_age=lambda r: r.birth_date.dt.age(),
     status=lambda r: if_else(r.quantity > 10, "Bulk", "Standard"),
 )
 ```
 
-### 连接与条件聚合
+### 流式处理大文件
 ```python
 from ltseq import LTSeq
-from ltseq.expr import count_if, sum_if
 
-users = LTSeq.read_csv("users.csv")
-orders = LTSeq.read_csv("orders.csv")
-
-# 找有订单的活跃用户
-active = users.semi_join(orders, on=lambda u, o: u.id == o.user_id)
-
-# 按地区统计高价值订单
-summary = orders.agg(
-    by=lambda r: r.region,
-    total_orders=lambda g: g.count(),
-    high_value_count=lambda g: count_if(g.amount > 1000),
-    high_value_total=lambda g: sum_if(g.amount > 1000, g.amount),
-)
+total = 0
+for batch in LTSeq.scan("huge.csv"):
+    total += process(batch)
 ```
 
-## 10. 执行与性能说明
+## 11. 执行与性能说明
 
-- 所有表达式会被序列化并下推到 Rust/DataFusion 层执行，不在 Python 侧逐行计算
-- 字符串/时间/NULL 等扩展操作会映射为底层 SQL/DataFusion 函数
-- `to_cursor` 提供流式处理能力，适合超大数据集
+- 所有表达式序列化后下推到 Rust/DataFusion 执行，不在 Python 中逐行求值
+- 字符串/时间/NULL 扩展映射到 SQL/DataFusion 函数
+- `LTSeq.scan()`/`scan_parquet()` 支持超大数据集的流式处理
+- `assume_sorted()` 对预排序输入跳过物理排序，同时启用窗口函数与归并连接
 
-### 表达式 SQL 转译速查表
+### 表达式 SQL 转译对照
 
-所有表达式在执行前均被序列化 → JSON → Rust/DataFusion 转译，不发生 Python 层的求值。
+所有表达式在执行前转译到 Rust/DataFusion 层，lambda 内不发生 Python 级求值。
 
 | 表达式 | SQL / DataFusion 等价 |
-|-------|----------------------|
+|-----------|----------------------------|
 | `if_else(cond, a, b)` | `CASE WHEN cond THEN a ELSE b END` |
 | `r.col.fill_null(v)` | `COALESCE(col, v)` |
 | `r.col.is_null()` | `col IS NULL` |
 | `r.col.is_not_null()` | `col IS NOT NULL` |
+| `r.col.is_in([a, b])` | `col IN (a, b)` |
+| `r.col.between(lo, hi)` | `col >= lo AND col <= hi` |
+| `r.col.cast("int64")` | `CAST(col AS BIGINT)` |
+| `r.col.abs()` | `ABS(col)` |
+| `r.col.round(n)` | `ROUND(col, n)` |
+| `r.col.floor()` / `r.col.ceil()` | `FLOOR(col)` / `CEIL(col)` |
 | `r.col.s.contains(p)` | `POSITION(p IN col) > 0` |
-| `r.col.s.lower()` | `LOWER(col)` |
-| `r.col.s.upper()` | `UPPER(col)` |
-| `r.col.s.strip()` | `TRIM(col)` |
-| `r.col.s.lstrip()` | `LTRIM(col)` |
-| `r.col.s.rstrip()` | `RTRIM(col)` |
+| `r.col.s.starts_with(p)` | `STARTS_WITH(col, p)` |
+| `r.col.s.ends_with(p)` | `ENDS_WITH(col, p)` |
+| `r.col.s.lower()` / `.upper()` | `LOWER(col)` / `UPPER(col)` |
+| `r.col.s.strip()` / `.lstrip()` / `.rstrip()` | `TRIM` / `LTRIM` / `RTRIM` |
 | `r.col.s.len()` | `CHARACTER_LENGTH(col)` |
 | `r.col.s.slice(s, n)` | `SUBSTRING(col, s+1, n)` |
 | `r.col.s.pos(sub)` | `STRPOS(col, sub)` |
-| `r.col.s.left(n)` | `LEFT(col, n)` |
-| `r.col.s.right(n)` | `RIGHT(col, n)` |
+| `r.col.s.left(n)` / `.right(n)` | `LEFT(col, n)` / `RIGHT(col, n)` |
 | `r.col.s.asc()` | `ASCII(col)` |
-| `r.col.s.replace(o, n)` | `REPLACE(col, o, n)` |
-| `r.col.s.pad_left(n, c)` | `LPAD(col, n, c)` |
-| `r.col.s.pad_right(n, c)` | `RPAD(col, n, c)` |
+| `r.col.s.like(p)` | `col LIKE p` |
+| `r.col.s.replace(old, new)` | `REPLACE(col, old, new)` |
+| `r.col.s.pad_left(n, c)` / `.pad_right(n, c)` | `LPAD(col, n, c)` / `RPAD(col, n, c)` |
 | `r.col.s.split(d, i)` | `SPLIT_PART(col, d, i)` |
 | `str_char(n)` | `CHR(n)` |
 | `concat_ws(d, ...)` | `CONCAT_WS(d, ...)` |
-| `r.col.dt.year()` | `EXTRACT(YEAR FROM col)` |
-| `r.col.dt.month()` | `EXTRACT(MONTH FROM col)` |
-| `r.col.dt.day()` | `EXTRACT(DAY FROM col)` |
-| `r.col.dt.hour()` | `EXTRACT(HOUR FROM col)` |
+| `r.col.dt.year()` 等 | `EXTRACT(YEAR FROM col)` 等 |
 | `r.col.dt.add(days=n)` | `col + INTERVAL 'n' DAY` |
-| `r.col.dt.add(hours=n)` | `col + INTERVAL 'n' HOUR` |
 | `r.col.dt.diff(other)` | `DATEDIFF('day', other, col)` |
-| `r.col.dt.diff(other, unit="month")` | `(year(col)-year(other))*12 + month(col)-month(other)` |
-| `r.col.dt.age()` | 年份差（含日期修正） |
-| `gcd(a, b)` | `GCD(a, b)` |
-| `lcm(a, b)` | `LCM(a, b)` |
-| `factorial(n)` | `FACTORIAL(n)` |
-| `count_if(cond)` | `COUNT(CASE WHEN cond THEN 1 END)` |
+| `r.col.dt.age()` | 相对 `CURRENT_DATE` 的年差（含年内日修正）|
+| `gcd(a, b)` / `lcm(a, b)` / `factorial(n)` | `GCD` / `LCM` / `FACTORIAL` |
+| `count_if(cond)` | `SUM(CASE WHEN cond THEN 1 ELSE 0 END)` |
 | `sum_if(cond, col)` | `SUM(CASE WHEN cond THEN col END)` |
+| `g.col.percentile(p)` | `APPROX_PERCENTILE_CONT(col, p)` |
 
-## 附录 A：从 Pandas 迁移
+## 附录 A: 从 Pandas 迁移
 
 | Pandas | LTSeq | 说明 |
-|--------|-------|------|
+|--------|-------|-------|
 | `df[df.age > 18]` | `t.filter(lambda r: r.age > 18)` | lambda 捕获表达式 |
 | `df[['id', 'name']]` | `t.select("id", "name")` | |
-| `df.assign(total=df.a + df.b)` | `t.derive(total=lambda r: r.a + r.b)` | |
+| `df.assign(total=df.a + df.b)` | `t.derive(total=lambda r: r.a + r.b)` | `with_columns` 为别名 |
+| `df.rename(columns={'a': 'b'})` | `t.rename(a="b")` | |
+| `df.drop(columns=['tmp'])` | `t.drop("tmp")` | |
 | `df.sort_values('date')` | `t.sort("date")` | |
-| `df.sort_values('date', ascending=False)` | `t.sort("date", desc=True)` | |
+| `df.sort_values('date', ascending=False)` | `t.sort("date", desc=True)` | 也接受 `descending=` |
 | `df.drop_duplicates('id')` | `t.distinct("id")` | |
-| `df.groupby('region').agg({'sales': 'sum'})` | `t.agg(by=lambda r: r.region, sales=lambda r: r.sales.sum())` | |
+| `df.groupby('region').agg({'sales': 'sum'})` | `t.group_by("region").agg(sales=lambda g: g.sales.sum())` | |
 | `df.merge(df2, on='id')` | `t.join(t2, on=lambda a, b: a.id == b.id)` | |
 | `df.merge(df2, on='id', how='left')` | `t.join(t2, on=lambda a, b: a.id == b.id, how="left")` | |
-| `df[df.id.isin(df2.id)]` | `t.semi_join(t2, on=lambda a, b: a.id == b.id)` | 半连接 |
-| `df[~df.id.isin(df2.id)]` | `t.anti_join(t2, on=lambda a, b: a.id == b.id)` | 反连接 |
-| `df['col'].shift(1)` | `t.sort(...).derive(prev=lambda r: r.col.shift(1))` | 需要先排序 |
-| `df['col'].rolling(5).mean()` | `t.sort(...).derive(ma=lambda r: r.col.rolling(5).mean())` | 需要先排序 |
-| `df['col'].diff()` | `t.sort(...).derive(d=lambda r: r.col.diff())` | 需要先排序 |
-| `df['col'].cumsum()` | `t.sort(...).cum_sum("col")` | 需要先排序 |
-| `df.head(10)` | `t.head(10)` | |
-| `df.tail(10)` | `t.tail(10)` | |
+| `pd.merge_asof(t, q, on='time')` | `t.asof_join(q, on=lambda t, q: t.time >= q.time)` | |
+| `df['col'].shift(1)` | `t.sort(...).derive(prev=lambda r: r.col.shift(1))` | 需要排序 |
+| `df['col'].rolling(5).mean()` | `t.sort(...).derive(ma=lambda r: r.col.rolling(5).mean())` | 需要排序 |
+| `df['col'].diff()` | `t.sort(...).derive(d=lambda r: r.col.diff())` | 需要排序 |
+| `df['col'].pct_change()` | `t.sort(...).derive(p=lambda r: r.col.pct_change())` | 需要排序 |
+| `df['col'].cumsum()` | `t.sort(...).cum_sum("col")` 或 `r.col.cum_sum()` | 需要排序 |
+| `df['col'].isin([1, 2])` | `t.filter(lambda r: r.col.is_in([1, 2]))` | |
+| `df['col'].astype('float')` | `t.derive(col=lambda r: r.col.cast("float64"))` | |
+| `df.head(10)` / `df.tail(10)` | `t.head(10)` / `t.tail(10)` | |
 | `df.to_dict('records')` | `t.collect()` | |
-| `len(df)` | `t.count()` | |
+| `len(df)` | `len(t)` 或 `t.count()` | |
 | `df.columns.tolist()` | `t.columns` | |
-| `df.isna()` | `t.filter(lambda r: r.col.is_null())` | 逐列操作 |
-| `df.fillna(0)` | `t.derive(col=lambda r: r.col.fill_null(0))` | 逐列操作 |
-| `df['col'].str.strip()` | `t.derive(c=lambda r: r.col.s.strip())` | |
-| `df['col'].str.lower()` | `t.derive(c=lambda r: r.col.s.lower())` | |
-| `df['col'].str.contains('x')` | `t.filter(lambda r: r.col.s.contains("x"))` | |
-| `np.where(cond, a, b)` | `if_else(cond, a, b)` | |
-| `df.rank(method='first')` | `row_number().over(order_by=r.col)` | 需 `.over()` |
-| `df.rank(method='dense')` | `dense_rank().over(order_by=r.col)` | 需 `.over()` |
+| `df.isna()` | `t.filter(lambda r: r.col.is_null())` | 按列 |
+| `df.fillna(0)` | `t.derive(col=lambda r: r.col.fill_null(0))` | 按列 |
+| `df.pipe(fn, arg)` | `t.pipe(fn, arg)` | |

--- a/docs/api.md
+++ b/docs/api.md
@@ -781,7 +781,7 @@ last_rows = groups.last()
 
 #### `NestedTable.flatten`
 - **Signature**: `nested.flatten() -> LTSeq`
-- **Behavior**: Return the underlying rows with a `__group_id__` column identifying each consecutive group
+- **Behavior**: Return the underlying rows with a `__group_id__` column identifying each consecutive group (plus internal `__group_count__` and `__rn__` helper columns)
 - **Returns**: flattened `LTSeq`
 - **Example**:
 ```python
@@ -817,10 +817,11 @@ enriched = groups.derive(lambda g: {
 
 #### `len(nested)` / `NestedTable.to_pandas`
 - **Signature**: `NestedTable.__len__() -> int`; `NestedTable.to_pandas()`
-- **Behavior**: `len()` returns the number of groups; `to_pandas()` materializes the flattened rows
+- **Behavior**: `len()` returns the number of **rows** in the underlying table (not the number of groups); `to_pandas()` materializes the underlying rows as-is, without the `__group_id__` column (use `flatten().to_pandas()` for that)
 - **Example**:
 ```python
-n_groups = len(groups)
+n_rows = len(groups)                  # row count, not group count
+df = groups.flatten().to_pandas()     # rows with __group_id__
 ```
 
 ### Group Proxy (`g` inside NestedTable filter/derive)
@@ -1114,10 +1115,10 @@ result = t.group_by("region").agg(
 
 ### `LTSeq.partition`
 - **Signature**: `LTSeq.partition(*cols: str) -> PartitionedTable` or `LTSeq.partition(by: Callable) -> PartitionedTable`
-- **Behavior**: Split into sub-tables by key (no aggregation). String columns use a fast SQL path; a callable uses the flexible Python path
+- **Behavior**: Split into sub-tables by key (no aggregation). A callable key must be a **simple column expression** (e.g. `lambda r: r.region`); derived expressions like `lambda r: r.price + 1` raise `ValueError` (they would force internal materialization)
 - **Parameters**: column name(s), a single callable, or `by=` callable
 - **Returns**: `PartitionedTable` (dict-like: key → LTSeq)
-- **Exceptions**: `TypeError` (invalid params), `AttributeError` (column not found), `ValueError` (schema not initialized)
+- **Exceptions**: `TypeError` (invalid params), `AttributeError` (column not found), `ValueError` (schema not initialized, or callable is not a simple column expression)
 - **Example**:
 ```python
 parts = t.partition("region")

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,25 +11,28 @@ Related documents:
 
 LTSeq is an ordered-sequence data processing library for Python backed by Rust/DataFusion. Unlike traditional DataFrames, LTSeq emphasizes order semantics and provides SPL-style capabilities such as window functions, ordered grouping, and cursor-based streaming.
 
+This document describes the API **as currently implemented**. Every signature below is verified against the source in `py-ltseq/ltseq/`.
+
 ## 0. Conventions and Terms
 
 - t: current LTSeq instance (immutable; all operations return a new instance)
 - r: row proxy used inside lambdas to build expressions (not executed in Python)
-- g: group proxy used in NestedTable filter/derive
-- Most operations return a new LTSeq; `to_cursor` returns an iterator; `is_subset` returns a bool
-- Window/ordered operations require a prior `sort`; otherwise runtime errors or incorrect results may occur
+- g: group proxy used in NestedTable filter/derive; group aggregations use string column names (`g.sum("amount")`), while `g.first()`/`g.last()` return row proxies with attribute access (`g.first().date`)
+- Most operations return a new LTSeq; `LTSeq.scan()`/`scan_parquet()` return a streaming `Cursor`; `is_subset`/`contain` return a bool
+- Window/ordered operations require a prior `sort` (or `assume_sorted`); otherwise runtime errors or incorrect results may occur. `shift`/`rolling`/`diff` also accept a `partition_by=` kwarg for per-group windows
 - Expressions are captured into AST on the Python side and executed in Rust/DataFusion
 
 ## Common Errors and Solutions
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `RuntimeError: window function used without sort` | Called `shift`/`rolling`/`diff` without prior `.sort()` | Add `.sort(order_column)` before window operations |
+| `RuntimeError: window function used without sort` | Called `shift`/`rolling`/`diff` without prior `.sort()` | Add `.sort(order_column)` (or `.assume_sorted(...)`) before window operations |
 | `AttributeError: column 'xxx' not found` | Typo in column name or column doesn't exist | Check `t.columns` for available column names |
 | `ValueError: schema mismatch` | Union/intersect with incompatible tables | Ensure both tables have same column names and types |
 | `ValueError: merge strategy requires sorted tables` | `join(..., strategy="merge")` called on unsorted tables | Call `.sort(join_key)` on both tables first |
 | `TypeError: predicate not boolean Expr` | Filter lambda returns non-boolean | Ensure predicate uses comparison operators (`>`, `==`, etc.) |
 | `ValueError: desc length mismatch` | `desc` list length doesn't match number of sort keys | Provide one bool per sort key, or use single bool for all |
+| `ValueError: Schema not initialized` | Operation called on an empty `LTSeq()` | Load data first (`read_csv`, `from_pandas`, ...) |
 
 ## Quick Reference
 
@@ -37,31 +40,38 @@ LTSeq is an ordered-sequence data processing library for Python backed by Rust/D
 | Operation | Method | Example |
 |-----------|--------|---------|
 | Load CSV | `LTSeq.read_csv()` | `t = LTSeq.read_csv("data.csv")` |
-| View schema | `.columns` | `print(t.columns)` |
-| Stream results | `.to_cursor()` | `for batch in t.to_cursor(): ...` |
-| Collect all | `.collect()` | `rows = t.collect()` |
+| Load Parquet | `LTSeq.read_parquet()` | `t = LTSeq.read_parquet("data.parquet")` |
+| Stream large file | `LTSeq.scan()` | `for batch in LTSeq.scan("big.csv"): ...` |
+| From Python data | `LTSeq.from_dict()` | `t = LTSeq.from_dict({"id": [1, 2]})` |
+| View schema | `.columns` / `.schema` | `print(t.columns)` |
+| Collect rows | `.collect()` | `rows = t.collect()` |
 | To pandas | `.to_pandas()` | `df = t.to_pandas()` |
-| Row count | `.count()` | `n = t.count()` |
+| Write file | `.write_csv()` / `.write_parquet()` | `t.write_csv("out.csv")` |
+| Row count | `.count()` / `len(t)` | `n = t.count()` |
+| Pretty print | `.show()` | `t.show(20)` |
 
 ### Basic Operations
 | Operation | Method | Example |
 |-----------|--------|---------|
 | Filter rows | `.filter()` | `t.filter(lambda r: r.age > 18)` |
 | Select columns | `.select()` | `t.select("id", "name")` |
-| Add columns | `.derive()` | `t.derive(total=lambda r: r.a + r.b)` |
+| Add columns | `.derive()` (alias `.with_columns()`) | `t.derive(total=lambda r: r.a + r.b)` |
+| Rename columns | `.rename()` | `t.rename(old="new")` |
+| Drop columns | `.drop()` | `t.drop("tmp")` |
 | Sort | `.sort()` | `t.sort("date", desc=True)` |
 | Deduplicate | `.distinct()` | `t.distinct("id")` |
 | Slice rows | `.slice()` | `t.slice(offset=10, length=5)` |
 | First N rows | `.head()` | `t.head(10)` |
 | Last N rows | `.tail()` | `t.tail(10)` |
 
-### Window Operations (require `.sort()` first)
+### Window Operations (require `.sort()` first; `partition_by=` for per-group)
 | Operation | Method | Example |
 |-----------|--------|---------|
 | Previous row | `.shift(n)` | `r.price.shift(1)` |
 | Rolling agg | `.rolling(n).agg()` | `r.price.rolling(5).mean()` |
 | Row difference | `.diff(n)` | `r.price.diff(1)` |
-| Cumulative sum | `.cum_sum()` | `t.cum_sum("volume")` |
+| Percent change | `.pct_change()` | `r.close.pct_change()` |
+| Cumulative sum | `.cum_sum()` | `t.cum_sum("volume")` or `r.volume.cum_sum()` |
 
 ### Ranking (use `.over()`)
 | Operation | Method | Example |
@@ -74,7 +84,8 @@ LTSeq is an ordered-sequence data processing library for Python backed by Rust/D
 ### Aggregation
 | Operation | Method | Example |
 |-----------|--------|---------|
-| Group aggregate | `.agg()` | `t.agg(by=lambda r: r.region, total=lambda r: r.sales.sum())` |
+| Group aggregate (chain) | `.group_by().agg()` | `t.group_by("region").agg(total=lambda g: g.sales.sum())` |
+| Group aggregate | `.agg()` | `t.agg(by=lambda r: r.region, total=lambda g: g.sales.sum())` |
 | Partition | `.partition()` | `parts = t.partition("region")` |
 | Pivot | `.pivot()` | `t.pivot(index="date", columns="region", values="amount")` |
 
@@ -83,74 +94,180 @@ LTSeq is an ordered-sequence data processing library for Python backed by Rust/D
 |-----------|--------|---------|
 | Hash join | `.join()` | `a.join(b, on=lambda a, b: a.id == b.id)` |
 | Merge join | `.join(..., strategy="merge")` | `a.sort("id").join(b.sort("id"), on=lambda a, b: a.id == b.id, strategy="merge")` |
+| As-of join | `.asof_join()` | `trades.asof_join(quotes, on=lambda t, q: t.time >= q.time)` |
 | Semi join | `.semi_join()` | `a.semi_join(b, on=lambda a, b: a.id == b.id)` |
 | Anti join | `.anti_join()` | `a.anti_join(b, on=lambda a, b: a.id == b.id)` |
+| Pointer link | `.link()` | `orders.link(products, on=lambda o, p: o.product_id == p.id, as_="prod")` |
 
 ### Set Operations
 | Operation | Method | Example |
 |-----------|--------|---------|
-| Union | `.union()` | `t1.union(t2)` |
+| Union (all) | `.union()` | `t1.union(t2)` |
 | Intersect | `.intersect()` | `t1.intersect(t2)` |
 | Diff | `.except_()` | `t1.except_(t2)` |
+| Symmetric diff | `.xunion()` | `t1.xunion(t2)` |
+
+### Row Mutation (copy-on-write)
+| Operation | Method | Example |
+|-----------|--------|---------|
+| Insert row | `.insert()` | `t.insert(0, {"id": 99})` |
+| Delete rows | `.delete()` | `t.delete(lambda r: r.expired)` |
+| Conditional update | `.update()` | `t.update(lambda r: r.age > 65, discount=0.2)` |
+| Modify one row | `.modify()` | `t.modify(0, status="active")` |
 
 ## 1. Input / Output
 
 ### `LTSeq.read_csv`
 - **Signature**: `LTSeq.read_csv(path: str, has_header: bool = True) -> LTSeq`
-- **Behavior**: Load a CSV file and infer schema; returns a chainable LTSeq
+- **Behavior**: Load a CSV file and infer schema; returns a chainable LTSeq. When `has_header=False`, columns are named `column_0`, `column_1`, ...
 - **Parameters**: `path` CSV path; `has_header` whether the first row is a header
 - **Returns**: `LTSeq` with loaded data and schema
-- **Exceptions**: `FileNotFoundError`/`IOError` (invalid path or unreadable), `ValueError` (parse or schema inference failure)
+- **Exceptions**: `FileNotFoundError` (invalid path), `ValueError` (parse or schema inference failure)
 - **Example**:
 ```python
 from ltseq import LTSeq
 
 t = LTSeq.read_csv("data.csv")
+t2 = LTSeq.read_csv("raw.csv", has_header=False)
+```
+
+### `LTSeq.read_parquet`
+- **Signature**: `LTSeq.read_parquet(path: str) -> LTSeq`
+- **Behavior**: Load a Parquet file and return an LTSeq table
+- **Parameters**: `path` Parquet path
+- **Returns**: `LTSeq` with loaded data and schema
+- **Exceptions**: `FileNotFoundError` (invalid path), `RuntimeError` (parse failure)
+- **Example**:
+```python
+t = LTSeq.read_parquet("data.parquet")
+```
+
+### `LTSeq.scan` / `LTSeq.scan_parquet` (streaming)
+- **Signature**: `LTSeq.scan(path: str, has_header: bool = True) -> Cursor`; `LTSeq.scan_parquet(path: str) -> Cursor`
+- **Behavior**: Create a streaming cursor over a CSV/Parquet file for lazy batch iteration without loading the whole file into memory
+- **Parameters**: `path` file path; `has_header` (CSV only) whether the first row is a header
+- **Returns**: `Cursor` (iterable of record batches)
+- **Exceptions**: `FileNotFoundError` (invalid path), `RuntimeError` (scan failure)
+- **Example**:
+```python
+for batch in LTSeq.scan("large.csv"):
+    process(batch)
+
+cursor = LTSeq.scan_parquet("large.parquet")
+```
+
+### `Cursor` (streaming handle)
+- **Signature**: iterable object returned by `scan`/`scan_parquet`
+- **Behavior**: Lazily yields record batches; also supports whole-stream materialization
+- **Members**:
+  - `__iter__()`: iterate over batches
+  - `schema -> dict[str, str]` (property), `columns -> list[str]` (property)
+  - `source -> str` (property): source file path; `exhausted -> bool` (property)
+  - `to_pandas()`, `to_arrow()`: materialize the remaining stream
+  - `count() -> int`: consume the stream and count rows
+- **Example**:
+```python
+cursor = LTSeq.scan("large.csv")
+print(cursor.columns)
+for batch in cursor:
+    ...
+```
+
+### `LTSeq.from_rows`
+- **Signature**: `LTSeq.from_rows(rows: list[dict[str, Any]], schema: dict[str, str] | None = None) -> LTSeq`
+- **Behavior**: Build a table from row dictionaries. Types are inferred from the first row unless `schema` is given; an explicit schema is required when `rows` is empty
+- **Parameters**: `rows` list of dicts (same keys per row); `schema` optional `{column: arrow_type}` mapping
+- **Returns**: new `LTSeq`
+- **Exceptions**: `ValueError` (empty rows without schema), `TypeError` (not a list of dicts)
+- **Example**:
+```python
+t = LTSeq.from_rows([{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}])
+empty = LTSeq.from_rows([], schema={"id": "Int64", "name": "Utf8"})
+```
+
+### `LTSeq.from_dict`
+- **Signature**: `LTSeq.from_dict(data: dict[str, list[Any]]) -> LTSeq`
+- **Behavior**: Build a table from a column-oriented dictionary
+- **Parameters**: `data` mapping of column name to list of values (equal lengths)
+- **Returns**: new `LTSeq`
+- **Exceptions**: `ValueError` (unequal column lengths), `TypeError` (not a dict)
+- **Example**:
+```python
+t = LTSeq.from_dict({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
+```
+
+### `LTSeq.from_pandas` / `LTSeq.from_arrow`
+- **Signature**: `LTSeq.from_pandas(df) -> LTSeq`; `LTSeq.from_arrow(arrow_table) -> LTSeq`
+- **Behavior**: Build a table from a pandas DataFrame / PyArrow Table
+- **Returns**: new `LTSeq`
+- **Exceptions**: `ImportError` (pandas/pyarrow not installed), `TypeError` (wrong input type)
+- **Example**:
+```python
+t = LTSeq.from_pandas(df)
+t = LTSeq.from_arrow(arrow_table)
+```
+
+### `seq` (integer sequence constructor)
+- **Signature**: `seq(start_or_stop: int, stop: int | None = None, step: int = 1) -> LTSeq`
+- **Behavior**: Generate an integer sequence as a single-column LTSeq (column named `value`, Int64). Mirrors Python's built-in `range()`
+- **Import**: `from ltseq import seq`
+- **Example**:
+```python
+from ltseq import seq
+
+seq(5)         # 0, 1, 2, 3, 4
+seq(2, 7)      # 2, 3, 4, 5, 6
+seq(0, 10, 2)  # 0, 2, 4, 6, 8
+```
+
+### `LTSeq.write_csv` / `LTSeq.write_parquet`
+- **Signature**: `LTSeq.write_csv(path: str) -> None`; `LTSeq.write_parquet(path: str, compression: str | None = None) -> None`
+- **Behavior**: Write the table to a CSV/Parquet file. Parquet `compression` is one of `"snappy" | "zstd" | "gzip" | "lz4" | "none"` (default uncompressed)
+- **Exceptions**: `RuntimeError` (write failure), `ValueError` (unknown compression)
+- **Example**:
+```python
+t.write_csv("output.csv")
+t.write_parquet("output.parquet", compression="zstd")
 ```
 
 ### `LTSeq.schema` (property)
-- **Signature**: `LTSeq.schema -> Dict[str, str]`
-- **Behavior**: Return the table schema as a dictionary mapping column names to type strings
-- **Parameters**: none (property)
-- **Returns**: dictionary mapping column names to their data types
-- **Exceptions**: none
+- **Signature**: `LTSeq.schema -> dict[str, str]`
+- **Behavior**: Return the table schema as a dictionary mapping column names to Arrow type strings
 - **Example**:
 ```python
-t = LTSeq.read_csv("data.csv")
 print(t.schema)   # {"id": "Int64", "name": "Utf8", ...}
 
-# Iterate columns
 for name, dtype in t.schema.items():
     print(f"{name}: {dtype}")
 ```
 
+### `LTSeq.python_schema` (property)
+- **Signature**: `LTSeq.python_schema -> dict[str, str]`
+- **Behavior**: Return the schema with Python-friendly type names (`Int64` → `int`, `Utf8` → `str`, `Float64` → `float`, `Boolean` → `bool`, ...). Unknown types are returned as-is
+- **Example**:
+```python
+print(t.python_schema)  # {"id": "int", "name": "str", "score": "float"}
+```
+
 ### `LTSeq.columns` (property)
-- **Signature**: `LTSeq.columns -> List[str]`
+- **Signature**: `LTSeq.columns -> list[str]`
 - **Behavior**: Return list of column names (shortcut for `list(schema.keys())`)
-- **Parameters**: none (property)
-- **Returns**: list of column name strings
-- **Exceptions**: none
 - **Example**:
 ```python
 print(t.columns)  # ["id", "name", "age"]
 ```
 
-### `LTSeq.to_cursor`
-- **Signature**: `LTSeq.to_cursor(chunk_size: int = 10000) -> Iterator[Record]`
-- **Behavior**: Stream results via cursor to avoid full materialization
-- **Parameters**: `chunk_size` rows per batch
-- **Returns**: record iterator (e.g., Record/RecordBatch)
-- **Exceptions**: `ValueError` (invalid chunk_size), `RuntimeError` (streaming not supported or execution failure)
+### `LTSeq.dtypes` (property)
+- **Signature**: `LTSeq.dtypes -> list[tuple[str, str]]`
+- **Behavior**: Return list of `(column_name, data_type)` tuples
 - **Example**:
 ```python
-for batch in t.to_cursor(chunk_size=5000):
-    print(batch)
+print(t.dtypes)  # [("id", "Int64"), ("name", "Utf8"), ...]
 ```
 
 ### `LTSeq.collect`
-- **Signature**: `LTSeq.collect() -> List[Dict[str, Any]]`
-- **Behavior**: Materialize all rows as a list of dictionaries
-- **Parameters**: none
+- **Signature**: `LTSeq.collect() -> list[dict[str, Any]]`
+- **Behavior**: Materialize all rows as a list of dictionaries. Note: unlike Polars' `collect()` (which returns a DataFrame), LTSeq's `collect()` returns row dicts — see `to_pandas()`/`to_arrow()` for table-shaped exports
 - **Returns**: list of row dictionaries
 - **Exceptions**: `MemoryError` (dataset too large), `RuntimeError` (execution failure)
 - **Example**:
@@ -160,34 +277,40 @@ for row in rows:
     print(row["name"])
 ```
 
-### `LTSeq.to_pandas`
-- **Signature**: `LTSeq.to_pandas() -> pandas.DataFrame`
-- **Behavior**: Convert to pandas DataFrame for interoperability
-- **Parameters**: none
-- **Returns**: `pandas.DataFrame`
-- **Exceptions**: `ImportError` (pandas not installed), `MemoryError` (dataset too large)
+### `LTSeq.to_pandas` / `LTSeq.to_arrow`
+- **Signature**: `LTSeq.to_pandas() -> pandas.DataFrame`; `LTSeq.to_arrow() -> pyarrow.Table`
+- **Behavior**: Materialize the table as a pandas DataFrame / PyArrow Table
+- **Exceptions**: `ImportError` (pandas/pyarrow not installed), `MemoryError` (dataset too large)
 - **Example**:
 ```python
 df = t.to_pandas()
 df.plot(x="date", y="price")
+
+arrow_table = t.to_arrow()
 ```
 
-### `LTSeq.count`
-- **Signature**: `LTSeq.count() -> int`
-- **Behavior**: Return the number of rows
-- **Parameters**: none
-- **Returns**: integer row count
+### `LTSeq.count` / `len(t)`
+- **Signature**: `LTSeq.count() -> int`; `LTSeq.__len__() -> int`
+- **Behavior**: Return the number of rows; `count()` is equivalent to `len(t)`
 - **Exceptions**: `RuntimeError` (execution failure)
 - **Example**:
 ```python
 n = t.filter(lambda r: r.status == "active").count()
+n = len(t)
+```
+
+### `LTSeq.show`
+- **Signature**: `LTSeq.show(n: int = 10) -> LTSeq`
+- **Behavior**: Pretty-print up to `n` rows as an ASCII table; returns `self` for chaining. The REPL `repr` of an LTSeq also shows dimensions, schema, and a 5-row preview
+- **Example**:
+```python
+t.show()
+t.filter(lambda r: r.active).show().derive(upper=lambda r: r.name.s.upper())
 ```
 
 ### `LTSeq.head`
 - **Signature**: `LTSeq.head(n: int = 10) -> LTSeq`
 - **Behavior**: Return the first n rows
-- **Parameters**: `n` number of rows (default 10)
-- **Returns**: `LTSeq` with first n rows
 - **Exceptions**: `ValueError` (n < 0)
 - **Example**:
 ```python
@@ -197,19 +320,37 @@ top_10 = t.sort("score", desc=True).head(10)
 ### `LTSeq.tail`
 - **Signature**: `LTSeq.tail(n: int = 10) -> LTSeq`
 - **Behavior**: Return the last n rows
-- **Parameters**: `n` number of rows (default 10)
-- **Returns**: `LTSeq` with last n rows
 - **Exceptions**: `ValueError` (n < 0)
 - **Example**:
 ```python
 recent = t.sort("date").tail(5)
 ```
 
+### `LTSeq.pipe`
+- **Signature**: `LTSeq.pipe(func: Callable[..., LTSeq], *args, **kwargs) -> LTSeq`
+- **Behavior**: Apply a user function to the table inside a method chain (same as pandas `DataFrame.pipe`)
+- **Example**:
+```python
+def add_tax(t, rate):
+    return t.derive(tax=lambda r: r.price * rate)
+
+result = t.filter(lambda r: r.qty > 0).pipe(add_tax, 0.1).sort("tax")
+```
+
+### `LTSeq.explain_plan`
+- **Signature**: `LTSeq.explain_plan() -> tuple[str, str]`
+- **Behavior**: Return the optimized logical and physical DataFusion plans for debugging
+- **Example**:
+```python
+logical, physical = t.filter(lambda r: r.age > 18).explain_plan()
+print(logical)
+```
+
 ## 2. Basic Relational Operations
 
 ### `LTSeq.filter`
 - **Signature**: `LTSeq.filter(predicate: Callable[[Row], Expr]) -> LTSeq`
-- **Behavior**: Filter rows matching the predicate; pushed down to the Rust engine when possible
+- **Behavior**: Filter rows matching the predicate; pushed down to the Rust engine
 - **Parameters**: `predicate` row predicate expression (returns boolean Expr)
 - **Returns**: filtered `LTSeq`
 - **Exceptions**: `ValueError` (schema not initialized), `TypeError` (predicate not boolean Expr), `AttributeError` (column not found)
@@ -219,7 +360,7 @@ filtered = t.filter(lambda r: r.amount > 100)
 ```
 
 ### `LTSeq.select`
-- **Signature**: `LTSeq.select(*cols: Union[str, Callable]) -> LTSeq`
+- **Signature**: `LTSeq.select(*cols: str | Callable) -> LTSeq`
 - **Behavior**: Project specified columns or expressions; supports column pruning
 - **Parameters**: `cols` column names or lambdas (single expr or list)
 - **Returns**: projected `LTSeq`
@@ -231,9 +372,9 @@ t.select("id", "name")
 t.select(lambda r: [r.id, r.name])
 ```
 
-### `LTSeq.derive`
-- **Signature**: `LTSeq.derive(**new_cols: Callable) -> LTSeq` or `LTSeq.derive(func: Callable[[Row], Dict[str, Expr]]) -> LTSeq`
-- **Behavior**: Add or overwrite columns; keeps existing columns
+### `LTSeq.derive` (alias: `with_columns`)
+- **Signature**: `LTSeq.derive(**new_cols: Callable) -> LTSeq` or `LTSeq.derive(func: Callable[[Row], dict[str, Expr]]) -> LTSeq`
+- **Behavior**: Add or overwrite columns; keeps existing columns. `with_columns` is an alias for Polars users
 - **Parameters**: `new_cols` mapping of column name to lambda; or a lambda that returns a dict
 - **Returns**: new `LTSeq` with derived columns
 - **Exceptions**: `ValueError` (schema not initialized), `TypeError` (invalid return type), `AttributeError` (column not found)
@@ -243,26 +384,47 @@ t.select(lambda r: [r.id, r.name])
 with_tax = t.derive(tax=lambda r: r.price * 0.1)
 # Style 2
 with_tax = t.derive(lambda r: {"tax": r.price * 0.1})
+# Polars-style alias
+with_tax = t.with_columns(tax=lambda r: r.price * 0.1)
+```
+
+### `LTSeq.rename`
+- **Signature**: `LTSeq.rename(mapping: dict[str, str] | None = None, **kwargs: str) -> LTSeq`
+- **Behavior**: Rename columns via a dict or keyword arguments (`old_name=new_name`)
+- **Returns**: new `LTSeq` with renamed columns
+- **Exceptions**: `AttributeError` (column not found), `ValueError` (schema not initialized)
+- **Example**:
+```python
+t.rename({"old_name": "new_name"})
+t.rename(price="unit_price", qty="quantity")
+```
+
+### `LTSeq.drop`
+- **Signature**: `LTSeq.drop(*cols: str) -> LTSeq`
+- **Behavior**: Remove the given columns, keeping the rest
+- **Exceptions**: `AttributeError` (column not found), `ValueError` (schema not initialized)
+- **Example**:
+```python
+t.drop("tmp", "debug_flag")
 ```
 
 ### `LTSeq.sort`
-- **Signature**: `LTSeq.sort(*keys: Union[str, Callable], desc: Union[bool, list] = False) -> LTSeq`
-- **Behavior**: Sort by one or more keys; required for window/ordered computing. Also populates `sort_keys` for sort order tracking.
-- **Parameters**: `keys` column names or expressions; `desc` (or `descending`) global or per-key descending flags
+- **Signature**: `LTSeq.sort(*keys: str | Callable, desc: bool | list[bool] = False, descending: bool | list[bool] | None = None) -> LTSeq`
+- **Behavior**: Sort by one or more keys; required for window/ordered computing. Also populates `sort_keys` for sort order tracking. `descending` is an alias for `desc` (Polars naming) and takes precedence when both are given
+- **Parameters**: `keys` column names or expressions; `desc`/`descending` global or per-key descending flags
 - **Returns**: sorted `LTSeq` with tracked sort keys
 - **Exceptions**: `ValueError` (schema not initialized or desc length mismatch), `TypeError` (invalid key type), `AttributeError` (column not found)
 - **Example**:
 ```python
 t_sorted = t.sort("date", "id", desc=[False, True])
 print(t_sorted.sort_keys)  # [("date", False), ("id", True)]
+
+t.sort("price", descending=True)  # Polars-style alias
 ```
 
 ### `LTSeq.sort_keys` (property)
-- **Signature**: `LTSeq.sort_keys -> Optional[List[Tuple[str, bool]]]`
+- **Signature**: `LTSeq.sort_keys -> list[tuple[str, bool]] | None`
 - **Behavior**: Returns the current sort keys as a list of (column_name, is_descending) tuples, or None if sort order is unknown
-- **Parameters**: none (property)
-- **Returns**: `Optional[List[Tuple[str, bool]]]` - list of (column, descending) tuples or None
-- **Exceptions**: none
 - **Example**:
 ```python
 t = LTSeq.read_csv("data.csv")
@@ -276,7 +438,7 @@ print(t_desc.sort_keys)  # [("price", True)]
 ```
 
 ### `LTSeq.is_sorted_by`
-- **Signature**: `LTSeq.is_sorted_by(*keys: str, desc: Union[bool, List[bool]] = False) -> bool`
+- **Signature**: `LTSeq.is_sorted_by(*keys: str, desc: bool | list[bool] = False) -> bool`
 - **Behavior**: Check if the table is sorted by the given keys (uses prefix matching)
 - **Parameters**: `keys` column names to check; `desc` expected descending flags (single bool or per-key list)
 - **Returns**: `bool` - True if sorted by the given keys (as a prefix), False otherwise
@@ -291,8 +453,20 @@ t_sorted.is_sorted_by("b")          # False (not a prefix)
 t_sorted.is_sorted_by("a", desc=True)  # False (direction mismatch)
 ```
 
+### `LTSeq.assume_sorted`
+- **Signature**: `LTSeq.assume_sorted(*keys: str, desc: bool | list[bool] = False) -> LTSeq`
+- **Behavior**: Declare that data is already sorted by the given keys **without physically sorting**. Enables window functions and merge joins on pre-sorted data (e.g., pre-sorted Parquet) while skipping the sort. The caller is responsible for correctness — wrong metadata produces wrong results
+- **Parameters**: `keys` column names declaring the sort order; `desc` descending flag(s)
+- **Returns**: `LTSeq` with sort metadata set (same underlying data)
+- **Exceptions**: `ValueError` (schema not initialized or desc length mismatch), `TypeError` (invalid desc type)
+- **Example**:
+```python
+t = LTSeq.read_parquet("presorted.parquet").assume_sorted("userid", "eventtime")
+t.is_sorted_by("userid")  # True
+```
+
 ### `LTSeq.distinct`
-- **Signature**: `LTSeq.distinct(*keys: Union[str, Callable]) -> LTSeq`
+- **Signature**: `LTSeq.distinct(*keys: str | Callable) -> LTSeq`
 - **Behavior**: Deduplicate; if no keys are provided, deduplicate by all columns
 - **Parameters**: `keys` key columns or expressions
 - **Returns**: deduplicated `LTSeq`
@@ -303,11 +477,11 @@ unique = t.distinct("customer_id")
 ```
 
 ### `LTSeq.slice`
-- **Signature**: `LTSeq.slice(offset: int = 0, length: Optional[int] = None) -> LTSeq`
+- **Signature**: `LTSeq.slice(offset: int = 0, length: int | None = None) -> LTSeq`
 - **Behavior**: Select a contiguous row range with logical zero-copy semantics
 - **Parameters**: `offset` starting row (0-based); `length` number of rows (None means to the end)
 - **Returns**: sliced `LTSeq`
-- **Exceptions**: `ValueError` (negative offset/length), `ValueError` (schema not initialized)
+- **Exceptions**: `ValueError` (negative offset/length or schema not initialized)
 - **Example**:
 ```python
 t.slice(offset=10, length=5)
@@ -317,22 +491,30 @@ t.slice(offset=10, length=5)
 
 ### 3.1 Row-Level Window Operations
 
-> These operations require a prior `.sort()` to establish order.
+> These operations require a prior `.sort()` (or `.assume_sorted()`) to establish order. `shift` additionally accepts a `partition_by=` kwarg (column name string or expression) to restart the window at group boundaries.
 
 #### `r.col.shift`
-- **Signature**: `r.col.shift(offset: int) -> Expr`
-- **Behavior**: Access relative rows. Positive offset looks backward (previous rows), negative offset looks forward (future rows). Consistent with pandas `Series.shift()`.
-- **Parameters**: `offset` row offset (positive = backward, negative = forward)
-- **Returns**: expression (NULL at boundaries where offset exceeds available rows)
+- **Signature**: `r.col.shift(offset: int, default: Any = None, partition_by: str | Expr | None = None) -> Expr`
+- **Behavior**: Access relative rows. Positive offset looks backward (previous rows), negative offset looks forward (future rows). Consistent with pandas `Series.shift()`. With `partition_by`, the window resets at group boundaries (LAG/LEAD OVER PARTITION BY)
+- **Parameters**: `offset` row offset (positive = backward, negative = forward); `default` fill value at boundaries (default NULL); `partition_by` optional partition column
+- **Returns**: expression (NULL — or `default` — at boundaries where offset exceeds available rows)
 - **Exceptions**: `TypeError` (offset not int), `RuntimeError` (used without sort)
 - **Example**:
 ```python
 with_prev = t.sort("date").derive(prev=lambda r: r.close.shift(1))
+
+# Per-group shift: NULL at each group boundary
+t.sort("grp", "date").derive(
+    prev=lambda r: r.value.shift(1, partition_by="grp")
+)
+
+# Fill boundary with a default instead of NULL
+t.sort("date").derive(prev=lambda r: r.value.shift(1, default=0))
 ```
 
 #### `r.col.rolling`
 - **Signature**: `r.col.rolling(window_size: int).agg_func() -> Expr`
-- **Behavior**: Sliding window aggregation; common aggs: `mean/sum/min/max/std`
+- **Behavior**: Sliding window aggregation; supported aggs: `mean/sum/min/max/count/std`
 - **Parameters**: `window_size` window size
 - **Returns**: window aggregation expression
 - **Exceptions**: `ValueError` (window_size <= 0), `RuntimeError` (used without sort)
@@ -352,17 +534,36 @@ ma5 = t.sort("date").derive(ma_5=lambda r: r.close.rolling(5).mean())
 changes = t.sort("date").derive(daily=lambda r: r.close.diff())
 ```
 
+#### `r.col.pct_change`
+- **Signature**: `r.col.pct_change() -> Expr`
+- **Behavior**: Percentage change from the previous row: `(x - x.shift(1)) / x.shift(1)`. Requires sort
+- **Returns**: numeric expression
+- **Example**:
+```python
+returns = t.sort("date").derive(daily_return=lambda r: r.close.pct_change())
+```
+
+#### `r.col.cum_sum` (expression form)
+- **Signature**: `r.col.cum_sum() -> Expr`
+- **Behavior**: Cumulative sum over the current order, usable inside `derive()` so the output column name is under your control
+- **Exceptions**: `TypeError` (non-numeric), `RuntimeError` (used without sort)
+- **Example**:
+```python
+t.sort("date").derive(cum_vol=lambda r: r.volume.cum_sum())
+```
+
 ### 3.2 Table-Level Cumulative Operations
 
 #### `LTSeq.cum_sum`
-- **Signature**: `LTSeq.cum_sum(*cols: Union[str, Callable]) -> LTSeq`
-- **Behavior**: Add cumulative sum columns with `*_cumsum` suffix
+- **Signature**: `LTSeq.cum_sum(*cols: str | Callable) -> LTSeq`
+- **Behavior**: Add cumulative sum columns with `*_cumsum` suffix. For custom output names use the expression form `r.col.cum_sum()` inside `derive()`
 - **Parameters**: `cols` column names or expressions
 - **Returns**: new `LTSeq` with cumulative columns
 - **Exceptions**: `ValueError` (no columns or schema not initialized), `TypeError` (non-numeric)
 - **Example**:
 ```python
 with_cum = t.sort("date").cum_sum("volume", "amount")
+# → adds volume_cumsum, amount_cumsum
 ```
 
 ### 3.3 Ranking Functions
@@ -373,13 +574,13 @@ Ranking functions assign positions or ranks to rows within partitions. They must
 
 #### `row_number`
 - **Signature**: `row_number().over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **Behavior**: Assign a unique sequential number to each row (1, 2, 3, ...). Unlike `rank()`, always produces distinct values even for ties.
+- **Behavior**: Assign a unique sequential number to each row (1, 2, 3, ...). Unlike `rank()`, always produces distinct values even for ties
 - **Parameters**: Use `.over()` to specify `partition_by` (optional), `order_by` (required), `descending` (optional)
 - **Returns**: integer expression
 - **Exceptions**: `RuntimeError` (no order_by specified)
 - **Example**:
 ```python
-from ltseq.expr import row_number
+from ltseq import row_number
 
 # Simple row numbering
 t.derive(rn=lambda r: row_number().over(order_by=r.date))
@@ -390,13 +591,13 @@ t.derive(rn=lambda r: row_number().over(partition_by=r.group, order_by=r.date))
 
 #### `rank`
 - **Signature**: `rank().over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **Behavior**: Assign rank with gaps for ties. Rows with equal values get the same rank; next rank is skipped (1, 2, 2, 4, 5).
+- **Behavior**: Assign rank with gaps for ties. Rows with equal values get the same rank; next rank is skipped (1, 2, 2, 4, 5)
 - **Parameters**: Use `.over()` to specify `partition_by` (optional), `order_by` (required), `descending` (optional)
 - **Returns**: integer expression
 - **Exceptions**: `RuntimeError` (no order_by specified)
 - **Example**:
 ```python
-from ltseq.expr import rank
+from ltseq import rank
 
 # Rank by score (ties get same rank, gaps after)
 t.derive(rnk=lambda r: rank().over(order_by=r.score))
@@ -407,13 +608,13 @@ t.derive(rnk=lambda r: rank().over(partition_by=r.dept, order_by=r.salary, desce
 
 #### `dense_rank`
 - **Signature**: `dense_rank().over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **Behavior**: Assign rank without gaps for ties. Rows with equal values get the same rank; next rank is NOT skipped (1, 2, 2, 3, 4).
+- **Behavior**: Assign rank without gaps for ties. Rows with equal values get the same rank; next rank is NOT skipped (1, 2, 2, 3, 4)
 - **Parameters**: Use `.over()` to specify `partition_by` (optional), `order_by` (required), `descending` (optional)
 - **Returns**: integer expression
 - **Exceptions**: `RuntimeError` (no order_by specified)
 - **Example**:
 ```python
-from ltseq.expr import dense_rank
+from ltseq import dense_rank
 
 # Dense rank by score (no gaps after ties)
 t.derive(drnk=lambda r: dense_rank().over(order_by=r.score))
@@ -424,13 +625,13 @@ t.derive(drnk=lambda r: dense_rank().over(partition_by=r.dept, order_by=r.salary
 
 #### `ntile`
 - **Signature**: `ntile(n: int).over(partition_by=None, order_by=Expr, descending=False) -> Expr`
-- **Behavior**: Divide rows into `n` roughly equal buckets (1 to n). Useful for percentiles and quantiles.
+- **Behavior**: Divide rows into `n` roughly equal buckets (1 to n). Useful for percentiles and quantiles
 - **Parameters**: `n` number of buckets; use `.over()` for partitioning/ordering
 - **Returns**: integer expression (bucket number 1 to n)
 - **Exceptions**: `ValueError` (n <= 0), `RuntimeError` (no order_by specified)
 - **Example**:
 ```python
-from ltseq.expr import ntile
+from ltseq import ntile
 
 # Divide into quartiles
 t.derive(quartile=lambda r: ntile(4).over(order_by=r.score))
@@ -440,28 +641,20 @@ t.derive(decile=lambda r: ntile(10).over(partition_by=r.group, order_by=r.value)
 ```
 
 #### `CallExpr.over` (Window Specification)
-- **Signature**: `expr.over(partition_by: Optional[Union[Expr, List[Expr]]] = None, order_by: Optional[Union[Expr, List[Expr]]] = None, descending: Union[bool, List[bool]] = False) -> WindowExpr`
-- **Behavior**: Apply window specification to a ranking function
+- **Signature**: `expr.over(partition_by: Expr | None = None, order_by: Expr | None = None, descending: bool = False) -> WindowExpr`
+- **Behavior**: Apply a window specification to a ranking function. `partition_by` and `order_by` each take a **single column expression**; `descending` is a single bool applied to `order_by`
 - **Parameters**:
-  - `partition_by` column(s) to partition by (single Expr or list of Exprs)
-  - `order_by` column(s) to order by (single Expr or list of Exprs)
-  - `descending` sort direction (single bool or per-column list of bools)
+  - `partition_by` column to partition by (optional)
+  - `order_by` column to order by (required for ranking functions)
+  - `descending` sort direction for order_by (default False)
 - **Returns**: `WindowExpr` ready for use in derive()
 - **Exceptions**: `TypeError` (invalid partition_by/order_by types)
 - **Example**:
 ```python
-# Single column partition and order
 t.derive(rn=lambda r: row_number().over(
     partition_by=r.region,
     order_by=r.date,
-    descending=True
-))
-
-# Multiple columns partition and order
-t.derive(rn=lambda r: row_number().over(
-    partition_by=[r.region, r.category],
-    order_by=[r.date, r.id],
-    descending=[True, False]
+    descending=True,
 ))
 ```
 
@@ -472,14 +665,44 @@ t.derive(rn=lambda r: row_number().over(
 - **Behavior**: Return the first matching row (single-row LTSeq); can do binary search on sorted data
 - **Parameters**: `predicate` row predicate
 - **Returns**: single-row `LTSeq` (empty if not found)
-- **Exceptions**: `ValueError` (schema not initialized), `TypeError` (invalid predicate), `RuntimeError` (execution failure)
+- **Exceptions**: `ValueError` (schema not initialized), `TypeError` (invalid predicate), `RuntimeError` (predicate cannot be transpiled)
 - **Example**:
 ```python
 first_big = t.sort("price").search_first(lambda r: r.price > 100)
 ```
 
+#### `LTSeq.search_pattern`
+- **Signature**: `LTSeq.search_pattern(*step_predicates: Callable, partition_by: str | None = None) -> LTSeq`
+- **Behavior**: Find rows where **consecutive rows** match a sequence of predicates (funnel/sequence matching). Returns the rows where step 1 matched, i.e. row `i` such that `step1(i), step2(i+1), ..., stepN(i+N-1)` all hold. With `partition_by`, the pattern cannot cross partition boundaries
+- **Parameters**: `step_predicates` one lambda per step; `partition_by` optional partition column
+- **Returns**: `LTSeq` of step-1 rows
+- **Exceptions**: `ValueError` (no predicates or schema not initialized)
+- **Example**:
+```python
+# Find a 3-step URL funnel per user
+matches = t.search_pattern(
+    lambda r: r.url.s.starts_with("/landing"),
+    lambda r: r.url.s.starts_with("/product"),
+    lambda r: r.url.s.starts_with("/checkout"),
+    partition_by="userid",
+)
+```
+
+#### `LTSeq.search_pattern_count`
+- **Signature**: `LTSeq.search_pattern_count(*step_predicates: Callable, partition_by: str | None = None) -> int`
+- **Behavior**: Same as `search_pattern` but returns only the match count
+- **Returns**: `int`
+- **Example**:
+```python
+n = t.search_pattern_count(
+    lambda r: r.event == "view",
+    lambda r: r.event == "buy",
+    partition_by="userid",
+)
+```
+
 #### `LTSeq.align`
-- **Signature**: `LTSeq.align(ref_sequence: List[Any], key: Callable[[Row], Expr]) -> LTSeq`
+- **Signature**: `LTSeq.align(ref_sequence: list[Any], key: Callable[[Row], Expr]) -> LTSeq`
 - **Behavior**: Align to `ref_sequence` order and insert NULLs for missing keys
 - **Parameters**: `ref_sequence` reference key sequence; `key` key extractor
 - **Returns**: aligned `LTSeq`
@@ -489,17 +712,40 @@ first_big = t.sort("price").search_first(lambda r: r.price > 100)
 aligned = t.align(["2024-01-01", "2024-01-02"], key=lambda r: r.date)
 ```
 
+### 3.5 Physical Row-Order Operations
+
+#### `LTSeq.rvs`
+- **Signature**: `LTSeq.rvs() -> LTSeq`
+- **Behavior**: Reverse the row order of the table
+- **Example**:
+```python
+reversed_t = t.sort("date").rvs()
+```
+
+#### `LTSeq.step`
+- **Signature**: `LTSeq.step(n: int) -> LTSeq`
+- **Behavior**: Take every nth row (0-based: rows 0, n, 2n, ...)
+- **Parameters**: `n` step size (must be >= 1)
+- **Exceptions**: `ValueError` (n < 1)
+- **Example**:
+```python
+every_other = t.step(2)   # rows 0, 2, 4, ...
+every_tenth = t.step(10)
+```
+
 ## 4. Ordered Grouping and Procedural Computing
 
-### `LTSeq.group_ordered`
+### `LTSeq.group_ordered` (alias: `group_consecutive`)
 - **Signature**: `LTSeq.group_ordered(key: Callable[[Row], Expr]) -> NestedTable`
-- **Behavior**: Group only consecutive equal values; does not reorder
+- **Behavior**: Group only consecutive equal values; does not reorder. `group_consecutive` is a more descriptive alias for the same method
 - **Parameters**: `key` grouping key expression
 - **Returns**: `NestedTable` (group-level operations)
 - **Exceptions**: `ValueError` (schema not initialized), `TypeError` (invalid key), `AttributeError` (column not found)
 - **Example**:
 ```python
 groups = t.sort("date").group_ordered(lambda r: r.is_up)
+# equivalent:
+groups = t.sort("date").group_consecutive(lambda r: r.is_up)
 ```
 
 ### `LTSeq.group_sorted`
@@ -513,26 +759,12 @@ groups = t.sort("date").group_ordered(lambda r: r.is_up)
 groups = t.sort("user_id").group_sorted(lambda r: r.user_id)
 ```
 
-### `LTSeq.scan`
-- **Signature**: `LTSeq.scan(func: Callable[[State, Row], State], init: Any) -> LTSeq`
-- **Behavior**: Stateful scan over current order; outputs per-row accumulated state
-- **Parameters**: `func` state transition; `init` initial state
-- **Returns**: `LTSeq` (usually a state sequence or appended state column)
-- **Exceptions**: `TypeError` (invalid func), `RuntimeError` (execution failure)
-- **Example**:
-```python
-# Compounding
-rates = t.sort("date").scan(lambda s, r: s * (1 + r.rate), init=1.0)
-```
-
 ### `NestedTable` (from `group_ordered` / `group_sorted`)
 
 #### `NestedTable.first`
 - **Signature**: `nested.first() -> LTSeq`
 - **Behavior**: First row of each group
-- **Parameters**: none
-- **Returns**: `LTSeq` of first rows
-- **Exceptions**: `RuntimeError` (execution failure)
+- **Returns**: `LTSeq` of first rows (one row per group)
 - **Example**:
 ```python
 first_rows = groups.first()
@@ -541,31 +773,16 @@ first_rows = groups.first()
 #### `NestedTable.last`
 - **Signature**: `nested.last() -> LTSeq`
 - **Behavior**: Last row of each group
-- **Parameters**: none
-- **Returns**: `LTSeq` of last rows
-- **Exceptions**: `RuntimeError` (execution failure)
+- **Returns**: `LTSeq` of last rows (one row per group)
 - **Example**:
 ```python
 last_rows = groups.last()
 ```
 
-#### `NestedTable.count`
-- **Signature**: `nested.count() -> LTSeq`
-- **Behavior**: Group size for each group
-- **Parameters**: none
-- **Returns**: `LTSeq` with counts
-- **Exceptions**: `RuntimeError` (execution failure)
-- **Example**:
-```python
-sizes = groups.count()
-```
-
 #### `NestedTable.flatten`
 - **Signature**: `nested.flatten() -> LTSeq`
-- **Behavior**: Flatten into a table with `__group_id__`
-- **Parameters**: none
+- **Behavior**: Return the underlying rows with a `__group_id__` column identifying each consecutive group
 - **Returns**: flattened `LTSeq`
-- **Exceptions**: `RuntimeError` (execution failure)
 - **Example**:
 ```python
 flat = groups.flatten()
@@ -573,208 +790,81 @@ flat = groups.flatten()
 
 #### `NestedTable.filter`
 - **Signature**: `nested.filter(predicate: Callable[[GroupProxy], Expr]) -> NestedTable`
-- **Behavior**: Filter groups by group-level predicate
-- **Parameters**: `predicate` group predicate (`g` is GroupProxy)
+- **Behavior**: Keep only groups satisfying a group-level predicate; rows of surviving groups are preserved
+- **Parameters**: `predicate` group predicate (`g` is a group proxy, see below)
 - **Returns**: filtered `NestedTable`
 - **Exceptions**: `TypeError` (invalid predicate), `RuntimeError` (execution failure)
 - **Example**:
 ```python
-a = groups.filter(lambda g: g.count() > 3)
+big_groups = groups.filter(lambda g: g.count() > 3)
 ```
 
 #### `NestedTable.derive`
-- **Signature**: `nested.derive(func: Callable[[GroupProxy], Dict[str, Expr]]) -> LTSeq`
-- **Behavior**: Derive group-level columns
+- **Signature**: `nested.derive(func: Callable[[GroupProxy], dict[str, Expr]]) -> LTSeq`
+- **Behavior**: Compute group-level values and **broadcast them to every row of the group**. The result keeps all original rows and columns, plus the new columns. (To collapse to one row per group, follow with `distinct()` on the derived columns or use `first()`/`last()`; for hash-style one-row-per-group aggregation see `agg()`/`group_by()` in Section 7)
 - **Parameters**: `func` returns a dict of group expressions
-- **Returns**: group-level `LTSeq`
-- **Exceptions**: `TypeError` (invalid func), `RuntimeError` (execution failure)
+- **Returns**: `LTSeq` with original rows plus broadcast group-level columns
+- **Exceptions**: `ValueError` (lambda doesn't return a dict), `RuntimeError` (execution failure)
 - **Example**:
 ```python
-spans = groups.derive(lambda g: {"start": g.first().date, "end": g.last().date})
+# Every row gets its group's size and span
+enriched = groups.derive(lambda g: {
+    "group_size": g.count(),
+    "start": g.first().date,
+    "end": g.last().date,
+})
 ```
 
-#### `GroupProxy` Common Aggregations
-- **Signature**: `g.count()`, `g.first()`, `g.last()`, `g.col.sum()`, `g.col.avg()`, `g.col.min()`, `g.col.max()`
-- **Behavior**: Aggregations or first/last within each group
-- **Parameters**: none (or column selection)
-- **Returns**: group-level expressions
-- **Exceptions**: `TypeError` (unsupported column type), `RuntimeError` (execution failure)
+#### `len(nested)` / `NestedTable.to_pandas`
+- **Signature**: `NestedTable.__len__() -> int`; `NestedTable.to_pandas()`
+- **Behavior**: `len()` returns the number of groups; `to_pandas()` materializes the flattened rows
 - **Example**:
 ```python
-groups.derive(lambda g: {"avg": g.price.avg(), "hi": g.price.max()})
+n_groups = len(groups)
 ```
 
-#### `GroupProxy.median`
-- **Signature**: `g.median(column: str) -> Any`
-- **Behavior**: Get the median value of a column in the group
-- **Parameters**: `column` column name
-- **Returns**: median value (or None if empty)
-- **Exceptions**: `TypeError` (non-numeric column)
+### Group Proxy (`g` inside NestedTable filter/derive)
+
+Group aggregations take the **column name as a string**; `first()`/`last()` return row proxies with attribute access.
+
+#### Aggregations: `g.count()`, `g.sum()`, `g.avg()`, `g.min()`, `g.max()`
+- **Signature**: `g.count() -> Expr`; `g.sum(column: str) -> Expr` (same for `avg`/`min`/`max`)
+- **Behavior**: Group size / aggregation over one column within each group
 - **Example**:
 ```python
-groups.derive(lambda g: {"med_price": g.median("price")})
+groups.derive(lambda g: {"avg_price": g.avg("price"), "hi": g.max("price")})
+groups.filter(lambda g: g.sum("amount") > 1000)
 ```
 
-#### `GroupProxy.percentile`
-- **Signature**: `g.percentile(column: str, p: float) -> Any`
-- **Behavior**: Get the p-th percentile value of a column in the group
-- **Parameters**: `column` column name; `p` percentile (0-1, e.g., 0.95 for 95th percentile)
-- **Returns**: percentile value (uses linear interpolation)
-- **Exceptions**: `ValueError` (p not in 0-1), `TypeError` (non-numeric column)
+#### Row access: `g.first()`, `g.last()`
+- **Signature**: `g.first() -> RowProxy`; `g.last() -> RowProxy`
+- **Behavior**: First/last row of the group; access columns as attributes
 - **Example**:
 ```python
-groups.derive(lambda g: {"p95": g.percentile("latency", 0.95)})
+groups.derive(lambda g: {"start": g.first().date, "end": g.last().date})
 ```
 
-#### `GroupProxy.variance` / `GroupProxy.var`
-- **Signature**: `g.variance(column: str) -> Any` or `g.var(column: str) -> Any`
-- **Behavior**: Get the sample variance of a column in the group
-- **Parameters**: `column` column name
-- **Returns**: sample variance (None if fewer than 2 values)
-- **Exceptions**: `TypeError` (non-numeric column)
+#### Quantifiers (filter only): `g.all()`, `g.any()`, `g.none()`
+- **Signature**: `g.all(predicate: Callable[[Row], Expr]) -> Expr` (same for `any`/`none`)
+- **Behavior**: True if the row-level predicate holds for ALL / AT LEAST ONE / NO rows of the group. Available in `NestedTable.filter`
+- **Parameters**: `predicate` row-level predicate (full row expression surface)
 - **Example**:
 ```python
-groups.derive(lambda g: {"price_var": g.variance("price")})
-```
-
-#### `GroupProxy.std` / `GroupProxy.stddev`
-- **Signature**: `g.std(column: str) -> Any` or `g.stddev(column: str) -> Any`
-- **Behavior**: Get the sample standard deviation of a column in the group
-- **Parameters**: `column` column name
-- **Returns**: sample standard deviation (None if fewer than 2 values)
-- **Exceptions**: `TypeError` (non-numeric column)
-- **Example**:
-```python
-groups.derive(lambda g: {"price_std": g.std("price")})
-```
-
-#### `GroupProxy.mode`
-- **Signature**: `g.mode(column: str) -> Any`
-- **Behavior**: Get the most frequent value (mode) of a column in the group
-- **Parameters**: `column` column name
-- **Returns**: most frequent value (one of the modes if multiple)
-- **Exceptions**: none
-- **Example**:
-```python
-groups.derive(lambda g: {"common_category": g.mode("category")})
-```
-
-#### `GroupProxy.top_k`
-- **Signature**: `g.top_k(column: str, k: int) -> List[Any]`
-- **Behavior**: Get the top K values from a column in the group (sorted descending)
-- **Parameters**: `column` column name; `k` number of values
-- **Returns**: list of top K values
-- **Exceptions**: `ValueError` (k <= 0)
-- **Example**:
-```python
-groups.derive(lambda g: {"top_3_prices": g.top_k("price", 3)})
-```
-
-#### `GroupProxy.all`
-- **Signature**: `g.all(predicate: Callable[[Row], Expr]) -> Expr`
-- **Behavior**: Returns True if predicate holds for ALL rows in the group
-- **Parameters**: `predicate` row-level predicate function
-- **Returns**: boolean expression
-- **Exceptions**: `TypeError` (invalid predicate), `RuntimeError` (execution failure)
-- **Example**:
-```python
-# Filter groups where ALL rows have positive amounts
+# Groups where all amounts are positive
 groups.filter(lambda g: g.all(lambda r: r.amount > 0))
 
-# Derive a flag for groups where all items are in stock
-groups.derive(lambda g: {"all_in_stock": g.all(lambda r: r.quantity > 0)})
-```
-
-#### `GroupProxy.any`
-- **Signature**: `g.any(predicate: Callable[[Row], Expr]) -> Expr`
-- **Behavior**: Returns True if predicate holds for AT LEAST ONE row in the group
-- **Parameters**: `predicate` row-level predicate function
-- **Returns**: boolean expression
-- **Exceptions**: `TypeError` (invalid predicate), `RuntimeError` (execution failure)
-- **Example**:
-```python
-# Filter groups where ANY row has an error
+# Groups containing at least one error
 groups.filter(lambda g: g.any(lambda r: r.status == "error"))
 
-# Derive a flag for groups containing VIP customers
-groups.derive(lambda g: {"has_vip": g.any(lambda r: r.is_vip == True)})
-```
-
-#### `GroupProxy.none`
-- **Signature**: `g.none(predicate: Callable[[Row], Expr]) -> Expr`
-- **Behavior**: Returns True if predicate holds for NO rows in the group (equivalent to `not any`)
-- **Parameters**: `predicate` row-level predicate function
-- **Returns**: boolean expression
-- **Exceptions**: `TypeError` (invalid predicate), `RuntimeError` (execution failure)
-- **Example**:
-```python
-# Filter groups where NO rows are marked as deleted
+# Groups with no deleted rows
 groups.filter(lambda g: g.none(lambda r: r.is_deleted == True))
-
-# Derive a flag for groups with no null values
-groups.derive(lambda g: {"complete": g.none(lambda r: r.value.is_null())})
-```
-
-#### `GroupProxy.count_if`
-- **Signature**: `g.count_if(predicate: Callable[[Row], bool]) -> int`
-- **Behavior**: Count rows in the group where predicate is True
-- **Parameters**: `predicate` row-level predicate function
-- **Returns**: integer count
-- **Exceptions**: `TypeError` (invalid predicate)
-- **Example**:
-```python
-groups.derive(lambda g: {"high_value_count": g.count_if(lambda r: r.price > 100)})
-```
-
-#### `GroupProxy.sum_if`
-- **Signature**: `g.sum_if(predicate: Callable[[Row], bool], column: str) -> Any`
-- **Behavior**: Sum column values in the group where predicate is True
-- **Parameters**: `predicate` row-level predicate function; `column` column name to sum
-- **Returns**: sum of matching values
-- **Exceptions**: `TypeError` (invalid predicate or non-numeric column)
-- **Example**:
-```python
-groups.derive(lambda g: {"vip_sales": g.sum_if(lambda r: r.is_vip, "amount")})
-```
-
-#### `GroupProxy.avg_if`
-- **Signature**: `g.avg_if(predicate: Callable[[Row], bool], column: str) -> Any`
-- **Behavior**: Average column values in the group where predicate is True
-- **Parameters**: `predicate` row-level predicate function; `column` column name to average
-- **Returns**: average of matching values (None if no matches)
-- **Exceptions**: `TypeError` (invalid predicate or non-numeric column)
-- **Example**:
-```python
-groups.derive(lambda g: {"active_avg_score": g.avg_if(lambda r: r.status == "active", "score")})
-```
-
-#### `GroupProxy.min_if`
-- **Signature**: `g.min_if(predicate: Callable[[Row], bool], column: str) -> Any`
-- **Behavior**: Minimum column value in the group where predicate is True
-- **Parameters**: `predicate` row-level predicate function; `column` column name
-- **Returns**: minimum of matching values (None if no matches)
-- **Exceptions**: `TypeError` (invalid predicate)
-- **Example**:
-```python
-groups.derive(lambda g: {"min_valid_price": g.min_if(lambda r: r.is_valid, "price")})
-```
-
-#### `GroupProxy.max_if`
-- **Signature**: `g.max_if(predicate: Callable[[Row], bool], column: str) -> Any`
-- **Behavior**: Maximum column value in the group where predicate is True
-- **Parameters**: `predicate` row-level predicate function; `column` column name
-- **Returns**: maximum of matching values (None if no matches)
-- **Exceptions**: `TypeError` (invalid predicate)
-- **Example**:
-```python
-groups.derive(lambda g: {"max_valid_price": g.max_if(lambda r: r.is_valid, "price")})
 ```
 
 ## 5. Set Algebra
 
 ### `LTSeq.union`
 - **Signature**: `LTSeq.union(other: LTSeq) -> LTSeq`
-- **Behavior**: Vertical concatenation (similar to SQL UNION ALL)
+- **Behavior**: Vertical concatenation, **keeping duplicates** (SQL UNION ALL semantics)
 - **Parameters**: `other` another LTSeq with same schema
 - **Returns**: combined `LTSeq`
 - **Exceptions**: `TypeError` (other is not LTSeq), `ValueError` (schema mismatch)
@@ -784,7 +874,7 @@ combined = t1.union(t2)
 ```
 
 ### `LTSeq.intersect`
-- **Signature**: `LTSeq.intersect(other: LTSeq, on: Optional[Callable] = None) -> LTSeq`
+- **Signature**: `LTSeq.intersect(other: LTSeq, on: Callable | None = None) -> LTSeq`
 - **Behavior**: Intersection of two tables
 - **Parameters**: `other` another table; `on` key selector (None means all columns)
 - **Returns**: intersection `LTSeq`
@@ -795,7 +885,7 @@ common = t1.intersect(t2, on=lambda r: r.id)
 ```
 
 ### `LTSeq.except_` (set difference)
-- **Signature**: `LTSeq.except_(other: LTSeq, on: Optional[Callable] = None) -> LTSeq`
+- **Signature**: `LTSeq.except_(other: LTSeq, on: Callable | None = None) -> LTSeq`
 - **Behavior**: Rows in left table but not in right table (SQL EXCEPT semantics)
 - **Parameters**: `other` another table; `on` key selector
 - **Returns**: difference `LTSeq`
@@ -808,8 +898,18 @@ only_left = t1.except_(t2, on=lambda r: r.id)
 
 > Note: `Expr.diff()` (row-level differences, Section 3) is unrelated to table set difference. Use `except_()` for table set difference.
 
+### `LTSeq.xunion` (symmetric difference)
+- **Signature**: `LTSeq.xunion(other: LTSeq, on: Callable | None = None) -> LTSeq`
+- **Behavior**: Rows in either table but not in both; equivalent to `(a except b) union (b except a)`
+- **Parameters**: `other` another table; `on` key selector (None means all columns)
+- **Returns**: symmetric difference `LTSeq`
+- **Example**:
+```python
+unique_to_either = t1.xunion(t2, on=lambda r: r.id)
+```
+
 ### `LTSeq.is_subset`
-- **Signature**: `LTSeq.is_subset(other: LTSeq, on: Optional[Callable] = None) -> bool`
+- **Signature**: `LTSeq.is_subset(other: LTSeq, on: Callable | None = None) -> bool`
 - **Behavior**: Check if this table is a subset of another
 - **Parameters**: `other` another table; `on` key selector
 - **Returns**: `bool`
@@ -819,50 +919,52 @@ only_left = t1.except_(t2, on=lambda r: r.id)
 flag = t_small.is_subset(t_big, on=lambda r: r.id)
 ```
 
+### `LTSeq.contain`
+- **Signature**: `LTSeq.contain(key_col: str, *values) -> bool`
+- **Behavior**: Check if **all** given values are present in the column
+- **Parameters**: `key_col` column name; `values` values to look for
+- **Returns**: `bool` (True if all values found; True for empty values)
+- **Exceptions**: `AttributeError` (column not found)
+- **Example**:
+```python
+t.contain("status", "active", "pending")
+t.contain("id", 1, 2, 3)
+```
+
 ## 6. Association and Joins
 
 ### `LTSeq.join`
-- **Signature**: `LTSeq.join(other: LTSeq, on: Callable, how: str = "inner") -> LTSeq`
-- **Behavior**: Standard hash join; no sorting required
-- **Parameters**: `other` other table; `on` join condition; `how` in {inner,left,right,full}
-- **Returns**: joined `LTSeq` (conflicting columns get a suffix)
-- **Exceptions**: `TypeError` (invalid other/on), `ValueError` (invalid how or schema not initialized)
+- **Signature**: `LTSeq.join(other: LTSeq, on: Callable, how: str = "inner", strategy: str | None = None) -> LTSeq`
+- **Behavior**: Join two tables. Default is a hash join (no sorting required); `strategy="merge"` performs a merge join on pre-sorted inputs and validates sort order. Conflicting right-table column names are prefixed with `_other_` (e.g. `product` → `_other_product`)
+- **Parameters**: `other` other table; `on` join condition lambda (e.g. `lambda a, b: a.id == b.id`); `how` in {inner,left,right,full}; `strategy` in {None,"hash","merge"}
+- **Returns**: joined `LTSeq`
+- **Exceptions**: `TypeError` (invalid other/on), `ValueError` (invalid how/strategy, or unsorted inputs for merge)
 - **Example**:
 ```python
 joined = users.join(orders, on=lambda u, o: u.id == o.user_id, how="left")
-```
 
-### Merge Join Strategy
-- **Signature**: `LTSeq.join(other: LTSeq, on: Callable, how: str = "inner", strategy: str = "hash") -> LTSeq`
-- **Behavior**: Use `strategy="merge"` to perform a merge join on sorted inputs
-- **Parameters**: `other` other table; `on` join condition; `how` in {inner,left,right,full}; `strategy` in {hash,merge}
-- **Returns**: joined `LTSeq`
-- **Exceptions**: `TypeError` (invalid other/on), `ValueError` (unsupported strategy or unsorted inputs for merge)
-- **Example**:
-```python
-t1_sorted = t1.sort("id")
-t2_sorted = t2.sort("id")
-result = t1_sorted.join(
-    t2_sorted,
+# Merge join on pre-sorted tables
+result = t1.sort("id").join(
+    t2.sort("id"),
     on=lambda a, b: a.id == b.id,
     strategy="merge",
 )
 ```
 
 ### `LTSeq.asof_join`
-- **Signature**: `LTSeq.asof_join(other: LTSeq, on: Callable, direction: str = "backward") -> LTSeq`
-- **Behavior**: As-of join for nearest time match
-- **Parameters**: `other` other table; `on` join condition; `direction` in {"backward","forward","nearest"}
+- **Signature**: `LTSeq.asof_join(other: LTSeq, on: Callable, direction: str = "backward", is_sorted: bool = False) -> LTSeq`
+- **Behavior**: As-of join for nearest time match. `is_sorted=True` skips sort verification when both inputs are known to be sorted (faster)
+- **Parameters**: `other` other table; `on` join condition (e.g. `lambda t, q: t.time >= q.time`); `direction` in {"backward","forward","nearest"}; `is_sorted` skip sort check
 - **Returns**: as-of joined `LTSeq`
-- **Exceptions**: `TypeError` (invalid other/on), `ValueError` (invalid direction or unsorted)
+- **Exceptions**: `TypeError` (invalid other/on), `ValueError` (invalid direction)
 - **Example**:
 ```python
-quotes = trades.asof_join(quotes, on=lambda t, q: t.time >= q.time, direction="backward")
+result = trades.asof_join(quotes, on=lambda t, q: t.time >= q.time, direction="backward")
 ```
 
 ### `LTSeq.semi_join`
 - **Signature**: `LTSeq.semi_join(other: LTSeq, on: Callable) -> LTSeq`
-- **Behavior**: Return rows from left table where keys exist in right table. Returns only left table columns with no duplicates from multiple matches.
+- **Behavior**: Return rows from left table where keys exist in right table. Returns only left table columns with no duplicates from multiple matches
 - **Parameters**: `other` right table to match against; `on` join condition lambda
 - **Returns**: `LTSeq` with matching rows from left table
 - **Exceptions**: `TypeError` (invalid other/on), `ValueError` (schema not initialized)
@@ -874,7 +976,7 @@ active_users = users.semi_join(orders, on=lambda u, o: u.id == o.user_id)
 
 ### `LTSeq.anti_join`
 - **Signature**: `LTSeq.anti_join(other: LTSeq, on: Callable) -> LTSeq`
-- **Behavior**: Return rows from left table where keys do NOT exist in right table. Returns only left table columns.
+- **Behavior**: Return rows from left table where keys do NOT exist in right table. Returns only left table columns
 - **Parameters**: `other` right table to match against; `on` join condition lambda
 - **Returns**: `LTSeq` with non-matching rows from left table
 - **Exceptions**: `TypeError` (invalid other/on), `ValueError` (schema not initialized)
@@ -886,9 +988,9 @@ inactive_users = users.anti_join(orders, on=lambda u, o: u.id == o.user_id)
 
 ### `LTSeq.link`
 - **Signature**: `LTSeq.link(target_table: LTSeq, on: Callable, as_: str, join_type: str = "inner") -> LinkedTable`
-- **Behavior**: Pointer-style association; not materialized; access via alias
-- **Parameters**: `target_table` target table; `on` join condition; `as_` alias; `join_type` join type
-- **Returns**: `LinkedTable` (can be used like LTSeq)
+- **Behavior**: Pointer-style association; not materialized until needed; access target columns via the alias
+- **Parameters**: `target_table` target table; `on` join condition; `as_` alias; `join_type` in {inner,left,right,full}
+- **Returns**: `LinkedTable`
 - **Exceptions**: `TypeError` (invalid on), `ValueError` (invalid join_type or schema not initialized)
 - **Example**:
 ```python
@@ -896,15 +998,31 @@ linked = orders.link(products, on=lambda o, p: o.product_id == p.id, as_="prod")
 result = linked.select(lambda r: [r.id, r.prod.name, r.prod.price])
 ```
 
-### `LTSeq.lookup` (table-level addressization)
-- **Signature**: `LTSeq.lookup(dim_table: LTSeq, on: Callable, as_: str) -> LTSeq`
-- **Behavior**: Load dim table into memory and build a direct index for fast lookups
-- **Parameters**: `dim_table` dimension table; `on` join condition; `as_` alias
-- **Returns**: `LTSeq` with internal pointers/indexes
-- **Exceptions**: `MemoryError`/`RuntimeError` (dim table too large or build failure), `TypeError` (invalid params)
+### `LinkedTable`
+- **Behavior**: Chainable view over a linked pair of tables. Supports `select`, `filter`, `derive`, `sort`, `slice`, `distinct`, `show`, and further `link` calls (multi-hop chains). Materializes via the underlying join only when required
 - **Example**:
 ```python
-fact = orders.lookup(products, on=lambda o, p: o.product_id == p.id, as_="prod")
+linked = orders.link(products, on=lambda o, p: o.product_id == p.id, as_="prod")
+cheap = linked.filter(lambda r: r.prod.price < 10)
+chained = linked.link(categories, on=lambda o, c: o.category_id == c.id, as_="cat")
+```
+
+See `docs/LINKING_GUIDE.md` for the full linking guide.
+
+### `r.col.lookup` (expression-level lookup)
+- **Signature**: `r.col.lookup(target_table: LTSeq, column: str, join_key: str | None = None) -> Expr`
+- **Behavior**: Lightweight lookup inside expressions, returning a single column value from a related table. Works on any expression (column or transformed value). Resolved via a join during `derive()`
+- **Parameters**: `target_table` target table; `column` output column; `join_key` join key in target table (optional)
+- **Returns**: lookup expression
+- **Exceptions**: `TypeError` (invalid params), `RuntimeError` (execution failure)
+- **Example**:
+```python
+enriched = orders.derive(product_name=lambda r: r.product_id.lookup(products, "name"))
+
+# Lookup on a transformed key
+enriched = orders.derive(
+    product_name=lambda r: r.product_id.lower().lookup(products, "name")
+)
 ```
 
 ### Join Strategy Summary
@@ -916,48 +1034,111 @@ fact = orders.lookup(products, on=lambda o, p: o.product_id == p.id, as_="prod")
 | `semi_join` | Filter by key existence | Hash Semi-Join | `WHERE EXISTS` |
 | `anti_join` | Filter by key non-existence | Hash Anti-Join | `WHERE NOT EXISTS` |
 | `link` | Fact-to-dimension pointer access | Pointer | `LEFT JOIN` (lazy) |
-| `lookup` | Fact + small dimension in memory | Direct Address | `LEFT JOIN` (indexed) |
+| `r.col.lookup(...)` | Fetch one column from a dimension table | Join during derive | `LEFT JOIN` (single column) |
 | `asof_join` | Financial time series | Ordered Search | `LATERAL JOIN` |
 
 ## 7. Aggregation, Partitioning, Pivot
 
-### `LTSeq.agg`
-- **Signature**: `LTSeq.agg(by: Optional[Callable] = None, **aggs: Callable[[GroupProxy], Expr]) -> LTSeq`
-- **Behavior**: Grouped aggregation (or full-table aggregation); one row per group
-- **Parameters**: `by` grouping key (single column or list); `aggs` aggregation expressions
-- **Returns**: aggregated `LTSeq`
-- **Exceptions**: `ValueError` (schema not initialized), `TypeError` (invalid expressions)
+### `LTSeq.group_by` (chain style)
+- **Signature**: `LTSeq.group_by(key: str | Callable) -> GroupBy`; `GroupBy.agg(**aggregations: Callable) -> LTSeq`
+- **Behavior**: Polars/pandas-style two-step grouped aggregation. `key` may be a column name string or a lambda; `agg` produces one row per group
+- **Parameters**: `key` grouping key; `aggregations` named aggregation lambdas
+- **Returns**: `GroupBy` intermediate, then aggregated `LTSeq`
+- **Exceptions**: `TypeError` (invalid key), `AttributeError` (column not found), `ValueError` (no aggregations)
 - **Example**:
 ```python
-summary = t.agg(by=lambda r: r.region, total=lambda r: r.sales.sum())
+summary = t.group_by("region").agg(
+    total=lambda g: g.sales.sum(),
+    avg_price=lambda g: g.price.avg(),
+)
+
+# Expression grouping key
+summary = t.group_by(lambda r: r.date.dt.year()).agg(n=lambda g: g.id.count())
 ```
 
-### `top_k` (aggregate function)
-- **Signature**: `top_k(col: Union[Expr, Callable], k: int) -> List[Value]`
-- **Behavior**: Return Top-K of a column (aggregate semantics)
-- **Parameters**: `col` target column (expression or callable); `k` Top count
-- **Returns**: Top-K list
-- **Exceptions**: `ValueError` (k <= 0), `TypeError` (invalid col)
+### `LTSeq.agg`
+- **Signature**: `LTSeq.agg(by: Callable | None = None, **aggs: Callable) -> LTSeq`
+- **Behavior**: Grouped aggregation (or full-table aggregation when `by=None`); one row per group. `by` must be a lambda (for string column names use `group_by`)
+- **Parameters**: `by` grouping key lambda; `aggs` aggregation expressions
+- **Returns**: aggregated `LTSeq`
+- **Exceptions**: `ValueError` (schema not initialized or no aggregations), `TypeError` (by/aggregation not callable)
 - **Example**:
 ```python
-# Used inside agg
-result = t.agg(top_prices=lambda r: top_k(r.price, 5))
+summary = t.agg(by=lambda r: r.region, total=lambda g: g.sales.sum())
+
+# Full-table aggregation
+total = t.agg(total=lambda g: g.sales.sum())
+```
+
+### Aggregate column methods (inside `agg` / `group_by().agg()` lambdas)
+- **Signature**: `g.col.sum() / .avg() / .count() / .min() / .max() / .median() / .var() / .variance() / .std() / .stddev() / .percentile(p)`
+- **Behavior**: Column aggregations available in aggregation context. `var`/`variance` is sample variance; `std`/`stddev` is sample standard deviation; `percentile(p)` takes `p` in 0–1 (approximate percentile)
+- **Example**:
+```python
+stats = t.group_by("region").agg(
+    total=lambda g: g.sales.sum(),
+    med=lambda g: g.sales.median(),
+    sd=lambda g: g.sales.std(),
+    p95=lambda g: g.latency.percentile(0.95),
+    n=lambda g: g.id.count(),
+)
+```
+
+### Conditional aggregation functions
+- **Signature**: `count_if(predicate: Expr)`, `sum_if(predicate: Expr, column: Expr)`, `avg_if(...)`, `min_if(...)`, `max_if(...)`
+- **Behavior**: Aggregate only rows where the predicate holds. Used inside `agg`/`group_by().agg()` lambdas
+- **Import**: `from ltseq import count_if, sum_if, avg_if, min_if, max_if`
+- **Example**:
+```python
+from ltseq import count_if, sum_if
+
+result = t.group_by("region").agg(
+    high_count=lambda g: count_if(g.price > 100),
+    high_sales=lambda g: sum_if(g.price > 100, g.quantity),
+)
+```
+
+### Statistical aggregation functions
+- **Signature**: `skew(col: Expr)`, `corr(a: Expr, b: Expr)`, `covar(a: Expr, b: Expr)`, `concat_agg(col: Expr, delimiter: str = ",")`
+- **Behavior**: Skewness, Pearson correlation, sample covariance, and string concatenation aggregation. Used inside `agg`/`group_by().agg()` lambdas
+- **Import**: `from ltseq import skew, corr, covar, concat_agg`
+- **Example**:
+```python
+from ltseq import corr, concat_agg
+
+result = t.group_by("region").agg(
+    price_qty_corr=lambda g: corr(g.price, g.quantity),
+    names=lambda g: concat_agg(g.name, delimiter="|"),
+)
 ```
 
 ### `LTSeq.partition`
 - **Signature**: `LTSeq.partition(*cols: str) -> PartitionedTable` or `LTSeq.partition(by: Callable) -> PartitionedTable`
-- **Behavior**: Split into sub-tables by key (no aggregation)
-- **Parameters**: column names or lambda
-- **Returns**: `PartitionedTable` (key -> LTSeq)
+- **Behavior**: Split into sub-tables by key (no aggregation). String columns use a fast SQL path; a callable uses the flexible Python path
+- **Parameters**: column name(s), a single callable, or `by=` callable
+- **Returns**: `PartitionedTable` (dict-like: key → LTSeq)
 - **Exceptions**: `TypeError` (invalid params), `AttributeError` (column not found), `ValueError` (schema not initialized)
 - **Example**:
 ```python
 parts = t.partition("region")
 west = parts["West"]
+
+parts = t.partition("year", "region")       # multiple columns
+parts = t.partition(by=lambda r: r.region)  # lambda key
+```
+
+### `PartitionedTable`
+- **Behavior**: Dict-like container of partitions. Supports `parts[key]`, iteration, `keys()`, `values()`, `items()`, `map(fn)` (apply a function to every partition), and `to_list()`
+- **Example**:
+```python
+for key, sub in parts.items():
+    print(key, len(sub))
+
+filtered = parts.map(lambda sub: sub.filter(lambda r: r.amount > 0))
 ```
 
 ### `LTSeq.pivot`
-- **Signature**: `LTSeq.pivot(index: Union[str, List[str]], columns: str, values: str, agg_fn: str = "sum") -> LTSeq`
+- **Signature**: `LTSeq.pivot(index: str | list[str], columns: str, values: str, agg_fn: str = "sum") -> LTSeq`
 - **Behavior**: Pivot from long to wide
 - **Parameters**:
   - `index` row index column(s)
@@ -989,44 +1170,77 @@ expr = (r.price * r.qty) > 100
 - **Behavior**: Conditional expression (SQL CASE WHEN)
 - **Parameters**: `condition`, `true_value`, `false_value`
 - **Returns**: expression
+- **Import**: `from ltseq import if_else`
 - **Exceptions**: `TypeError` (condition not boolean)
 - **Example**:
 ```python
-from ltseq.expr import if_else
+from ltseq import if_else
 status = if_else(r.amount > 100, "VIP", "Normal")
 ```
 
-### `r.col.fill_null`
+### `ifa` / `nvl` / `coalesce`
+- **Signature**: `ifa(cond: Expr, value: Expr) -> Expr`; `nvl(x: Expr, default: Expr) -> Expr`; `coalesce(*args: Expr) -> Expr`
+- **Behavior**: `ifa(cond, v)` = `if_else(cond, v, NULL)`; `nvl(x, d)` = `coalesce(x, d)`; `coalesce` returns the first non-NULL argument
+- **Import**: `from ltseq import ifa, nvl, coalesce`
+- **Example**:
+```python
+from ltseq import nvl, coalesce
+t.derive(price2=lambda r: nvl(r.price, 0))
+t.derive(contact=lambda r: coalesce(r.mobile, r.phone, r.email))
+```
+
+### Null / membership / type helpers (`Expr` methods)
+
+#### `r.col.fill_null`
 - **Signature**: `r.col.fill_null(default: Any) -> Expr`
 - **Behavior**: NULL fill (SQL COALESCE)
-- **Parameters**: `default` fallback value
-- **Returns**: expression
-- **Exceptions**: `TypeError` (incompatible default type)
 - **Example**:
 ```python
 safe_price = r.price.fill_null(0)
 ```
 
-### `r.col.is_null`
-- **Signature**: `r.col.is_null() -> Expr`
-- **Behavior**: NULL check
-- **Parameters**: none
-- **Returns**: boolean expression
-- **Exceptions**: none (may fail at execution for unsupported types)
+#### `r.col.is_null` / `r.col.is_not_null`
+- **Signature**: `r.col.is_null() -> Expr`; `r.col.is_not_null() -> Expr`
+- **Behavior**: NULL / NOT NULL check
 - **Example**:
 ```python
 missing = t.filter(lambda r: r.email.is_null())
+valid = t.filter(lambda r: r.email.is_not_null())
 ```
 
-### `r.col.is_not_null`
-- **Signature**: `r.col.is_not_null() -> Expr`
-- **Behavior**: NOT NULL check
-- **Parameters**: none
-- **Returns**: boolean expression
-- **Exceptions**: none (may fail at execution for unsupported types)
+#### `r.col.is_in`
+- **Signature**: `r.col.is_in(values: list[Any]) -> Expr`
+- **Behavior**: Membership check (SQL `IN`)
 - **Example**:
 ```python
-valid = t.filter(lambda r: r.email.is_not_null())
+t.filter(lambda r: r.status.is_in(["active", "pending", "review"]))
+```
+
+#### `r.col.between`
+- **Signature**: `r.col.between(low: Any, high: Any) -> Expr`
+- **Behavior**: Inclusive range check, equivalent to `(x >= low) & (x <= high)`
+- **Example**:
+```python
+t.filter(lambda r: r.price.between(10, 100))
+```
+
+#### `r.col.cast`
+- **Signature**: `r.col.cast(dtype: str) -> Expr`
+- **Behavior**: Cast to another type. Supported: `"int32"`, `"int64"`, `"float32"`, `"float64"`, `"utf8"`/`"string"`, `"bool"`, `"date32"`, `"timestamp"`
+- **Example**:
+```python
+t.derive(amount=lambda r: r.amount_str.cast("float64"))
+```
+
+#### `r.col.abs` / `r.col.round` / `r.col.floor` / `r.col.ceil`
+- **Signature**: `r.col.abs() -> Expr`; `r.col.round(decimals: int = 0) -> Expr`; `r.col.floor() -> Expr`; `r.col.ceil() -> Expr`
+- **Behavior**: Numeric rounding helpers
+- **Example**:
+```python
+t.derive(
+    abs_change=lambda r: (r.price - r.prev).abs(),
+    rounded=lambda r: r.score.round(2),
+)
 ```
 
 ### String Operations (`r.col.s.*`)
@@ -1034,64 +1248,32 @@ valid = t.filter(lambda r: r.email.is_not_null())
 #### `contains`
 - **Signature**: `r.col.s.contains(pattern: str) -> Expr`
 - **Behavior**: substring containment
-- **Parameters**: `pattern` substring
-- **Returns**: boolean expression
-- **Exceptions**: `TypeError` (non-string column)
 - **Example**:
 ```python
 gmail = t.filter(lambda r: r.email.s.contains("gmail"))
 ```
 
-#### `starts_with`
-- **Signature**: `r.col.s.starts_with(prefix: str) -> Expr`
-- **Behavior**: prefix match
-- **Parameters**: `prefix` prefix string
-- **Returns**: boolean expression
-- **Exceptions**: `TypeError` (non-string column)
+#### `starts_with` / `ends_with`
+- **Signature**: `r.col.s.starts_with(prefix: str) -> Expr`; `r.col.s.ends_with(suffix: str) -> Expr`
+- **Behavior**: prefix / suffix match
 - **Example**:
 ```python
 orders = t.filter(lambda r: r.code.s.starts_with("ORD"))
-```
-
-#### `ends_with`
-- **Signature**: `r.col.s.ends_with(suffix: str) -> Expr`
-- **Behavior**: suffix match
-- **Parameters**: `suffix` suffix string
-- **Returns**: boolean expression
-- **Exceptions**: `TypeError` (non-string column)
-- **Example**:
-```python
 pdfs = t.filter(lambda r: r.filename.s.ends_with(".pdf"))
 ```
 
-#### `lower`
-- **Signature**: `r.col.s.lower() -> Expr`
-- **Behavior**: lowercase
-- **Parameters**: none
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string column)
+#### `lower` / `upper`
+- **Signature**: `r.col.s.lower() -> Expr`; `r.col.s.upper() -> Expr`
+- **Behavior**: case conversion
 - **Example**:
 ```python
 normalized = t.derive(email_lower=lambda r: r.email.s.lower())
 ```
 
-#### `upper`
-- **Signature**: `r.col.s.upper() -> Expr`
-- **Behavior**: uppercase
-- **Parameters**: none
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string column)
-- **Example**:
-```python
-normalized = t.derive(email_upper=lambda r: r.email.s.upper())
-```
-
-#### `strip`
-- **Signature**: `r.col.s.strip() -> Expr`
-- **Behavior**: trim whitespace
-- **Parameters**: none
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string column)
+#### `strip` / `lstrip` / `rstrip`
+- **Signature**: `r.col.s.strip() -> Expr`; `r.col.s.lstrip() -> Expr`; `r.col.s.rstrip() -> Expr`
+- **Behavior**: trim whitespace (both sides / left only / right only)
+- **SQL Equivalent**: `TRIM` / `LTRIM` / `RTRIM`
 - **Example**:
 ```python
 clean = t.derive(name_clean=lambda r: r.name.s.strip())
@@ -1100,9 +1282,6 @@ clean = t.derive(name_clean=lambda r: r.name.s.strip())
 #### `len`
 - **Signature**: `r.col.s.len() -> Expr`
 - **Behavior**: string length
-- **Parameters**: none
-- **Returns**: integer expression
-- **Exceptions**: `TypeError` (non-string column)
 - **Example**:
 ```python
 long_names = t.filter(lambda r: r.name.s.len() > 50)
@@ -1112,8 +1291,6 @@ long_names = t.filter(lambda r: r.name.s.len() > 50)
 - **Signature**: `r.col.s.slice(start: int, length: int) -> Expr`
 - **Behavior**: substring slicing
 - **Parameters**: `start` start index (0-based); `length` length
-- **Returns**: string expression
-- **Exceptions**: `ValueError` (invalid start/length), `TypeError` (non-string column)
 - **Example**:
 ```python
 year = t.derive(year=lambda r: r.date.s.slice(0, 4))
@@ -1122,20 +1299,23 @@ year = t.derive(year=lambda r: r.date.s.slice(0, 4))
 #### `regex_match`
 - **Signature**: `r.col.s.regex_match(pattern: str) -> Expr`
 - **Behavior**: regex match (boolean)
-- **Parameters**: `pattern` regex
-- **Returns**: boolean expression
-- **Exceptions**: `ValueError` (invalid regex), `TypeError` (non-string column)
+- **Exceptions**: `ValueError` (invalid regex)
 - **Example**:
 ```python
 valid = t.filter(lambda r: r.email.s.regex_match(r"^[a-z]+@"))
 ```
 
+#### `like`
+- **Signature**: `r.col.s.like(pattern: str) -> Expr`
+- **Behavior**: SQL LIKE pattern match (`%` any chars, `_` one char)
+- **Example**:
+```python
+t.filter(lambda r: r.code.s.like("ORD-%"))
+```
+
 #### `replace`
 - **Signature**: `r.col.s.replace(old: str, new: str) -> Expr`
 - **Behavior**: Replace all occurrences of a substring with another string
-- **Parameters**: `old` substring to find; `new` replacement string
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string column)
 - **Example**:
 ```python
 clean = t.derive(clean_name=lambda r: r.name.s.replace("-", "_"))
@@ -1144,146 +1324,73 @@ clean = t.derive(clean_name=lambda r: r.name.s.replace("-", "_"))
 #### `concat`
 - **Signature**: `r.col.s.concat(*others) -> Expr`
 - **Behavior**: Concatenate this string with other strings or column expressions
-- **Parameters**: `others` strings or column expressions to concatenate
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string arguments)
 - **Example**:
 ```python
-# Concatenate with literal string
 greeting = t.derive(msg=lambda r: r.name.s.concat(" says hello"))
-
-# Concatenate multiple columns
 full = t.derive(full_name=lambda r: r.first.s.concat(" ", r.last))
 ```
 
-#### `pad_left`
-- **Signature**: `r.col.s.pad_left(width: int, char: str = " ") -> Expr`
-- **Behavior**: Pad string on the left to reach specified width. Note: truncates if string is longer than width (SQL LPAD behavior).
-- **Parameters**: `width` target width; `char` padding character (default: space)
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string column), `ValueError` (invalid width)
+#### `pad_left` / `pad_right`
+- **Signature**: `r.col.s.pad_left(width: int, char: str = " ") -> Expr`; `r.col.s.pad_right(width: int, char: str = " ") -> Expr`
+- **Behavior**: Pad to the given width. Note: truncates if the string is longer than width (SQL LPAD/RPAD behavior)
 - **Example**:
 ```python
-# Zero-pad IDs to 5 characters
 padded = t.derive(padded_id=lambda r: r.id.s.pad_left(5, "0"))
-```
-
-#### `pad_right`
-- **Signature**: `r.col.s.pad_right(width: int, char: str = " ") -> Expr`
-- **Behavior**: Pad string on the right to reach specified width. Note: truncates if string is longer than width (SQL RPAD behavior).
-- **Parameters**: `width` target width; `char` padding character (default: space)
-- **Returns**: string expression
-- **Exceptions**: `TypeError` (non-string column), `ValueError` (invalid width)
-- **Example**:
-```python
-# Pad names with dots to 20 characters
-padded = t.derive(padded_name=lambda r: r.name.s.pad_right(20, "."))
 ```
 
 #### `split`
 - **Signature**: `r.col.s.split(delimiter: str, index: int) -> Expr`
-- **Behavior**: Split string by delimiter and return the part at specified index. Index is 1-based (1 = first part) to match SQL SPLIT_PART convention.
-- **Parameters**: `delimiter` string to split on; `index` 1-based index of part to return
-- **Returns**: string expression (empty string if index out of range)
-- **Exceptions**: `TypeError` (non-string column), `ValueError` (index <= 0)
+- **Behavior**: Split string by delimiter and return the part at the specified index. Index is **1-based** (1 = first part) to match SQL SPLIT_PART. Returns empty string if index is out of range
+- **Exceptions**: `ValueError` (index <= 0)
 - **Example**:
 ```python
 # Get domain from email "user@example.com"
 domain = t.derive(domain=lambda r: r.email.s.split("@", 2))
-
-# Get first name from "first.last" format
-first = t.derive(first_name=lambda r: r.username.s.split(".", 1))
 ```
 
 #### `pos`
 - **Signature**: `r.col.s.pos(sub: str) -> Expr`
-- **Behavior**: Returns the 1-based position of the first occurrence of `sub`; returns 0 if not found
-- **Parameters**: `sub` substring to search for
-- **Returns**: integer expression
+- **Behavior**: Returns the **1-based** position of the first occurrence of `sub`; returns 0 if not found
 - **SQL Equivalent**: `STRPOS(col, sub)`
-- **SPL Equivalent**: `pos(s, sub)`
-- **Exceptions**: `TypeError` (non-string column)
 - **Example**:
 ```python
 at_pos = t.derive(pos=lambda r: r.email.s.pos("@"))  # "user@example" → 5
 ```
 
-#### `left`
-- **Signature**: `r.col.s.left(n: int) -> Expr`
-- **Behavior**: Returns the leftmost `n` characters; returns the full string if `n` exceeds its length
-- **Parameters**: `n` character count
-- **Returns**: string expression
-- **SQL Equivalent**: `LEFT(col, n)`
-- **SPL Equivalent**: `left(s, n)`
-- **Exceptions**: `TypeError` (non-string column)
+#### `left` / `right`
+- **Signature**: `r.col.s.left(n: int) -> Expr`; `r.col.s.right(n: int) -> Expr`
+- **Behavior**: Leftmost / rightmost `n` characters; returns the full string if `n` exceeds its length
+- **SQL Equivalent**: `LEFT(col, n)` / `RIGHT(col, n)`
 - **Example**:
 ```python
-prefix = t.derive(pfx=lambda r: r.code.s.left(3))  # "ABC123" → "ABC"
-```
-
-#### `right`
-- **Signature**: `r.col.s.right(n: int) -> Expr`
-- **Behavior**: Returns the rightmost `n` characters; returns the full string if `n` exceeds its length
-- **Parameters**: `n` character count
-- **Returns**: string expression
-- **SQL Equivalent**: `RIGHT(col, n)`
-- **SPL Equivalent**: `right(s, n)`
-- **Exceptions**: `TypeError` (non-string column)
-- **Example**:
-```python
-suffix = t.derive(sfx=lambda r: r.code.s.right(3))  # "ABC123" → "123"
-```
-
-#### `lstrip`
-- **Signature**: `r.col.s.lstrip() -> Expr`
-- **Behavior**: Removes leading whitespace only (left-trim)
-- **Parameters**: none
-- **Returns**: string expression
-- **SQL Equivalent**: `LTRIM(col)`
-- **SPL Equivalent**: `ltrim(s)`
-- **Exceptions**: `TypeError` (non-string column)
-- **Example**:
-```python
-clean = t.derive(name=lambda r: r.name.s.lstrip())  # "  hello" → "hello"
-```
-
-#### `rstrip`
-- **Signature**: `r.col.s.rstrip() -> Expr`
-- **Behavior**: Removes trailing whitespace only (right-trim)
-- **Parameters**: none
-- **Returns**: string expression
-- **SQL Equivalent**: `RTRIM(col)`
-- **SPL Equivalent**: `rtrim(s)`
-- **Exceptions**: `TypeError` (non-string column)
-- **Example**:
-```python
-clean = t.derive(name=lambda r: r.name.s.rstrip())  # "hello  " → "hello"
+prefix = t.derive(pfx=lambda r: r.code.s.left(3))    # "ABC123" → "ABC"
+suffix = t.derive(sfx=lambda r: r.code.s.right(3))   # "ABC123" → "123"
 ```
 
 #### `asc`
 - **Signature**: `r.col.s.asc() -> Expr`
-- **Behavior**: Returns the ASCII/Unicode code point of the first character of the string
-- **Parameters**: none
-- **Returns**: integer expression
+- **Behavior**: Returns the ASCII/Unicode code point of the first character of the string (like Python `ord()`)
 - **SQL Equivalent**: `ASCII(col)`
-- **SPL Equivalent**: `asc(s)`
-- **Exceptions**: `TypeError` (non-string column)
 - **Example**:
 ```python
 code = t.derive(code=lambda r: r.ch.s.asc())  # "A" → 65, "a" → 97
+```
+
+#### `isalpha` / `isdigit` / `islower` / `isupper`
+- **Signature**: `r.col.s.isalpha() -> Expr` (same for the others)
+- **Behavior**: Character-class checks, mirroring Python `str` methods
+- **Example**:
+```python
+numeric_codes = t.filter(lambda r: r.code.s.isdigit())
 ```
 
 ### String Global Functions
 
 #### `str_char`
 - **Signature**: `str_char(n: Expr) -> Expr`
-- **Behavior**: Converts a Unicode code point integer to its single-character string representation
-- **Parameters**: `n` integer expression (Unicode code point)
-- **Returns**: string expression
+- **Behavior**: Converts a Unicode code point integer to its single-character string representation (like Python `chr()`)
 - **SQL Equivalent**: `CHR(n)`
-- **SPL Equivalent**: `char(n)`
 - **Import**: `from ltseq.expr import str_char`
-- **Exceptions**: `ValueError` (invalid code point)
 - **Example**:
 ```python
 from ltseq.expr import str_char
@@ -1293,16 +1400,12 @@ ch = t.derive(ch=lambda r: str_char(r.code))  # 65 → "A", 97 → "a"
 #### `concat_ws`
 - **Signature**: `concat_ws(delimiter: str, *cols: Expr) -> Expr`
 - **Behavior**: Concatenate two or more column expressions with a separator between each
-- **Parameters**: `delimiter` separator string; `cols` two or more string column expressions
-- **Returns**: string expression
 - **SQL Equivalent**: `CONCAT_WS(delimiter, col1, col2, ...)`
 - **Import**: `from ltseq.expr import concat_ws`
-- **Exceptions**: `TypeError` (non-string columns)
 - **Example**:
 ```python
 from ltseq.expr import concat_ws
 full = t.derive(full_name=lambda r: concat_ws(" ", r.first, r.last))
-csv_row = t.derive(row=lambda r: concat_ws(",", r.a, r.b, r.c))
 ```
 
 ### Temporal Operations (`r.col.dt.*`)
@@ -1310,217 +1413,162 @@ csv_row = t.derive(row=lambda r: concat_ws(",", r.a, r.b, r.c))
 #### `year` / `month` / `day`
 - **Signature**: `r.col.dt.year() -> Expr` (same for month/day)
 - **Behavior**: extract date components
-- **Parameters**: none
-- **Returns**: integer expression
-- **Exceptions**: `TypeError` (non-date column)
 - **Example**:
 ```python
 by_date = t.derive(year=lambda r: r.date.dt.year())
 ```
 
-#### `hour` / `minute` / `second`
-- **Signature**: `r.col.dt.hour() -> Expr` (same for minute/second)
-- **Behavior**: extract time components
-- **Parameters**: none
-- **Returns**: integer expression
-- **Exceptions**: `TypeError` (non-time column)
+#### `hour` / `minute` / `second` / `millisecond`
+- **Signature**: `r.col.dt.hour() -> Expr` (same for minute/second/millisecond)
+- **Behavior**: extract time components (`millisecond` returns 0–999)
 - **Example**:
 ```python
 with_time = t.derive(hour=lambda r: r.ts.dt.hour())
 ```
 
+#### `weekday`
+- **Signature**: `r.col.dt.weekday() -> Expr`
+- **Behavior**: Extract weekday as 0-based integer (Monday=0 ... Sunday=6)
+- **Example**:
+```python
+t.derive(wd=lambda r: r.date.dt.weekday())
+```
+
 #### `add`
 - **Signature**: `r.col.dt.add(days: int = 0, months: int = 0, years: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0, weeks: int = 0) -> Expr`
-- **Behavior**: Date/time arithmetic. `weeks` is converted to `days × 7`; `hours/minutes/seconds` use nanosecond precision internally.
-- **Parameters**: `days/months/years/hours/minutes/seconds/weeks` integer offsets (all default to 0)
+- **Behavior**: Date/time arithmetic. `weeks` is converted to `days × 7`; `hours/minutes/seconds` use nanosecond precision internally
+- **Parameters**: integer offsets (all default to 0; negative to subtract)
 - **Returns**: date/timestamp expression
 - **SPL Equivalent**: `elapse(t, k, unit)`
-- **Exceptions**: `TypeError` (non-date column)
 - **Example**:
 ```python
 delivery   = t.derive(delivery=lambda r: r.order_date.dt.add(days=5))
 after_2h   = t.derive(ts2=lambda r: r.ts.dt.add(hours=2, minutes=30))
 next_week  = t.derive(d2=lambda r: r.date.dt.add(weeks=1))
-next_month = t.derive(d3=lambda r: r.date.dt.add(days=10, months=1))
 ```
 
 #### `diff`
 - **Signature**: `r.col.dt.diff(other: Expr, unit: str = "day") -> Expr`
-- **Behavior**: Returns the integer difference between `self` and `other` in the specified unit. `unit` can be `"day"` (default), `"month"`, `"year"`, `"hour"`, `"minute"`, or `"second"`.
-- **Parameters**: `other` other date/timestamp expression; `unit` time unit (default: `"day"`)
-- **Returns**: integer expression
+- **Behavior**: Returns the integer difference between `self` and `other` in the specified unit. `unit` can be `"day"` (default), `"month"`, `"year"`, `"hour"`, `"minute"`, or `"second"`
 - **SPL Equivalent**: `interval(t1, t2, unit)`
-- **Exceptions**: `TypeError` (non-date column), `ValueError` (invalid unit)
 - **Example**:
 ```python
-days   = t.derive(d=lambda r: r.end.dt.diff(r.start))                    # days (default)
+days   = t.derive(d=lambda r: r.end.dt.diff(r.start))
 months = t.derive(m=lambda r: r.end.dt.diff(r.start, unit="month"))
-years  = t.derive(y=lambda r: r.end.dt.diff(r.start, unit="year"))
-hours  = t.derive(h=lambda r: r.end.dt.diff(r.start, unit="hour"))
 ```
 
 #### `age`
 - **Signature**: `r.col.dt.age() -> Expr`
-- **Behavior**: Returns the number of complete years between the column's date and today (today - col, in full years). Result is negative for future dates.
-- **Parameters**: none
-- **Returns**: integer expression
-- **SQL Equivalent**: `EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM col)` with day-of-year correction
+- **Behavior**: Returns the number of complete years between the column's date and today. Result is negative for future dates
 - **SPL Equivalent**: `age(dt)`
-- **Exceptions**: `TypeError` (non-date column)
 - **Example**:
 ```python
 age = t.derive(age=lambda r: r.birth_date.dt.age())
 ```
 
+#### `now` / `today` (global functions)
+- **Signature**: `now() -> Expr`; `today() -> Expr`
+- **Behavior**: Current timestamp / current date
+- **Import**: `from ltseq import now, today`
+- **Example**:
+```python
+from ltseq import now
+t.derive(fetched_at=lambda r: now())
+```
+
 ### Math Global Functions
 
-#### `gcd`
-- **Signature**: `gcd(a: Expr, b: Expr) -> Expr`
-- **Behavior**: Greatest common divisor of two integer expressions
-- **Parameters**: `a`, `b` integer expressions
-- **Returns**: integer expression
-- **SQL Equivalent**: `GCD(a, b)` (DataFusion)
-- **SPL Equivalent**: `gcd(a, b)`
-- **Import**: `from ltseq.expr import gcd`
+#### `gcd` / `lcm` / `factorial`
+- **Signature**: `gcd(a: Expr, b: Expr) -> Expr`; `lcm(a: Expr, b: Expr) -> Expr`; `factorial(n: Expr) -> Expr`
+- **Behavior**: Greatest common divisor, least common multiple, factorial (DataFusion `GCD`/`LCM`/`FACTORIAL`)
+- **Import**: `from ltseq.expr import gcd, lcm, factorial`
 - **Example**:
 ```python
-from ltseq.expr import gcd
-t.derive(g=lambda r: gcd(r.a, r.b))  # gcd(12, 8) → 4
+from ltseq.expr import gcd, lcm, factorial
+t.derive(g=lambda r: gcd(r.a, r.b))       # gcd(12, 8) → 4
+t.derive(l=lambda r: lcm(r.a, r.b))       # lcm(4, 6) → 12
+t.derive(f=lambda r: factorial(r.n))      # factorial(5) → 120
 ```
 
-#### `lcm`
-- **Signature**: `lcm(a: Expr, b: Expr) -> Expr`
-- **Behavior**: Least common multiple of two integer expressions
-- **Parameters**: `a`, `b` integer expressions
-- **Returns**: integer expression
-- **SQL Equivalent**: `LCM(a, b)` (DataFusion)
-- **SPL Equivalent**: `lcm(a, b)`
-- **Import**: `from ltseq.expr import lcm`
+#### General math: `sqrt`, `power`, `sign`, `log`, `ln`, `exp`, trig, `rand`
+- **Signature**: `sqrt(x)`, `power(x, n)`, `sign(x)`, `log(x, base=None)`, `ln(x)`, `exp(x)`, `sin/cos/tan/asin/acos/atan(x)`, `atan2(y, x)`, `rand()`
+- **Behavior**: Standard math functions mapped to DataFusion equivalents
+- **Import**: `from ltseq import sqrt, power, log, ...`
 - **Example**:
 ```python
-from ltseq.expr import lcm
-t.derive(l=lambda r: lcm(r.a, r.b))  # lcm(4, 6) → 12
+from ltseq import sqrt, power, log
+
+t.derive(
+    dist=lambda r: sqrt(power(r.x, 2) + power(r.y, 2)),
+    log_amt=lambda r: log(r.amount, 10),
+)
 ```
 
-#### `factorial`
-- **Signature**: `factorial(n: Expr) -> Expr`
-- **Behavior**: Factorial of a non-negative integer expression; `n! = 1 × 2 × ... × n`, `0! = 1`
-- **Parameters**: `n` non-negative integer expression
-- **Returns**: integer expression
-- **SQL Equivalent**: `FACTORIAL(n)` (DataFusion)
-- **SPL Equivalent**: `fact(n)`
-- **Import**: `from ltseq.expr import factorial`
+## 9. Row Mutation Operations (copy-on-write)
+
+All mutation operations return a **new** LTSeq; the original is unchanged.
+
+### `LTSeq.insert`
+- **Signature**: `LTSeq.insert(pos: int, row_dict: dict[str, Any]) -> LTSeq`
+- **Behavior**: Insert a row at the given 0-based position. `pos` beyond the end appends; negative `pos` is clamped to 0
 - **Example**:
 ```python
-from ltseq.expr import factorial
-t.derive(f=lambda r: factorial(r.n))  # factorial(5) → 120
+t2 = t.insert(0, {"id": 99, "name": "Alice"})     # prepend
+t2 = t.insert(len(t), {"id": 100, "name": "Bob"}) # append
 ```
 
-### `r.col.lookup` (expression-level lookup)
-- **Signature**: `r.col.lookup(target_table: LTSeq, column: str, join_key: Optional[str] = None) -> Expr`
-- **Behavior**: Lightweight lookup inside expressions, returning a single column value
-- **Parameters**: `target_table` target table; `column` output column; `join_key` join key in target table
-- **Returns**: lookup expression
-- **Exceptions**: `TypeError` (invalid params), `RuntimeError` (execution failure)
+### `LTSeq.delete`
+- **Signature**: `LTSeq.delete(predicate_or_pos: Callable | int) -> LTSeq`
+- **Behavior**: Delete rows matching a predicate, or the single row at a 0-based index
 - **Example**:
 ```python
-enriched = orders.derive(product_name=lambda r: r.product_id.lookup(products, "name"))
+t2 = t.delete(lambda r: r.status == "expired")
+t2 = t.delete(0)   # delete first row
 ```
 
-### Conditional Aggregation Functions
-
-Module-level functions for conditional aggregation in `.agg()` contexts. These take expression predicates (not lambdas) and are designed for use with the GroupProxy `g` parameter.
-
-#### `count_if`
-- **Signature**: `count_if(predicate: Expr) -> Expr`
-- **Behavior**: Count rows where predicate expression is True
-- **Parameters**: `predicate` boolean expression
-- **Returns**: integer expression
-- **Exceptions**: `TypeError` (non-boolean predicate)
+### `LTSeq.update`
+- **Signature**: `LTSeq.update(predicate: Callable, **updates: Any) -> LTSeq`
+- **Behavior**: Conditionally update column values where predicate is True. Each column becomes `if_else(predicate, new_value, old_value)`
 - **Example**:
 ```python
-from ltseq.expr import count_if
-
-result = t.agg(by=lambda r: r.region, high_count=lambda r: count_if(r.price > 100))
+t2 = t.update(lambda r: r.age > 65, discount=0.2)
+t2 = t.update(lambda r: r.status == "old", status="archived")
 ```
 
-#### `sum_if`
-- **Signature**: `sum_if(predicate: Expr, column: Expr) -> Expr`
-- **Behavior**: Sum column values where predicate expression is True
-- **Parameters**: `predicate` boolean expression; `column` column expression to sum
-- **Returns**: numeric expression
-- **Exceptions**: `TypeError` (non-boolean predicate or non-numeric column)
+### `LTSeq.modify`
+- **Signature**: `LTSeq.modify(pos: int, **updates: Any) -> LTSeq`
+- **Behavior**: Modify specific columns in the single row at 0-based position `pos`. Silently ignored if `pos` is out of range
 - **Example**:
 ```python
-from ltseq.expr import sum_if
-
-result = t.agg(by=lambda r: r.region, high_sales=lambda r: sum_if(r.price > 100, r.quantity))
+t2 = t.modify(0, status="active", score=100)
 ```
 
-#### `avg_if`
-- **Signature**: `avg_if(predicate: Expr, column: Expr) -> Expr`
-- **Behavior**: Average column values where predicate expression is True
-- **Parameters**: `predicate` boolean expression; `column` column expression to average
-- **Returns**: numeric expression
-- **Exceptions**: `TypeError` (non-boolean predicate or non-numeric column)
-- **Example**:
-```python
-from ltseq.expr import avg_if
-
-result = t.agg(by=lambda r: r.region, avg_high=lambda r: avg_if(r.price > 100, r.sales))
-```
-
-#### `min_if`
-- **Signature**: `min_if(predicate: Expr, column: Expr) -> Expr`
-- **Behavior**: Minimum column value where predicate expression is True
-- **Parameters**: `predicate` boolean expression; `column` column expression
-- **Returns**: expression of column type
-- **Exceptions**: `TypeError` (non-boolean predicate)
-- **Example**:
-```python
-from ltseq.expr import min_if
-
-result = t.agg(by=lambda r: r.region, min_active=lambda r: min_if(r.is_active, r.score))
-```
-
-#### `max_if`
-- **Signature**: `max_if(predicate: Expr, column: Expr) -> Expr`
-- **Behavior**: Maximum column value where predicate expression is True
-- **Parameters**: `predicate` boolean expression; `column` column expression
-- **Returns**: expression of column type
-- **Exceptions**: `TypeError` (non-boolean predicate)
-- **Example**:
-```python
-from ltseq.expr import max_if
-
-result = t.agg(by=lambda r: r.region, max_active=lambda r: max_if(r.is_active, r.score))
-```
-
-## 9. End-to-End Examples
+## 10. End-to-End Examples
 
 ### Ordered Computing + Consecutive Grouping
 ```python
 from ltseq import LTSeq
 
 # Task: find intervals where a stock rose for more than 3 consecutive days
-result = (
+runs = (
     LTSeq.read_csv("stock.csv")
-    .sort(lambda r: r.date)
-    .derive(lambda r: {"is_up": r.price > r.price.shift(1)})
+    .sort("date")
+    .derive(is_up=lambda r: r.price > r.price.shift(1))
     .group_ordered(lambda r: r.is_up)
-    .filter(lambda g: (g.first().is_up == True) & (g.count() > 3))
-    .derive(lambda g: {
+    .filter(lambda g: g.count() > 3)
+    .filter(lambda g: g.all(lambda r: r.is_up == True))
+    .derive(lambda g: {          # broadcast: every row gets its group's span
         "start": g.first().date,
         "end": g.last().date,
-        "gain": (g.last().price - g.first().price) / g.first().price,
+        "gain": g.last().price - g.first().price,
     })
 )
+intervals = runs.distinct("start", "end")   # one row per interval
 ```
 
 ### String + Temporal + Conditional + Lookup
 ```python
-from ltseq import LTSeq
-from ltseq.expr import if_else
+from ltseq import LTSeq, if_else
 
 orders = LTSeq.read_csv("orders.csv")
 products = LTSeq.read_csv("products.csv")
@@ -1533,11 +1581,21 @@ result = orders.derive(
 )
 ```
 
-## 10. Execution and Performance Notes
+### Streaming a Large File
+```python
+from ltseq import LTSeq
+
+total = 0
+for batch in LTSeq.scan("huge.csv"):
+    total += process(batch)
+```
+
+## 11. Execution and Performance Notes
 
 - All expressions are serialized and pushed down to Rust/DataFusion, not evaluated row-by-row in Python
 - String/temporal/NULL extensions map to SQL/DataFusion functions
-- `to_cursor` enables streaming for very large datasets
+- `LTSeq.scan()`/`scan_parquet()` enable streaming for very large datasets
+- `assume_sorted()` skips physical sorting for pre-sorted inputs while enabling window functions and merge joins
 
 ### Expression SQL Translation Reference
 
@@ -1549,43 +1607,36 @@ All expressions are transpiled to the Rust/DataFusion layer before execution. No
 | `r.col.fill_null(v)` | `COALESCE(col, v)` |
 | `r.col.is_null()` | `col IS NULL` |
 | `r.col.is_not_null()` | `col IS NOT NULL` |
+| `r.col.is_in([a, b])` | `col IN (a, b)` |
+| `r.col.between(lo, hi)` | `col >= lo AND col <= hi` |
+| `r.col.cast("int64")` | `CAST(col AS BIGINT)` |
+| `r.col.abs()` | `ABS(col)` |
+| `r.col.round(n)` | `ROUND(col, n)` |
+| `r.col.floor()` / `r.col.ceil()` | `FLOOR(col)` / `CEIL(col)` |
 | `r.col.s.contains(p)` | `POSITION(p IN col) > 0` |
 | `r.col.s.starts_with(p)` | `STARTS_WITH(col, p)` |
 | `r.col.s.ends_with(p)` | `ENDS_WITH(col, p)` |
-| `r.col.s.lower()` | `LOWER(col)` |
-| `r.col.s.upper()` | `UPPER(col)` |
-| `r.col.s.strip()` | `TRIM(col)` |
-| `r.col.s.lstrip()` | `LTRIM(col)` |
-| `r.col.s.rstrip()` | `RTRIM(col)` |
+| `r.col.s.lower()` / `.upper()` | `LOWER(col)` / `UPPER(col)` |
+| `r.col.s.strip()` / `.lstrip()` / `.rstrip()` | `TRIM` / `LTRIM` / `RTRIM` |
 | `r.col.s.len()` | `CHARACTER_LENGTH(col)` |
 | `r.col.s.slice(s, n)` | `SUBSTRING(col, s+1, n)` |
 | `r.col.s.pos(sub)` | `STRPOS(col, sub)` |
-| `r.col.s.left(n)` | `LEFT(col, n)` |
-| `r.col.s.right(n)` | `RIGHT(col, n)` |
+| `r.col.s.left(n)` / `.right(n)` | `LEFT(col, n)` / `RIGHT(col, n)` |
 | `r.col.s.asc()` | `ASCII(col)` |
+| `r.col.s.like(p)` | `col LIKE p` |
 | `r.col.s.replace(old, new)` | `REPLACE(col, old, new)` |
-| `r.col.s.pad_left(n, c)` | `LPAD(col, n, c)` |
-| `r.col.s.pad_right(n, c)` | `RPAD(col, n, c)` |
+| `r.col.s.pad_left(n, c)` / `.pad_right(n, c)` | `LPAD(col, n, c)` / `RPAD(col, n, c)` |
 | `r.col.s.split(d, i)` | `SPLIT_PART(col, d, i)` |
 | `str_char(n)` | `CHR(n)` |
 | `concat_ws(d, ...)` | `CONCAT_WS(d, ...)` |
-| `r.col.dt.year()` | `EXTRACT(YEAR FROM col)` |
-| `r.col.dt.month()` | `EXTRACT(MONTH FROM col)` |
-| `r.col.dt.day()` | `EXTRACT(DAY FROM col)` |
-| `r.col.dt.hour()` | `EXTRACT(HOUR FROM col)` |
-| `r.col.dt.minute()` | `EXTRACT(MINUTE FROM col)` |
-| `r.col.dt.second()` | `EXTRACT(SECOND FROM col)` |
+| `r.col.dt.year()` etc. | `EXTRACT(YEAR FROM col)` etc. |
 | `r.col.dt.add(days=n)` | `col + INTERVAL 'n' DAY` |
-| `r.col.dt.add(hours=n)` | `col + INTERVAL 'n' HOUR` |
 | `r.col.dt.diff(other)` | `DATEDIFF('day', other, col)` |
-| `r.col.dt.diff(other, unit="month")` | `(year(col)-year(other))*12 + month(col)-month(other)` |
-| `r.col.dt.diff(other, unit="year")` | `EXTRACT(YEAR FROM col) - EXTRACT(YEAR FROM other)` |
 | `r.col.dt.age()` | year diff from `CURRENT_DATE` with day-of-year correction |
-| `gcd(a, b)` | `GCD(a, b)` |
-| `lcm(a, b)` | `LCM(a, b)` |
-| `factorial(n)` | `FACTORIAL(n)` |
-| `count_if(cond)` | `COUNT(CASE WHEN cond THEN 1 END)` |
+| `gcd(a, b)` / `lcm(a, b)` / `factorial(n)` | `GCD` / `LCM` / `FACTORIAL` |
+| `count_if(cond)` | `SUM(CASE WHEN cond THEN 1 ELSE 0 END)` |
 | `sum_if(cond, col)` | `SUM(CASE WHEN cond THEN col END)` |
+| `g.col.percentile(p)` | `APPROX_PERCENTILE_CONT(col, p)` |
 
 ## Appendix A: Migrating from Pandas
 
@@ -1593,21 +1644,27 @@ All expressions are transpiled to the Rust/DataFusion layer before execution. No
 |--------|-------|-------|
 | `df[df.age > 18]` | `t.filter(lambda r: r.age > 18)` | Lambda captures expression |
 | `df[['id', 'name']]` | `t.select("id", "name")` | |
-| `df.assign(total=df.a + df.b)` | `t.derive(total=lambda r: r.a + r.b)` | |
+| `df.assign(total=df.a + df.b)` | `t.derive(total=lambda r: r.a + r.b)` | `with_columns` is an alias |
+| `df.rename(columns={'a': 'b'})` | `t.rename(a="b")` | |
+| `df.drop(columns=['tmp'])` | `t.drop("tmp")` | |
 | `df.sort_values('date')` | `t.sort("date")` | |
-| `df.sort_values('date', ascending=False)` | `t.sort("date", desc=True)` | |
+| `df.sort_values('date', ascending=False)` | `t.sort("date", desc=True)` | `descending=` also accepted |
 | `df.drop_duplicates('id')` | `t.distinct("id")` | |
-| `df.groupby('region').agg({'sales': 'sum'})` | `t.agg(by=lambda r: r.region, sales=lambda r: r.sales.sum())` | |
+| `df.groupby('region').agg({'sales': 'sum'})` | `t.group_by("region").agg(sales=lambda g: g.sales.sum())` | |
 | `df.merge(df2, on='id')` | `t.join(t2, on=lambda a, b: a.id == b.id)` | |
 | `df.merge(df2, on='id', how='left')` | `t.join(t2, on=lambda a, b: a.id == b.id, how="left")` | |
+| `pd.merge_asof(t, q, on='time')` | `t.asof_join(q, on=lambda t, q: t.time >= q.time)` | |
 | `df['col'].shift(1)` | `t.sort(...).derive(prev=lambda r: r.col.shift(1))` | Requires sort |
 | `df['col'].rolling(5).mean()` | `t.sort(...).derive(ma=lambda r: r.col.rolling(5).mean())` | Requires sort |
 | `df['col'].diff()` | `t.sort(...).derive(d=lambda r: r.col.diff())` | Requires sort |
-| `df['col'].cumsum()` | `t.sort(...).cum_sum("col")` | Requires sort |
-| `df.head(10)` | `t.head(10)` | |
-| `df.tail(10)` | `t.tail(10)` | |
+| `df['col'].pct_change()` | `t.sort(...).derive(p=lambda r: r.col.pct_change())` | Requires sort |
+| `df['col'].cumsum()` | `t.sort(...).cum_sum("col")` or `r.col.cum_sum()` | Requires sort |
+| `df['col'].isin([1, 2])` | `t.filter(lambda r: r.col.is_in([1, 2]))` | |
+| `df['col'].astype('float')` | `t.derive(col=lambda r: r.col.cast("float64"))` | |
+| `df.head(10)` / `df.tail(10)` | `t.head(10)` / `t.tail(10)` | |
 | `df.to_dict('records')` | `t.collect()` | |
-| `len(df)` | `t.count()` | |
+| `len(df)` | `len(t)` or `t.count()` | |
 | `df.columns.tolist()` | `t.columns` | |
 | `df.isna()` | `t.filter(lambda r: r.col.is_null())` | Per-column |
 | `df.fillna(0)` | `t.derive(col=lambda r: r.col.fill_null(0))` | Per-column |
+| `df.pipe(fn, arg)` | `t.pipe(fn, arg)` | |


### PR DESCRIPTION
## 背景

2026-07 API 设计 review 时发现 `docs/api.md` 与实现严重脱节：文档记载了大量**不存在的 API**，同时**遗漏了大量已实现 API**。本 PR 对照 `py-ltseq/ltseq/` 源码逐条核实后重写两份文档，只描述现状；review 产出的改进建议已另行整理为 #106-#112。

## 修正与实现不符的条目

- 删除不存在的 API：`to_cursor`、表级 `LTSeq.lookup`、有序累积 `scan(func, init)`（能力追踪 → #112）、GroupProxy 属性风格聚合（`g.price.avg()`）及 `median/percentile/var/std/mode/top_k/*_if` 等 13 个未实现方法（#97 当时漏改 api.md）、agg 上下文的 `top_k`
- `NestedTable.derive` 修正为**广播语义**（原文档误写为组级坍缩，返回形状完全不同），端到端示例同步改写
- join 冲突列修正为 `_other_` **前缀**（原文档误写为后缀）
- `asof_join` 补 `is_sorted` 参数；`agg(by=)` 标注仅接受 callable
- `over()` 修正为单列 `partition_by`/`order_by` + 单布尔 `descending`（原文档误写支持列表）
- 组代理聚合修正为字符串列名风格 `g.sum("col")`

## 补全已实现但未文档化的 API（40+ 条目）

- **分组**：`group_by()`/`GroupBy.agg` 链、`group_consecutive` 别名、聚合上下文的 `median/var/std/percentile`、`skew/corr/covar/concat_agg`
- **窗口**：`shift(partition_by=, default=)`、表达式 `r.col.cum_sum()`/`pct_change()`、rolling 支持的聚合列表
- **IO**：`read_parquet`、`scan`/`scan_parquet` → `Cursor`（流式）、`from_rows/from_dict/from_pandas/from_arrow`、`write_csv/write_parquet`、`to_arrow`、`seq`
- **列变换/工具**：`with_columns` 别名、`rename/drop/pipe/show/explain_plan/python_schema/dtypes/assume_sorted`、`len(t)`
- **集合/序列**：`xunion/rvs/step/contain`、`search_pattern/search_pattern_count`
- **行变更**：`insert/delete/update/modify` 新小节
- **表达式**：`is_in/between/cast/abs/round/floor/ceil`、`like/isalpha/isdigit/islower/isupper`、`dt.millisecond/weekday`、`now/today`、`ifa/nvl/coalesce`、数学函数族

Quick Reference、Common Errors、SQL 转译对照表、Pandas 迁移表均同步更新。

## 验证

- 中英文档 1:1 镜像：章节与条目级标题数完全一致（15 个二级标题、146 个 API 条目、各 1670 行）
- 反向 grep 确认无过时 API 残留
- 文档中 30+ 个新增/改写示例已在真实环境分三批实际运行，全部通过（分组聚合、窗口 partition_by、NestedTable 广播、流式 scan、set ops、mutation、join/link/lookup、pivot、search_pattern 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)