### PR TITLE
fix!: ordered APIs require declared row order + sort metadata prefix correctness (issue #125 findings 1/2/3/5)

### DIFF
--- a/docs/api.cn.md
+++ b/docs/api.cn.md
@@ -27,6 +27,7 @@ LTSeq 是面向有序序列的 Python 数据处理库，底层由 Rust/DataFusio
 | 错误 | 原因 | 解决方法 |
 |------|------|---------|
 | `SortRequiredError: Window functions ... require a defined row order` | 未排序直接调用 `shift`/`rolling`/`diff`/累积 | 在窗口函数前添加 `.sort(order_column)`（或 `.assume_sorted(...)`）|
+| `SortRequiredError: group_ordered() ... requires a declared row order` | 未排序直接调用 `group_ordered`/`group_sorted`/`cum_sum` | 先 `.sort(...)`，或对已有序数据用 `.assume_sorted(...)`。计算排序键不构成声明顺序——先派生为列 |
 | `ColumnNotFoundError: column 'xxx' not found` | 列名拼写错误或列不存在 | 通过 `t.columns` 查看可用列名 |
 | `SchemaMismatchError: schema mismatch` | union/intersect 的表 schema 不匹配 | 确保两表列名和类型相同 |
 | `SortRequiredError: merge strategy requires sorted tables` | 对未排序的表调用 `join(..., strategy="merge")` | 先对双方调用 `.sort(join_key)` |
@@ -461,6 +462,7 @@ t.drop("tmp", "debug_flag")
 - **参数**: `keys` 列名或表达式；`desc`/`descending` 全局或逐键降序标志
 - **返回**: 排序后的 `LTSeq`（带排序键追踪）
 - **异常**: `ValueError`（schema 未初始化或 desc 长度不匹配），`TypeError`（键类型无效），`AttributeError`（列不存在）
+- **计算键**: 计算键（如 `lambda r: r.a * 2`）会物理排序数据，但**无法作为声明顺序被追踪**——`sort_keys` 在首个计算键处截断，因此 `sort("a", lambda r: r.b * 2, "c")` 只声明 `[a]`，而单独的 `sort(lambda r: r.a * 2)` 不声明任何顺序（`cum_sum` 等有序 API 仍会抛 `SortRequiredError`）。要把计算键用作声明顺序，先派生为列：`.derive(k=...).sort("k")`。截断后，声明前缀相等的行之间顺序**未定义**——窗口执行可能重排这些 tie 行
 - **示例**:
 ```python
 t_sorted = t.sort("date", "id", desc=[False, True])
@@ -501,8 +503,8 @@ t_sorted.is_sorted_by("a", desc=True)  # False（方向不匹配）
 ```
 
 ### `LTSeq.assume_sorted`
-- **签名**: `LTSeq.assume_sorted(*keys: str, desc: bool | list[bool] = False) -> LTSeq`
-- **行为**: 声明数据已按给定键排序，**不做物理排序**。可对预排序数据（如预排序的 Parquet）跳过排序开销，同时启用窗口函数与归并连接。正确性由调用方负责——错误的声明会产生错误结果
+- **签名**: `LTSeq.assume_sorted(*keys: str | Callable, desc: bool | list[bool] = False) -> LTSeq`
+- **行为**: 声明数据已按给定键排序，**不做物理排序**。可对预排序数据（如预排序的 Parquet）跳过排序开销，同时启用窗口函数与归并连接。正确性由调用方负责——错误的声明会产生错误结果。与 `sort()` 相同，声明顺序在首个计算键处截断——只有前导的普通列键生效
 - **参数**: `keys` 声明排序顺序的列名；`desc` 降序标志
 - **返回**: 设置了排序元数据的 `LTSeq`（底层数据不变）
 - **异常**: `ValueError`（schema 未初始化或 desc 长度不匹配），`TypeError`（desc 类型无效）
@@ -617,10 +619,10 @@ t.sort("date").derive(
 
 #### `LTSeq.cum_sum`
 - **签名**: `LTSeq.cum_sum(*cols: str | Callable) -> LTSeq`
-- **行为**: 添加带 `*_cumsum` 后缀的累计求和列。若需自定义列名，请在 `derive()` 中使用表达式形式 `r.col.cum_sum()`
+- **行为**: 添加带 `*_cumsum` 后缀的累计求和列。要求先 `.sort(...)` 或 `.assume_sorted(...)`。若需自定义列名，请在 `derive()` 中使用表达式形式 `r.col.cum_sum()`
 - **参数**: `cols` 列名或表达式
 - **返回**: 带累计列的新 `LTSeq`
-- **异常**: `ValueError`（无列或 schema 未初始化），`TypeError`（非数值）
+- **异常**: `SortRequiredError`（无声明行序），`ValueError`（无列或 schema 未初始化），`TypeError`（非数值）
 - **示例**:
 ```python
 with_cum = t.sort("date").cum_sum("volume", "amount")
@@ -816,10 +818,10 @@ every_tenth = t.step(10)
 
 ### `LTSeq.group_ordered`（别名: `group_consecutive`）
 - **签名**: `LTSeq.group_ordered(key: Callable[[Row], Expr]) -> NestedTable`
-- **行为**: 只把连续相等的值归为一组；不重排数据。`group_consecutive` 是同一方法的更直白别名
+- **行为**: 按表的声明行序，只把连续相等的值归为一组；不重排数据。要求先 `.sort(...)` 或 `.assume_sorted(...)`。`group_consecutive` 是同一方法的更直白别名
 - **参数**: `key` 分组键表达式
 - **返回**: `NestedTable`（组级操作）
-- **异常**: `ValueError`（schema 未初始化），`TypeError`（键无效），`AttributeError`（列不存在）
+- **异常**: `SortRequiredError`（无声明行序），`ValueError`（schema 未初始化），`TypeError`（键无效），`AttributeError`（列不存在）
 - **示例**:
 ```python
 groups = t.sort("date").group_ordered(lambda r: r.is_up)
@@ -829,10 +831,10 @@ groups = t.sort("date").group_consecutive(lambda r: r.is_up)
 
 ### `LTSeq.group_sorted`
 - **签名**: `LTSeq.group_sorted(key: Callable[[Row], Expr]) -> NestedTable`
-- **行为**: 假定数据已按键全局排序；单遍分组，无需哈希
+- **行为**: 假定数据已按键全局排序；单遍分组，无需哈希。分组键必须是引领声明排序的普通列（先 `.sort(key)` 或 `.assume_sorted(key)`）；计算分组键无法对照排序元数据验证，会被拒绝——先派生为列
 - **参数**: `key` 分组键表达式
 - **返回**: `NestedTable`
-- **异常**: `ValueError`（未排序或 schema 未初始化），`TypeError`（键无效）
+- **异常**: `SortRequiredError`（无声明顺序、键不引领排序、或计算键），`ValueError`（schema 未初始化），`TypeError`（键无效）
 - **示例**:
 ```python
 groups = t.sort("user_id").group_sorted(lambda r: r.user_id)
@@ -903,7 +905,7 @@ enriched = groups.derive(lambda g: {
 - **示例**:
 ```python
 # 每个连续段一行
-spans = t.group_ordered(lambda r: r.is_up).agg(lambda g: {
+spans = t.sort("date").group_ordered(lambda r: r.is_up).agg(lambda g: {
     "start": g.first().date,
     "end": g.last().date,
     "n": g.count(),

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,7 @@ This document describes the API **as currently implemented**. Every signature be
 | Error | Cause | Solution |
 |-------|-------|----------|
 | `SortRequiredError: Window functions ... require a defined row order` | Called `shift`/`rolling`/`diff`/cumulative without prior `.sort()` | Add `.sort(order_column)` (or `.assume_sorted(...)`) before window operations |
+| `SortRequiredError: group_ordered() ... requires a declared row order` | Called `group_ordered`/`group_sorted`/`cum_sum` without prior `.sort()` | Add `.sort(...)` first, or `.assume_sorted(...)` if the data is already ordered. Computed sort keys don't count — derive them as a column first |
 | `ColumnNotFoundError: column 'xxx' not found` | Typo in column name or column doesn't exist | Check `t.columns` for available column names |
 | `SchemaMismatchError: schema mismatch` | Union/intersect with incompatible tables | Ensure both tables have same column names and types |
 | `SortRequiredError: merge strategy requires sorted tables` | `join(..., strategy="merge")` called on unsorted tables | Call `.sort(join_key)` on both tables first |
@@ -464,6 +465,7 @@ t.drop("tmp", "debug_flag")
 - **Parameters**: `keys` column names or expressions; `desc`/`descending` global or per-key descending flags
 - **Returns**: sorted `LTSeq` with tracked sort keys
 - **Exceptions**: `ValueError` (schema not initialized or desc length mismatch), `TypeError` (invalid key type), `AttributeError` (column not found)
+- **Computed keys**: a computed key (e.g. `lambda r: r.a * 2`) sorts the data physically but **cannot be tracked as declared order** — `sort_keys` truncates at the first computed key, so `sort("a", lambda r: r.b * 2, "c")` declares only `[a]`, and `sort(lambda r: r.a * 2)` alone declares nothing (ordered APIs like `cum_sum` will still raise `SortRequiredError`). To use a computed key as declared order, derive it as a column first: `.derive(k=...).sort("k")`. After truncation, the order of rows that tie on the declared prefix is **unspecified** — window execution may reorder ties
 - **Example**:
 ```python
 t_sorted = t.sort("date", "id", desc=[False, True])
@@ -504,8 +506,8 @@ t_sorted.is_sorted_by("a", desc=True)  # False (direction mismatch)
 ```
 
 ### `LTSeq.assume_sorted`
-- **Signature**: `LTSeq.assume_sorted(*keys: str, desc: bool | list[bool] = False) -> LTSeq`
-- **Behavior**: Declare that data is already sorted by the given keys **without physically sorting**. Enables window functions and merge joins on pre-sorted data (e.g., pre-sorted Parquet) while skipping the sort. The caller is responsible for correctness — wrong metadata produces wrong results
+- **Signature**: `LTSeq.assume_sorted(*keys: str | Callable, desc: bool | list[bool] = False) -> LTSeq`
+- **Behavior**: Declare that data is already sorted by the given keys **without physically sorting**. Enables window functions and merge joins on pre-sorted data (e.g., pre-sorted Parquet) while skipping the sort. The caller is responsible for correctness — wrong metadata produces wrong results. Like `sort()`, the declared order truncates at the first computed key — only leading plain-column keys count
 - **Parameters**: `keys` column names declaring the sort order; `desc` descending flag(s)
 - **Returns**: `LTSeq` with sort metadata set (same underlying data)
 - **Exceptions**: `ValueError` (schema not initialized or desc length mismatch), `TypeError` (invalid desc type)
@@ -620,10 +622,10 @@ t.sort("date").derive(
 
 #### `LTSeq.cum_sum`
 - **Signature**: `LTSeq.cum_sum(*cols: str | Callable) -> LTSeq`
-- **Behavior**: Add cumulative sum columns with `*_cumsum` suffix. For custom output names use the expression form `r.col.cum_sum()` inside `derive()`
+- **Behavior**: Add cumulative sum columns with `*_cumsum` suffix. Requires a prior `.sort(...)` or `.assume_sorted(...)`. For custom output names use the expression form `r.col.cum_sum()` inside `derive()`
 - **Parameters**: `cols` column names or expressions
 - **Returns**: new `LTSeq` with cumulative columns
-- **Exceptions**: `ValueError` (no columns or schema not initialized), `TypeError` (non-numeric)
+- **Exceptions**: `SortRequiredError` (no declared row order), `ValueError` (no columns or schema not initialized), `TypeError` (non-numeric)
 - **Example**:
 ```python
 with_cum = t.sort("date").cum_sum("volume", "amount")
@@ -819,10 +821,10 @@ every_tenth = t.step(10)
 
 ### `LTSeq.group_ordered` (alias: `group_consecutive`)
 - **Signature**: `LTSeq.group_ordered(key: Callable[[Row], Expr]) -> NestedTable`
-- **Behavior**: Group only consecutive equal values; does not reorder. `group_consecutive` is a more descriptive alias for the same method
+- **Behavior**: Group only consecutive equal values in the table's declared row order; does not reorder. Requires a prior `.sort(...)` or `.assume_sorted(...)`. `group_consecutive` is a more descriptive alias for the same method
 - **Parameters**: `key` grouping key expression
 - **Returns**: `NestedTable` (group-level operations)
-- **Exceptions**: `ValueError` (schema not initialized), `TypeError` (invalid key), `AttributeError` (column not found)
+- **Exceptions**: `SortRequiredError` (no declared row order), `ValueError` (schema not initialized), `TypeError` (invalid key), `AttributeError` (column not found)
 - **Example**:
 ```python
 groups = t.sort("date").group_ordered(lambda r: r.is_up)
@@ -832,10 +834,10 @@ groups = t.sort("date").group_consecutive(lambda r: r.is_up)
 
 ### `LTSeq.group_sorted`
 - **Signature**: `LTSeq.group_sorted(key: Callable[[Row], Expr]) -> NestedTable`
-- **Behavior**: Assumes global sort by key; one-pass grouping without hashing
+- **Behavior**: Assumes global sort by key; one-pass grouping without hashing. The grouping key must be a plain column that leads the declared sort order (`.sort(key)` or `.assume_sorted(key)` first); computed grouping keys cannot be verified against sort metadata and are rejected — derive them as a column first
 - **Parameters**: `key` grouping key expression
 - **Returns**: `NestedTable`
-- **Exceptions**: `ValueError` (unsorted or schema not initialized), `TypeError` (invalid key)
+- **Exceptions**: `SortRequiredError` (no declared order, key does not lead it, or computed key), `ValueError` (schema not initialized), `TypeError` (invalid key)
 - **Example**:
 ```python
 groups = t.sort("user_id").group_sorted(lambda r: r.user_id)
@@ -906,7 +908,7 @@ enriched = groups.derive(lambda g: {
 - **Example**:
 ```python
 # One row per consecutive run
-spans = t.group_ordered(lambda r: r.is_up).agg(lambda g: {
+spans = t.sort("date").group_ordered(lambda r: r.is_up).agg(lambda g: {
     "start": g.first().date,
     "end": g.last().date,
     "n": g.count(),

--- a/py-ltseq/ltseq/__init__.pyi
+++ b/py-ltseq/ltseq/__init__.pyi
@@ -169,7 +169,12 @@ class LTSeq:
         desc: bool | list[bool] = ...,
         descending: bool | list[bool] | None = ...,
     ) -> "LTSeq": ...
-    def assume_sorted(self, *keys: str, desc: bool | list[bool] = ...) -> "LTSeq": ...
+    def assume_sorted(
+        self,
+        *keys: str | Callable[[SchemaProxy], Expr],
+        desc: bool | list[bool] = ...,
+    ) -> "LTSeq": ...
+    def explain_plan(self) -> tuple[str, str]: ...
     def fold(
         self,
         fn: Callable[[Any, Any], Any],

--- a/py-ltseq/ltseq/aggregation.py
+++ b/py-ltseq/ltseq/aggregation.py
@@ -146,11 +146,13 @@ class AggregationMixin(LTSeqLike):
         # already ordered on disk, .assume_sorted().
         if not self._sort_keys:
             from .exceptions import SortRequiredError
+            from .transforms import _COMPUTED_SORT_HINT
 
             raise SortRequiredError(
                 "group_ordered() groups consecutive rows and therefore "
                 "requires a declared row order. Call .sort(...) first, or "
                 ".assume_sorted(...) if the data is already ordered."
+                + _COMPUTED_SORT_HINT
             )
 
         return NestedTable(self if isinstance(self, LTSeq) else LTSeq._from_inner(self._inner), grouping_fn, is_sorted=False)
@@ -213,8 +215,20 @@ class AggregationMixin(LTSeqLike):
                     f"'{first_sort_col}' first). Sort by the grouping key, "
                     "or use .assume_sorted() to declare the actual order."
                 )
-        # Computed grouping keys cannot be checked against sort metadata;
-        # the declared-order requirement above still applies.
+        else:
+            # A computed grouping key cannot be checked against column-level
+            # sort metadata, and letting it through unchecked silently splits
+            # logical keys into multiple runs whenever the table is sorted by
+            # something else (PR #126 review P1). Sorted-by-g also does not
+            # prove sorted-by-f(g) for arbitrary f, so reject uniformly.
+            from .exceptions import SortRequiredError
+
+            raise SortRequiredError(
+                "group_sorted() cannot verify a computed grouping key "
+                "against the declared sort order. Derive the key as a "
+                "column and sort by it first, e.g. "
+                ".derive(k=...).sort('k').group_sorted(lambda r: r.k)."
+            )
 
         return NestedTable(self if isinstance(self, LTSeq) else LTSeq._from_inner(self._inner), key, is_sorted=True)
 

--- a/py-ltseq/ltseq/aggregation.py
+++ b/py-ltseq/ltseq/aggregation.py
@@ -95,6 +95,14 @@ class AggregationMixin(LTSeqLike):
         if not cols:
             raise ValueError("cum_sum() requires at least one column argument")
 
+        # Same ordering invariant as window expressions in derive() (issue
+        # #125): a running sum over an undeclared row order is nondeterministic
+        # on multi-partition plans.
+        if not self._sort_keys:
+            from .transforms import _window_sort_required_error
+
+            raise _window_sort_required_error()
+
         cum_exprs = _collect_key_exprs(cols, self._schema, self._capture_expr)
 
         result_inner = self._inner.cum_sum(cum_exprs)
@@ -104,7 +112,10 @@ class AggregationMixin(LTSeqLike):
         """
         Group consecutive identical values based on a grouping function.
 
-        Groups only consecutive rows with identical values in the grouping column.
+        Groups only consecutive rows with identical values in the grouping
+        column, in the table's DECLARED row order: call .sort(...) first, or
+        .assume_sorted(...) if the data is already ordered (issue #125 —
+        undeclared physical order is not stable on multi-partition plans).
 
         Args:
             grouping_fn: Lambda that extracts the grouping key.
@@ -127,6 +138,19 @@ class AggregationMixin(LTSeqLike):
         if not callable(grouping_fn):
             raise TypeError(
                 f"grouping_fn must be callable, got {type(grouping_fn).__name__}"
+            )
+
+        # group_ordered() groups CONSECUTIVE rows, so its result is defined by
+        # row order. An undeclared physical order is not stable on
+        # multi-partition plans (issue #125): require .sort() or, for data
+        # already ordered on disk, .assume_sorted().
+        if not self._sort_keys:
+            from .exceptions import SortRequiredError
+
+            raise SortRequiredError(
+                "group_ordered() groups consecutive rows and therefore "
+                "requires a declared row order. Call .sort(...) first, or "
+                ".assume_sorted(...) if the data is already ordered."
             )
 
         return NestedTable(self if isinstance(self, LTSeq) else LTSeq._from_inner(self._inner), grouping_fn, is_sorted=False)
@@ -161,6 +185,36 @@ class AggregationMixin(LTSeqLike):
 
         if not callable(key):
             raise TypeError(f"key must be callable, got {type(key).__name__}")
+
+        # Capture first so invalid columns raise ColumnNotFound-style errors
+        # before any sortedness complaint.
+        key_expr = self._capture_expr(key)
+
+        # Validate the sortedness the API name promises (issue #125): the
+        # grouping key must lead the declared sort order, or interleaved keys
+        # would be split into multiple consecutive runs instead of one group
+        # per key. .assume_sorted(key) is the trust-the-caller escape hatch.
+        if not self._sort_keys:
+            from .exceptions import SortRequiredError
+
+            raise SortRequiredError(
+                "group_sorted() requires the table to be sorted by the "
+                "grouping key. Call .sort(key) first, or .assume_sorted(key) "
+                "if the data is already ordered."
+            )
+        if key_expr.get("type") == "Column":
+            first_sort_col = self._sort_keys[0][0]
+            if key_expr.get("name") != first_sort_col:
+                from .exceptions import SortRequiredError
+
+                raise SortRequiredError(
+                    f"group_sorted() key '{key_expr.get('name')}' does not "
+                    f"lead the declared sort order (sorted by "
+                    f"'{first_sort_col}' first). Sort by the grouping key, "
+                    "or use .assume_sorted() to declare the actual order."
+                )
+        # Computed grouping keys cannot be checked against sort metadata;
+        # the declared-order requirement above still applies.
 
         return NestedTable(self if isinstance(self, LTSeq) else LTSeq._from_inner(self._inner), key, is_sorted=True)
 

--- a/py-ltseq/ltseq/grouping/nested_table.py
+++ b/py-ltseq/ltseq/grouping/nested_table.py
@@ -18,7 +18,7 @@ class NestedTable:
     underlying row data.
 
     The difference between group_ordered and group_sorted is semantic:
-    - group_ordered: groups consecutive identical values (no assumption about sorting)
+    - group_ordered: groups consecutive identical values in the declared row order
     - group_sorted: assumes data is globally sorted by key (consecutive = all same key)
 
     Both use the same underlying algorithm (consecutive grouping), but group_sorted

--- a/py-ltseq/ltseq/transforms.py
+++ b/py-ltseq/ltseq/transforms.py
@@ -10,6 +10,17 @@ from .expr import SchemaProxy
 from .lookup import LookupMixin
 
 
+# Computed sort keys cannot be represented in column-level sort metadata
+# (sort() truncates at the first computed key), so a table sorted ONLY by
+# computed keys still has no declared order. Guards append this hint so the
+# error is actionable for users who literally just called .sort(lambda ...).
+_COMPUTED_SORT_HINT = (
+    " Note: computed sort keys (e.g. sort(lambda r: r.a * 2)) do not "
+    "establish a declared order — derive the key as a column first, "
+    "e.g. .derive(k=...).sort('k')."
+)
+
+
 def _window_sort_required_error() -> Exception:
     """Build the SortRequiredError raised when a window expression is used
     on a table with no defined row order (neither ``.sort()`` nor
@@ -19,7 +30,7 @@ def _window_sort_required_error() -> Exception:
     return SortRequiredError(
         "Window functions (shift/rolling/diff/rank/cumulative) require a "
         "defined row order. Call .sort(...) or .assume_sorted(...) before "
-        "using them in derive()."
+        "using them in derive()." + _COMPUTED_SORT_HINT
     )
 
 
@@ -528,6 +539,15 @@ class TransformMixin(LookupMixin, LTSeqLike):
         """
         Sort by one or more keys.
 
+        Computed keys (e.g. ``lambda r: r.a * 2``) sort the data physically
+        but cannot be tracked as declared order: sort metadata truncates at
+        the first computed key, so a computed-only sort declares no order and
+        ordered APIs (``cum_sum``, ``group_ordered``, window expressions)
+        will still raise ``SortRequiredError``. Derive the key as a column
+        first (``.derive(k=...).sort("k")``) to use it as declared order.
+        After truncation, the order of rows tied on the declared prefix is
+        unspecified.
+
         Args:
             *keys: Column names or expressions to sort by
             desc: Descending flag(s) - single bool or list per key
@@ -583,6 +603,9 @@ class TransformMixin(LookupMixin, LTSeqLike):
         The caller is responsible for ensuring the data is actually
         sorted in the declared order. Incorrect metadata will produce
         wrong results.
+
+        Like sort(), the declared order truncates at the first computed
+        key — only leading plain-column keys count.
 
         Args:
             *keys: Column names declaring the sort order

--- a/py-ltseq/ltseq/transforms.py
+++ b/py-ltseq/ltseq/transforms.py
@@ -569,7 +569,7 @@ class TransformMixin(LookupMixin, LTSeqLike):
 
     def assume_sorted(
         self,
-        *keys: str,
+        *keys: str | Callable,
         desc: bool | list[bool] = False,
     ) -> "LTSeq":
         """

--- a/py-ltseq/tests/test_derive.py
+++ b/py-ltseq/tests/test_derive.py
@@ -31,7 +31,7 @@ class TestNestedTableDeriveBasic:
     @pytest.fixture
     def basic_table(self):
         """Create basic test table."""
-        return LTSeq.read_csv("py-ltseq/tests/test_data/test_derive_basic.csv")
+        return LTSeq.read_csv("py-ltseq/tests/test_data/test_derive_basic.csv").assume_sorted("group")
 
     def test_derive_count(self, basic_table):
         """Test g.count() broadcasted to all rows in group."""
@@ -57,7 +57,7 @@ class TestNestedTableDeriveBasic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"first_val": g.first().val, "first_name": g.first().name}
             )
@@ -82,7 +82,7 @@ class TestNestedTableDeriveBasic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"last_val": g.last().val, "last_name": g.last().name}
             )
@@ -108,7 +108,7 @@ class TestNestedTableDeriveBasic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {
                     "start": g.first().val,
@@ -147,7 +147,7 @@ class TestNestedTableDeriveAggregates:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"max_val": g.max("val")}
             )
@@ -173,7 +173,7 @@ class TestNestedTableDeriveAggregates:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"min_val": g.min("val")}
             )
@@ -197,7 +197,7 @@ class TestNestedTableDeriveAggregates:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"total": g.sum("val")}
             )
@@ -222,7 +222,7 @@ class TestNestedTableDeriveAggregates:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"avg_val": g.avg("val")}
             )
@@ -245,7 +245,7 @@ class TestNestedTableDeriveAggregates:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {
                     "count": g.count(),
@@ -280,7 +280,7 @@ class TestNestedTableDeriveArithmetic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"range": g.max("val") - g.min("val")}
             )
@@ -304,7 +304,7 @@ class TestNestedTableDeriveArithmetic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"ratio": g.max("val") / g.min("val")}
             )
@@ -328,7 +328,7 @@ class TestNestedTableDeriveArithmetic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"sum_extremes": g.max("val") + g.min("val")}
             )
@@ -352,7 +352,7 @@ class TestNestedTableDeriveArithmetic:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"product": g.max("val") * g.min("val")}
             )
@@ -382,7 +382,7 @@ class TestNestedTableDeriveBroadcasting:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"group_sum": g.sum("val")}
             )
@@ -411,7 +411,7 @@ class TestNestedTableDeriveBroadcasting:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"count": g.count(), "value": g.first().val}
             )
@@ -441,7 +441,7 @@ class TestNestedTableDeriveMultipleColumns:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {
                     "count": g.count(),
@@ -473,7 +473,7 @@ class TestNestedTableDeriveMultipleColumns:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             result = t.group_ordered(lambda r: r.group).derive(
                 lambda g: {"count": g.count()}
             )
@@ -502,7 +502,7 @@ class TestNestedTableDeriveErrorHandling:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             with pytest.raises((ValueError, AttributeError)):
                 t.group_ordered(lambda r: r.group).derive(
                     lambda g: {"m": g.mode("val")}  # mode not supported on group proxy
@@ -518,7 +518,7 @@ class TestNestedTableDeriveErrorHandling:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
             with pytest.raises(ValueError):
                 t.group_ordered(lambda r: r.group).derive(
                     lambda g: g.count()  # Returns number, not dict
@@ -542,7 +542,7 @@ class TestNestedTableDeriveIntegration:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("group")
 
             # Test filter -> derive chain
             result = (
@@ -577,7 +577,7 @@ class TestNestedTableDeriveIntegration:
             fname = f.name
 
         try:
-            t = LTSeq.read_csv(fname)
+            t = LTSeq.read_csv(fname).assume_sorted("id")
 
             result = t.group_ordered(lambda r: r.id).derive(
                 lambda g: {

--- a/py-ltseq/tests/test_group_agg_extended.py
+++ b/py-ltseq/tests/test_group_agg_extended.py
@@ -8,7 +8,9 @@ from ltseq import LTSeq
 
 
 def make_table(rows, schema):
-    return LTSeq._from_rows(rows, schema)
+    # Row order of the literal data IS the intended sequence order; declare
+    # it (group_ordered now requires a declared row order, issue #125).
+    return LTSeq._from_rows(rows, schema).assume_sorted("date")
 
 
 @pytest.fixture

--- a/py-ltseq/tests/test_group_sorted.py
+++ b/py-ltseq/tests/test_group_sorted.py
@@ -40,13 +40,13 @@ class TestGroupSortedBasic(unittest.TestCase):
 
     def test_group_sorted_returns_nested_table(self):
         """group_sorted() should return a NestedTable instance."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
         self.assertIsInstance(groups, NestedTable)
 
     def test_group_sorted_first_returns_ltseq(self):
         """group_sorted().first() should return an LTSeq-compatible object."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
         first_rows = groups.first()
         # _LazyFirstLTSeq duck-types as LTSeq: has count(), to_pandas(), etc.
@@ -55,14 +55,14 @@ class TestGroupSortedBasic(unittest.TestCase):
 
     def test_group_sorted_last_returns_ltseq(self):
         """group_sorted().last() should return an LTSeq instance."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
         last_rows = groups.last()
         self.assertIsInstance(last_rows, LTSeq)
 
     def test_group_sorted_first_row_per_group(self):
         """group_sorted().first() should return first row of each group."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
         first_rows = groups.first()
 
@@ -76,7 +76,7 @@ class TestGroupSortedBasic(unittest.TestCase):
 
     def test_group_sorted_last_row_per_group(self):
         """group_sorted().last() should return last row of each group."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
         last_rows = groups.last()
 
@@ -118,7 +118,7 @@ class TestGroupSortedFilter(unittest.TestCase):
 
     def test_group_sorted_filter_by_count(self):
         """group_sorted().filter() should filter groups by count."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
 
         # Filter to groups with more than 2 events
@@ -131,7 +131,7 @@ class TestGroupSortedFilter(unittest.TestCase):
 
     def test_group_sorted_filter_preserves_is_sorted(self):
         """group_sorted().filter() should preserve is_sorted flag."""
-        t = LTSeq.read_csv(self.events_csv.name)
+        t = LTSeq.read_csv(self.events_csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
 
         # Filter to groups with more than 2 events
@@ -178,7 +178,7 @@ class TestGroupSortedVsGroupOrdered(unittest.TestCase):
 
     def test_group_sorted_on_sorted_data(self):
         """group_sorted() on sorted data should group correctly."""
-        t = LTSeq.read_csv(self.sorted_csv.name)
+        t = LTSeq.read_csv(self.sorted_csv.name).assume_sorted("category")
         groups = t.group_sorted(lambda r: r.category)
         first_rows = groups.first()
 
@@ -187,7 +187,7 @@ class TestGroupSortedVsGroupOrdered(unittest.TestCase):
 
     def test_group_ordered_on_sorted_data(self):
         """group_ordered() on sorted data should behave same as group_sorted()."""
-        t = LTSeq.read_csv(self.sorted_csv.name)
+        t = LTSeq.read_csv(self.sorted_csv.name).assume_sorted("category")
 
         # Both should produce same results on sorted data
         sorted_groups = t.group_sorted(lambda r: r.category)
@@ -199,14 +199,20 @@ class TestGroupSortedVsGroupOrdered(unittest.TestCase):
         self.assertEqual(len(sorted_first), len(ordered_first))
 
     def test_group_sorted_vs_ordered_on_unsorted_data(self):
-        """group_ordered() on unsorted data groups consecutive only."""
+        """Undeclared row order now raises (issue #125); with the file order
+        declared, group_ordered groups consecutive runs; after sorting,
+        group_sorted yields one group per key."""
+        from ltseq.exceptions import SortRequiredError
+
         t = LTSeq.read_csv(self.unsorted_csv.name)
 
-        # group_ordered groups consecutive identical values
-        ordered_groups = t.group_ordered(lambda r: r.category)
-        ordered_first = ordered_groups.first()
+        with self.assertRaises(SortRequiredError):
+            t.group_ordered(lambda r: r.category)
 
-        # Data: A, B, A, B, A - so 5 consecutive groups
+        # Declaring the file order keeps the consecutive-run semantics:
+        # A, B, A, B, A → 5 consecutive groups
+        t_declared = t.assume_sorted("id") if "id" in t.columns else t.assume_sorted(t.columns[0])
+        ordered_first = t_declared.group_ordered(lambda r: r.category).first()
         self.assertEqual(len(ordered_first), 5)
 
         # If we sort first, then group_sorted works correctly
@@ -240,7 +246,7 @@ class TestGroupSortedDerive(unittest.TestCase):
 
     def test_group_sorted_derive_count(self):
         """group_sorted().derive() should add group count column."""
-        t = LTSeq.read_csv(self.sales_csv.name)
+        t = LTSeq.read_csv(self.sales_csv.name).assume_sorted("region")
         groups = t.group_sorted(lambda r: r.region)
 
         derived = groups.derive(lambda g: {"group_size": g.count()})
@@ -307,7 +313,7 @@ class TestGroupSortedChaining(unittest.TestCase):
 
     def test_group_sorted_filter_then_first(self):
         """Should be able to chain filter().first() on group_sorted()."""
-        t = LTSeq.read_csv(self.csv.name)
+        t = LTSeq.read_csv(self.csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
 
         # Filter to users with more than 1 action, then get first
@@ -318,7 +324,7 @@ class TestGroupSortedChaining(unittest.TestCase):
 
     def test_group_sorted_filter_then_derive(self):
         """Should be able to chain filter().derive() on group_sorted()."""
-        t = LTSeq.read_csv(self.csv.name)
+        t = LTSeq.read_csv(self.csv.name).assume_sorted("user_id")
         groups = t.group_sorted(lambda r: r.user_id)
 
         # Filter to users with more than 1 action, then derive

--- a/py-ltseq/tests/test_group_window_native.py
+++ b/py-ltseq/tests/test_group_window_native.py
@@ -111,7 +111,7 @@ class TestChains:
 class TestEdges:
     def test_empty_table(self):
         df = pd.DataFrame({"g": pd.Series([], dtype="int64"), "v": pd.Series([], dtype="float64")})
-        t = LTSeq.from_pandas(df)
+        t = LTSeq.from_pandas(df).sort("g")
         grouped = t.group_ordered(lambda r: r.g)
         result = grouped.derive(lambda g: {"n": g.count()})
         assert len(result) == 0

--- a/py-ltseq/tests/test_nested_derive_proxy.py
+++ b/py-ltseq/tests/test_nested_derive_proxy.py
@@ -371,7 +371,7 @@ class TestDeriveInREPLContext:
         result_holder = {}
         code = f"""
 from ltseq import LTSeq
-t = LTSeq.read_csv({repr(sample_csv)})
+t = LTSeq.read_csv({repr(sample_csv)}).assume_sorted("date")
 grouped = t.group_ordered(lambda r: r.is_up)
 result = grouped.derive(lambda g: {{"n": g.count()}})
 result_holder['result'] = result
@@ -386,7 +386,7 @@ result_holder['result'] = result
         result_holder = {}
         code = f"""
 from ltseq import LTSeq
-t = LTSeq.read_csv({repr(sample_csv)})
+t = LTSeq.read_csv({repr(sample_csv)}).assume_sorted("date")
 grouped = t.group_ordered(lambda r: r.is_up)
 result = grouped.derive(lambda g: {{"start": g.first().date}})
 result_holder['result'] = result
@@ -401,7 +401,7 @@ result_holder['result'] = result
         result_holder = {}
         code = f"""
 from ltseq import LTSeq
-t = LTSeq.read_csv({repr(sample_csv)})
+t = LTSeq.read_csv({repr(sample_csv)}).assume_sorted("date")
 grouped = t.group_ordered(lambda r: r.is_up)
 filtered = grouped.filter(lambda g: g.count() > 2)
 result = filtered.derive(lambda g: {{"n": g.count()}})

--- a/py-ltseq/tests/test_ordered_invariants.py
+++ b/py-ltseq/tests/test_ordered_invariants.py
@@ -1,0 +1,107 @@
+"""Ordered-API invariants (issue #125 findings 1/2/3/5).
+
+Every API whose semantics depend on row order must require a declared
+order (.sort() or .assume_sorted()) and raise SortRequiredError otherwise;
+sort metadata must always be a valid prefix of the actual sort order.
+"""
+
+import pandas as pd
+import pytest
+
+from ltseq import LTSeq
+from ltseq.exceptions import SortRequiredError
+
+
+@pytest.fixture
+def unsorted():
+    df = pd.DataFrame({"g": [1, 2, 1], "v": [10.0, 20.0, 30.0]})
+    return LTSeq.from_pandas(df)
+
+
+class TestCumSumRequiresOrder:
+    def test_unsorted_raises(self, unsorted):
+        with pytest.raises(SortRequiredError):
+            unsorted.cum_sum("v")
+
+    def test_after_sort_works(self, unsorted):
+        result = unsorted.sort("g").cum_sum("v")
+        assert "v_cumsum" in result.columns
+
+    def test_after_assume_sorted_works(self):
+        df = pd.DataFrame({"g": [1, 1, 2], "v": [1.0, 2.0, 3.0]})
+        t = LTSeq.from_pandas(df).assume_sorted("g")
+        result = t.cum_sum("v")
+        assert result.to_pandas()["v_cumsum"].tolist() == [1.0, 3.0, 6.0]
+
+
+class TestGroupSortedValidates:
+    def test_unsorted_raises(self, unsorted):
+        with pytest.raises(SortRequiredError):
+            unsorted.group_sorted(lambda r: r.g)
+
+    def test_wrong_key_raises(self):
+        """Table sorted by v, grouped by g — interleaved keys would be split
+        into multiple runs instead of one group per key."""
+        df = pd.DataFrame({"g": ["A", "B", "A"], "v": [1, 2, 3]})
+        t = LTSeq.from_pandas(df).sort("v")
+        with pytest.raises(SortRequiredError):
+            t.group_sorted(lambda r: r.g)
+
+    def test_matching_sort_key_works(self):
+        df = pd.DataFrame({"g": ["A", "A", "B"], "v": [1, 2, 3]})
+        t = LTSeq.from_pandas(df).sort("g")
+        groups = t.group_sorted(lambda r: r.g)
+        assert groups.first().count() == 2
+
+    def test_sort_key_prefix_works(self):
+        """Grouping by the FIRST sort key of a multi-key sort is valid."""
+        df = pd.DataFrame({"g": ["A", "A", "B"], "v": [2, 1, 3]})
+        t = LTSeq.from_pandas(df).sort("g", "v")
+        groups = t.group_sorted(lambda r: r.g)
+        assert groups.first().count() == 2
+
+    def test_assume_sorted_is_the_trust_escape_hatch(self):
+        """Callers who know their data is ordered declare it — no extra
+        unsafe API needed."""
+        df = pd.DataFrame({"g": ["A", "A", "B"], "v": [1, 2, 3]})
+        t = LTSeq.from_pandas(df).assume_sorted("g")
+        groups = t.group_sorted(lambda r: r.g)
+        assert groups.first().count() == 2
+
+
+class TestGroupOrderedRequiresOrder:
+    def test_unsorted_raises(self, unsorted):
+        with pytest.raises(SortRequiredError):
+            unsorted.group_ordered(lambda r: r.g)
+
+    def test_after_sort_works(self, unsorted):
+        groups = unsorted.sort("g").group_ordered(lambda r: r.g)
+        assert groups.first().count() == 2
+
+    def test_after_assume_sorted_works(self):
+        df = pd.DataFrame({"g": [1, 1, 2], "v": [1.0, 2.0, 3.0]})
+        t = LTSeq.from_pandas(df).assume_sorted("g")
+        groups = t.group_ordered(lambda r: r.g)
+        assert groups.first().count() == 2
+
+
+class TestComputedSortMetadataPrefix:
+    def test_pure_computed_sort_has_no_keys(self):
+        df = pd.DataFrame({"a": [3, 1, 2]})
+        t = LTSeq.from_pandas(df).sort(lambda r: r.a * 2)
+        assert t.sort_keys is None
+        assert t._inner.get_sort_keys() == []
+
+    def test_mixed_sort_truncates_at_first_computed_key(self):
+        """sort("a", computed, "c"): metadata must be [a], never [a, c] —
+        [a, c] is not a prefix of the true order (a, b*2, c)."""
+        df = pd.DataFrame({"a": [1, 1, 2], "b": [3, 1, 2], "c": [9, 8, 7]})
+        t = LTSeq.from_pandas(df).sort("a", lambda r: r.b * 2, "c")
+        assert t._inner.get_sort_keys() == [("a", False)]
+        assert t.is_sorted_by("a")
+        assert not t.is_sorted_by("a", "c")
+
+    def test_assume_sorted_mixed_truncates_too(self):
+        df = pd.DataFrame({"a": [1, 1, 2], "b": [1, 2, 3], "c": [9, 8, 7]})
+        t = LTSeq.from_pandas(df).assume_sorted("a", lambda r: r.b * 2, "c")
+        assert t._inner.get_sort_keys() == [("a", False)]

--- a/py-ltseq/tests/test_ordered_invariants.py
+++ b/py-ltseq/tests/test_ordered_invariants.py
@@ -105,3 +105,45 @@ class TestComputedSortMetadataPrefix:
         df = pd.DataFrame({"a": [1, 1, 2], "b": [1, 2, 3], "c": [9, 8, 7]})
         t = LTSeq.from_pandas(df).assume_sorted("a", lambda r: r.b * 2, "c")
         assert t._inner.get_sort_keys() == [("a", False)]
+
+    def test_window_after_mixed_sort_uses_prefix(self):
+        """Windows after a mixed computed sort run off the truncated prefix
+        metadata. The declared order is only the prefix — tie order among
+        rows equal on the prefix is unspecified — so the guarantee is
+        self-consistency: output sorted by the prefix, and shift(1) matching
+        the output's own row sequence."""
+        df = pd.DataFrame({"a": [1, 1, 2], "b": [3, 1, 2], "c": [9, 8, 7]})
+        t = LTSeq.from_pandas(df).sort("a", lambda r: r.b * 2, "c")
+        result = t.derive(prev_c=lambda r: r.c.shift(1)).to_pandas()
+        assert result["a"].tolist() == sorted(result["a"].tolist())
+        prev = result["prev_c"].tolist()
+        assert pd.isna(prev[0])
+        assert prev[1:] == [float(x) for x in result["c"].tolist()[:-1]]
+
+
+class TestMultiBatchRegression:
+    """Ordered ops must stay correct when data spans multiple record
+    batches (issue #125 finding 3: undeclared order is unstable on
+    multi-batch/multi-partition plans — declared order must not be)."""
+
+    def test_group_ordered_and_cum_sum_across_batches(self, tmp_path):
+        n = 50_000
+        run = 1_000
+        csv = tmp_path / "multibatch.csv"
+        with open(csv, "w") as f:
+            f.write("cat,v\n")
+            for i in range(n):
+                f.write(f"{i // run},1\n")
+
+        t = LTSeq.read_csv(str(csv)).assume_sorted("cat")
+
+        sized = t.group_ordered(lambda r: r.cat).derive(
+            lambda g: {"sz": g.count()}
+        )
+        df = sized.to_pandas()
+        assert len(df) == n
+        assert (df["sz"] == run).all()
+        assert df["cat"].tolist() == [i // run for i in range(n)]
+
+        cs = t.cum_sum("v").to_pandas()["v_cumsum"]
+        assert cs.tolist() == list(range(1, n + 1))

--- a/py-ltseq/tests/test_ordered_invariants.py
+++ b/py-ltseq/tests/test_ordered_invariants.py
@@ -6,6 +6,8 @@ sort metadata must always be a valid prefix of the actual sort order.
 """
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from ltseq import LTSeq
@@ -59,6 +61,30 @@ class TestGroupSortedValidates:
         t = LTSeq.from_pandas(df).sort("g", "v")
         groups = t.group_sorted(lambda r: r.g)
         assert groups.first().count() == 2
+
+    def test_computed_key_rejected_on_unrelated_sort(self):
+        """PR #126 review P1: a computed grouping key cannot be checked
+        against column-level sort metadata — accepting it silently splits
+        logical keys into multiple runs (here 3 runs for 2 key values)."""
+        df = pd.DataFrame({"g": [1, 2, 1], "v": [1, 2, 3]})
+        t = LTSeq.from_pandas(df).sort("v")
+        with pytest.raises(SortRequiredError, match="derive"):
+            t.group_sorted(lambda r: r.g + 0)
+
+    def test_computed_key_rejected_even_when_source_column_is_sorted(self):
+        """Sorted by g does not prove sorted by f(g) for arbitrary f, so the
+        computed key is rejected uniformly; the migration is derive-then-sort."""
+        df = pd.DataFrame({"g": [1, 1, 2], "v": [1, 2, 3]})
+        t = LTSeq.from_pandas(df).sort("g")
+        with pytest.raises(SortRequiredError):
+            t.group_sorted(lambda r: r.g + 0)
+
+    def test_derive_then_sort_is_the_computed_key_migration(self):
+        df = pd.DataFrame({"g": [1, 2, 1], "v": [1, 2, 3]})
+        t = LTSeq.from_pandas(df).derive(k=lambda r: r.g + 0).sort("k")
+        groups = t.group_sorted(lambda r: r.k)
+        sized = groups.derive(lambda gr: {"sz": gr.count()})
+        assert sorted(sized.to_pandas()["sz"].tolist()) == [1, 2, 2]
 
     def test_assume_sorted_is_the_trust_escape_hatch(self):
         """Callers who know their data is ordered declare it — no extra
@@ -119,6 +145,114 @@ class TestComputedSortMetadataPrefix:
         prev = result["prev_c"].tolist()
         assert pd.isna(prev[0])
         assert prev[1:] == [float(x) for x in result["c"].tolist()[:-1]]
+
+
+class TestComputedOnlySortGuidance:
+    """PR #126 review P2: after sort(lambda r: r.a * 2) the user HAS sorted,
+    but computed keys cannot be represented in column-level sort metadata, so
+    ordered APIs still (correctly) refuse — window ORDER BY built from that
+    metadata would otherwise silently run unordered, which is the original
+    finding-3 bug. The error must explain this and point at the
+    derive-then-sort migration instead of just saying 'call .sort()'."""
+
+    def test_cum_sum_error_explains_computed_keys(self):
+        df = pd.DataFrame({"a": [3, 1, 2]})
+        t = LTSeq.from_pandas(df).sort(lambda r: r.a * 2)
+        with pytest.raises(SortRequiredError, match="[Cc]omputed"):
+            t.cum_sum("a")
+
+    def test_group_ordered_error_explains_computed_keys(self):
+        df = pd.DataFrame({"a": [3, 1, 2]})
+        t = LTSeq.from_pandas(df).sort(lambda r: r.a * 2)
+        with pytest.raises(SortRequiredError, match="derive"):
+            t.group_ordered(lambda r: r.a)
+
+    def test_derive_then_sort_migration_works(self):
+        df = pd.DataFrame({"a": [3, 1, 2]})
+        t = LTSeq.from_pandas(df).derive(k=lambda r: r.a * 2).sort("k")
+        result = t.cum_sum("a").to_pandas()
+        assert result["a_cumsum"].tolist() == [1.0, 3.0, 6.0]
+
+
+class TestEmptyTableDeclaredOrder:
+    """PR #126 review P2: assume_sorted() on a filtered-to-empty table must
+    keep a queryable zero-row table (schema intact, ordered ops working) —
+    it is the one-line migration path for the breaking change, so it cannot
+    degrade to a schema-only stub that raises 'No data loaded'."""
+
+    @pytest.fixture
+    def empty_declared(self):
+        df = pd.DataFrame({"g": [1, 1, 2], "v": [1.0, 2.0, 3.0]})
+        t = LTSeq.from_pandas(df).sort("v")
+        return t.filter(lambda r: r.v < 0).assume_sorted("v")
+
+    def test_len_is_zero(self, empty_declared):
+        assert len(empty_declared) == 0
+
+    def test_cum_sum_keeps_result_column(self, empty_declared):
+        out = empty_declared.cum_sum("v")
+        assert "v_cumsum" in out.columns
+        assert len(out.to_pandas()) == 0
+
+    def test_group_ordered_yields_no_groups(self, empty_declared):
+        sized = empty_declared.group_ordered(lambda r: r.g).derive(
+            lambda gr: {"sz": gr.count()}
+        )
+        assert len(sized.to_pandas()) == 0
+
+    def test_sort_metadata_survives(self, empty_declared):
+        assert empty_declared._inner.get_sort_keys() == [("v", False)]
+
+
+class TestMultiPartitionRegression:
+    """Issue #125 finding 3 acceptance: the original bug came from partition
+    merge order, so ordered ops must be exercised on a genuinely
+    multi-partition plan. Multiple Parquet files through the lazy
+    assume_sorted path keep separate file groups (the non-Parquet path
+    collect()s into a single MemTable partition and cannot cover this)."""
+
+    def test_group_ordered_and_cum_sum_multi_partition(self, tmp_path):
+        n = 40_000
+        run = 700  # does not divide the per-file row count: runs span files
+        files = 4
+        per_file = n // files
+        pdir = tmp_path / "parts"
+        pdir.mkdir()
+        for f in range(files):
+            start = f * per_file
+            pq.write_table(
+                pa.table(
+                    {
+                        "cat": [(start + i) // run for i in range(per_file)],
+                        "v": [1] * per_file,
+                    }
+                ),
+                pdir / f"part-{f}.parquet",
+            )
+
+        t = LTSeq.read_parquet(str(pdir)).assume_sorted("cat")
+
+        # Premise check: the physical plan must actually read multiple
+        # file groups, otherwise this test silently degrades to the
+        # single-partition case it exists to go beyond.
+        import re
+
+        _, physical = t.explain_plan()
+        m = re.search(r"file_groups=\{(\d+) group", physical)
+        assert m is not None and int(m.group(1)) >= 2, physical
+
+        sized = t.group_ordered(lambda r: r.cat).derive(
+            lambda gr: {"sz": gr.count()}
+        )
+        df = sized.to_pandas()
+        expected_cat = [i // run for i in range(n)]
+        expected_sz = [run if (c + 1) * run <= n else n - c * run for c in expected_cat]
+        assert len(df) == n
+        assert df["cat"].tolist() == expected_cat
+        assert df["sz"].tolist() == expected_sz
+
+        cs = t.cum_sum("v").to_pandas()["v_cumsum"]
+        assert cs.tolist() == list(range(1, n + 1))
 
 
 class TestMultiBatchRegression:

--- a/py-ltseq/tests/test_sequence_ops_basic.py
+++ b/py-ltseq/tests/test_sequence_ops_basic.py
@@ -405,20 +405,25 @@ class TestCumSumBasic:
             pytest.skip("cum_sum() not yet implemented")
 
     def test_cum_sum_requires_sort(self, sample_csv):
-        """cum_sum() should ideally be used on sorted data."""
+        """cum_sum() on an undeclared row order raises (issue #125): a
+        running sum over unstable physical order is nondeterministic."""
+        from ltseq.exceptions import SortRequiredError
+
         t = LTSeq.read_csv(sample_csv)  # Not sorted
 
-        try:
-            result = t.cum_sum("volume")
-            assert isinstance(result, LTSeq)
-        except NotImplementedError:
-            pytest.skip("cum_sum() not yet implemented")
+        with pytest.raises(SortRequiredError):
+            t.cum_sum("volume")
 
     def test_cum_sum_empty_table(self, empty_table):
         """cum_sum() on an empty (0-row) table stays native (#91 PR 3):
         the window select over an empty DataFrame must produce an empty
         result whose schema carries the new cumsum column."""
-        result = empty_table.cum_sum("value")
+        # Build a 0-row table that still has a live dataframe and declared
+        # order (assume_sorted on a truly empty table degrades to a
+        # schema-only table, which short-circuits before the native path).
+        t = LTSeq._from_rows([{"value": 1.0}], {"value": "float64"})
+        empty = t.sort("value").filter(lambda r: r.value < 0)
+        result = empty.cum_sum("value")
         assert isinstance(result, LTSeq)
         assert "value_cumsum" in result.columns
         assert len(result) == 0

--- a/src/ops/grouping.rs
+++ b/src/ops/grouping.rs
@@ -271,7 +271,11 @@ pub fn group_id_impl(table: &LTSeqTable, grouping_expr: Bound<'_, PyDict>) -> Py
             params: WindowFunctionParams {
                 args: agg.params.args,
                 partition_by: vec![],
-                order_by: vec![],
+                // Accumulate in the DECLARED row order (issue #125): with an
+                // empty ORDER BY the running sum follows physical order,
+                // which is unstable on multi-partition plans. The Python
+                // entry guard guarantees sort_specs is non-empty here.
+                order_by: order_by.clone(),
                 window_frame: group_id_frame,
                 filter: None,
                 null_treatment: None,
@@ -328,9 +332,12 @@ pub fn group_id_impl(table: &LTSeqTable, grouping_expr: Bound<'_, PyDict>) -> Py
         }
     };
 
-    // Build __rn__: ROW_NUMBER() OVER (PARTITION BY __group_id__)
+    // Build __rn__: ROW_NUMBER() OVER (PARTITION BY __group_id__ ORDER BY
+    // <declared sort>) — in-group numbering must follow the declared row
+    // order, not the physical partition order (issue #125).
     let rn_expr = row_number()
         .partition_by(vec![group_id_col])
+        .order_by(order_by.clone())
         .build()
         .map_err(|e| LtseqError::Runtime(format!("Failed to build row_number window: {}", e)))?;
 

--- a/src/ops/sort.rs
+++ b/src/ops/sort.rs
@@ -187,18 +187,21 @@ pub fn assume_sorted_impl(
         })
         .map_err(LtseqError::Runtime)?;
 
-    if batches.is_empty() {
-        return Ok(LTSeqTable::empty(
-            Arc::clone(&table.session),
-            table.schema.as_ref().map(Arc::clone),
-            captured_specs,
-            None,
-        ));
-    }
-
-    let batch_schema = batches[0].schema();
+    // A filtered-to-empty table must stay queryable (PR #126 review):
+    // assume_sorted() is the one-line migration for the declared-order
+    // requirement, so it cannot degrade to a schema-only stub that raises
+    // "No data loaded" on len()/cum_sum(). Keep a zero-row MemTable.
+    let batch_schema = match batches.first() {
+        Some(batch) => batch.schema(),
+        None => LTSeqTable::schema_from_df(df.schema()),
+    };
+    let partitions = if batches.is_empty() {
+        vec![Vec::new()]
+    } else {
+        vec![batches]
+    };
     let mem_table =
-        MemTable::try_new(Arc::clone(&batch_schema), vec![batches])
+        MemTable::try_new(Arc::clone(&batch_schema), partitions)
             .map_err(|e| {
                 LtseqError::Runtime(format!(
                     "Failed to create MemTable: {}",

--- a/src/ops/sort.rs
+++ b/src/ops/sort.rs
@@ -38,6 +38,7 @@ pub fn sort_impl(
 
     // Capture full sort specs (column + direction) for downstream window ops
     let mut captured_specs = Vec::new();
+    let mut metadata_truncated = false;
 
     // Deserialize and transpile each sort expression
     let mut df_sort_exprs = Vec::new();
@@ -47,9 +48,16 @@ pub fn sort_impl(
         // Get desc flag for this sort key
         let is_desc = desc_flags.get(i).copied().unwrap_or(false);
 
-        // Capture column name if this is a simple column reference
+        // Capture column name if this is a simple column reference. A
+        // computed key cannot be represented in sort metadata — TRUNCATE
+        // there (issue #125): capturing later columns would record a
+        // non-prefix of the true order, e.g. sort("a", expr, "c") → [a, c].
         if let PyExpr::Column(ref col_name) = py_expr {
-            captured_specs.push(SortSpec::new(col_name.clone(), is_desc));
+            if !metadata_truncated {
+                captured_specs.push(SortSpec::new(col_name.clone(), is_desc));
+            }
+        } else {
+            metadata_truncated = true;
         }
 
         let df_expr = pyexpr_to_datafusion(py_expr, schema)
@@ -125,7 +133,8 @@ pub fn assume_sorted_impl(
 
     let (df, _schema) = table.require_df_and_schema()?;
 
-    // Capture sort specs (same logic as sort_impl, but skip the actual sort)
+    // Capture sort specs (same logic as sort_impl, but skip the actual
+    // sort). Truncate at the first computed key — see sort_impl.
     let mut captured_specs = Vec::new();
     for (i, expr_dict) in sort_exprs.iter().enumerate() {
         let py_expr = dict_to_py_expr(expr_dict)?;
@@ -133,6 +142,8 @@ pub fn assume_sorted_impl(
         if let PyExpr::Column(ref col_name) = py_expr {
             let is_desc = desc_flags.get(i).copied().unwrap_or(false);
             captured_specs.push(SortSpec::new(col_name.clone(), is_desc));
+        } else {
+            break;
         }
     }
 


### PR DESCRIPTION
## ⚠️ 破坏性变更

**`cum_sum()` / `group_ordered()` / `group_sorted()` 现在要求已声明的行序**：在没有 `.sort(...)` 或 `.assume_sorted(...)` 的表上调用会抛出 `SortRequiredError`。

**迁移只需一行**：数据已物理有序时加 `.assume_sorted(key)`，否则加 `.sort(key)`。

## 覆盖 issue #125 的发现 1/2/3/5

### 发现 1：`cum_sum()` 接入排序 invariant
docstring 一直声称 "Requires data to be sorted"，实现现在真正强制执行——与 derive 窗口路径共用同一个 `_window_sort_required_error()` 守卫。

### 发现 2：`group_sorted()` 验证 grouping key
简单列 grouping key 必须等于首个已声明排序键；不匹配（如表按 `v` 排序却按 `g` 分组，交错的 key 会被拆成多个 run）抛 `SortRequiredError`。**不新增 unsafe 入口**：`assume_sorted()` 就是现有的信任声明通道——声明后验证自然通过。计算型 grouping key 无法对照 sort 元数据，保守地只要求表已声明排序。

### 发现 3：`group_ordered()` 要求已声明行序（用户决策）
连续分组的语义依赖行序，而未声明的物理行序在多分区 lazy 计划上不稳定。Python 入口加守卫之外，Rust `group_id_impl` 的 `__group_id__` 累计 SUM 与 `__rn__` row_number 窗口补齐了来自 sort specs 的 ORDER BY——此前这两个窗口在 `CoalescePartitionsExec` / hash-repartition 的**不确定行序**上计算（正是本发现指出的 bug）。

### 发现 5：sort 元数据前缀截断
`sort("a", lambda r: r.b*2, "c")` 此前记录 `[a, c]`——不是真实排序 `(a, b*2, c)` 的前缀，导致 `is_sorted_by("a", "c")` 假阳性。现在 `sort()`/`assume_sorted()` 在首个计算键处截断，元数据恒为真实排序的合法前缀。顺带把 `assume_sorted()` 的类型注解从 `str` 放宽为 `str | Callable`（与 `sort()` 及实际运行时行为一致）。

## 测试
- 新增 `test_ordered_invariants.py`（14 项）：三个 API 的未排序负例 + sort/assume_sorted 正例、`[A,B,A]` 错键负例、多键前缀正例、mixed computed sort 截断断言
- 存量测试迁移：约 30 处未声明排序的调用点补 `.sort()`/`.assume_sorted()`（bench 与 R2 sessionization 工作负载本来就已声明 ✓）
- 全量：**1534 passed, 3 skipped**；cargo test ✓；pyright 与 main 基线持平（67 errors 全部位于本 PR 未触碰的文件）

## Bench（诚实披露：group_ordered 有实测回归）

方法：`pgrep` 确认无并行负载；main/branch 交叉两轮，每档 warmup 2 + 7 次取中位（100k 行）：

| workload | main r1/r2 | branch r1/r2 | Δ |
|---|---|---|---|
| group_ordered_100000 | 24.5 / 24.6 ms | 32.5 / 33.1 ms | **+33%** |
| window_lag_100000 | 5.3 / 5.5 ms | 5.5 / 5.7 ms | 噪声内 |
| window_cumsum_100000 | 5.2 / 5.4 ms | 5.4 / 5.5 ms | 噪声内 |

**机制分析**（对比两分支物理计划）：main 的快来自**在不确定的行序上计算**——`__group_id__` SUM 直接吃 `CoalescePartitionsExec` 的任意合并序、`__rn__` 按 hash 分区到达序编号。branch 的额外开销 = SUM 前的 `SortPreservingMergeExec`（flatten 分解实测 ~1ms）+ `__rn__` 的 ORDER BY 使 repartition 后的 SortExec 从单键 `[__group_id__]` 变双键 `[__group_id__, category]`（~7ms，Utf8 键比较）。即换取确定性结果的成本约 80ns/行；如需进一步优化（如内部窗口的单分区执行提示）建议另开 issue。

Closes 无（伞形 issue #125 分阶段交付，本 PR 勾选发现 1/2/3/5 的 checkbox）

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)